### PR TITLE
check cache results against limit

### DIFF
--- a/lib/domain_layer/usecases/cache_read/cache_read.dart
+++ b/lib/domain_layer/usecases/cache_read/cache_read.dart
@@ -27,13 +27,16 @@ class CacheRead {
           since: filter.since,
           until: filter.until,
         );
+
         foundEvents.addAll(foundAuthors);
 
         // remove found authors from unresolved filter if it's not a subscription
-        if (!requestState.isSubscription) {
-          filter.authors!.removeWhere(
-            (author) => foundEvents.any((event) => event.pubKey == author),
-          );
+        if (!requestState.isSubscription && foundAuthors.isNotEmpty) {
+          if ((filter.limit != null && foundEvents.length >= filter.limit!)) {
+            filter.authors!.removeWhere(
+              (author) => foundEvents.any((event) => event.pubKey == author),
+            );
+          }
         }
       }
 


### PR DESCRIPTION
fixes a bug on req when cache is partly filled but does not satisfy the full limit param.
=> Dont delete authors and send to network in this case