### PR TITLE
use timeout in response merger

### DIFF
--- a/lib/domain_layer/usecases/requests/requests.dart
+++ b/lib/domain_layer/usecases/requests/requests.dart
@@ -52,7 +52,7 @@ class Requests {
   /// [relaySet] An optional set of relays to query \
   /// [cacheRead] Whether to read from cache \
   /// [cacheWrite] Whether to write results to cache \
-  /// [timeout] An optional timeout for the query \
+  /// [timeout] An optional timeout in seconds for the query \
   /// [explicitRelays] A list of specific relays to use, bypassing inbox/outbox \
   /// [desiredCoverage] The number of relays per pubkey to query, default: 2 \
   ///
@@ -151,6 +151,7 @@ class Requests {
       ],
       trackingSet: state.returnedIds,
       outController: state.controller,
+      timeout: request.timeout,
     )();
 
     /// avoids sending events to response stream before a listener could be attached

--- a/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
+++ b/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
+import '../../../config/request_defaults.dart';
 import '../../../shared/logger/logger.dart';
 import '../../entities/nip_01_event.dart';
 
-/// given a stream  with Nip01 events it tracks the id and adds the one to the provided stream controller
+/// given a stream  with Nip01 events it tracks the id and adds the one to the provided stream controller \
 /// tracking of the happens in the tracking list
 class StreamResponseCleaner {
   final Set<String> trackingSet;
@@ -15,23 +16,24 @@ class StreamResponseCleaner {
 
   int? timeout;
 
-  /// [trackingSet] a set of ids that are already returned
-  /// [inputStreams] a list of streams that are be listened to
-  /// [outController] the controller that is used to add the events to
-  /// [timeout] the timeout for the stream, if null no timeout is set
+  /// -  [trackingSet] a set of ids that are already returned \
+  /// - [inputStreams] a list of streams that are be listened to \
+  /// - [outController] the controller that is used to add the events to \
+  /// - [timeout] the timeout for the stream, if null [RequestDefaults.DEFAULT_STREAM_IDLE_TIMEOUT] is used
   StreamResponseCleaner({
     required this.trackingSet,
     required this.inputStreams,
     required this.outController,
     required this.timeout,
   }) {
-    if (timeout != null) {
-      Future.delayed(Duration(seconds: timeout!), () {
-        if (!outController.isClosed) {
-          outController.close();
-        }
-      });
-    }
+    Future.delayed(
+        Duration(
+          seconds: timeout ?? RequestDefaults.DEFAULT_STREAM_IDLE_TIMEOUT,
+        ), () {
+      if (!outController.isClosed) {
+        outController.close();
+      }
+    });
   }
 
   void call() {

--- a/test/usecases/stream_response_cleaner/stream_response_cleander_test.dart
+++ b/test/usecases/stream_response_cleaner/stream_response_cleander_test.dart
@@ -47,6 +47,7 @@ void main() async {
         inputStreams: [inputController.stream],
         trackingSet: tracking,
         outController: outController,
+        timeout: 5,
       )();
 
       expectLater(outController.stream, emitsInAnyOrder(myEventsNoDublicate));


### PR DESCRIPTION
fixes offline use when using requests query.
Maybe there is a better solution to close network stream directly on no connection TBD