### PR TITLE
remove change Event Signer

### DIFF
--- a/lib/presentation_layer/ndk.dart
+++ b/lib/presentation_layer/ndk.dart
@@ -60,12 +60,4 @@ class Ndk {
   /// calculate relay set
   RelaySets get relaySets => _initialization.relaySets;
 
-  /// Changes the event signer used by the NDK instance
-  ///
-  /// This method allows for hot-swapping the [EventSigner] implementation
-  ///
-  /// [newEventSigner] The new [EventSigner] to be used. Can be null to remove the current signer
-  changeEventSigner(EventSigner? newEventSigner) {
-    config.eventSigner = newEventSigner;
-  }
 }

--- a/test/ndk_test.dart
+++ b/test/ndk_test.dart
@@ -45,18 +45,13 @@ void main() async {
         NdkConfig(
             eventVerifier: Bip340EventVerifier(),
             eventSigner: Bip340EventSigner(
-              privateKey: "",
-              publicKey: "",
+              privateKey: key1.privateKey,
+              publicKey: key1.publicKey,
             ),
             cache: MemCacheManager(),
             engine: NdkEngine.RELAY_SETS,
             bootstrapRelays: [relay1.url]),
       );
-
-      ndk.changeEventSigner(Bip340EventSigner(
-        privateKey: key1.privateKey,
-        publicKey: key1.publicKey,
-      ));
 
       NdkResponse response = ndk.requests.query(filters: [
         Filter(kinds: [Nip01Event.TEXT_NODE_KIND], authors: [key1.publicKey])


### PR DESCRIPTION
since we can't hot-swap the signer, because many usecases copy the injected signer to their structures and it breaks.
So if client want to change signer, it needs to create a new ndk instance with new signer