### PR TITLE
TMP fix dont remove all to keep filters working

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/cache_read/cache_read.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cache_read/cache_read.dart
@@ -33,14 +33,27 @@ class CacheRead {
         // remove found authors from unresolved filter if it's not a subscription
         if (!requestState.isSubscription && foundAuthors.isNotEmpty) {
           if (filter.limit == null) {
-            filter.authors!.removeWhere(
-              (author) => foundEvents.any((event) => event.pubKey == author),
-            );
+            // Keep track of whether we've kept one item
+            bool keptOne = false;
+            filter.authors!.removeWhere((author) {
+              if (!keptOne &&
+                  foundEvents.any((event) => event.pubKey == author)) {
+                keptOne = true;
+                return false; // Keep the first matching item
+              }
+              return foundEvents.any((event) => event.pubKey == author);
+            });
           } else if (foundEvents.length >= filter.limit!) {
-            // also ok to remove authors if limit is reached
-            filter.authors!.removeWhere(
-              (author) => foundEvents.any((event) => event.pubKey == author),
-            );
+            // Keep track of whether we've kept one item
+            bool keptOne = false;
+            filter.authors!.removeWhere((author) {
+              if (!keptOne &&
+                  foundEvents.any((event) => event.pubKey == author)) {
+                keptOne = true;
+                return false; // Keep the first matching item
+              }
+              return foundEvents.any((event) => event.pubKey == author);
+            });
           }
         }
       }
@@ -55,9 +68,15 @@ class CacheRead {
           foundIdEvents.add(foundId);
         }
 
-        filter.ids!.removeWhere(
-          (id) => foundIdEvents.any((event) => event.id == id),
-        );
+        // Keep track of whether we've kept one item
+        bool keptOne = false;
+        filter.ids!.removeWhere((id) {
+          if (!keptOne && foundIdEvents.any((event) => event.id == id)) {
+            keptOne = true;
+            return false; // Keep the first matching item
+          }
+          return foundIdEvents.any((event) => event.id == id);
+        });
 
         foundEvents.addAll(foundIdEvents);
       }

--- a/packages/ndk/lib/domain_layer/usecases/cache_read/cache_read.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cache_read/cache_read.dart
@@ -15,47 +15,49 @@ class CacheRead {
     required RequestState requestState,
     required StreamController<Nip01Event> outController,
   }) async {
-    final unresolved = requestState.unresolvedFilters;
+    final unresolved = requestState.unresolvedFilters.toSet();
     for (final filter in unresolved) {
       final List<Nip01Event> foundEvents = [];
 
       // authors
       if (filter.authors != null) {
-        final foundAuthors = await cacheManager.loadEvents(
+        final cached = await cacheManager.loadEvents(
           pubKeys: filter.authors!,
           kinds: filter.kinds ?? [],
           since: filter.since,
           until: filter.until,
         );
 
-        foundEvents.addAll(foundAuthors);
-
-        // remove found authors from unresolved filter if it's not a subscription
-        if (!requestState.isSubscription && foundAuthors.isNotEmpty) {
-          if (filter.limit == null) {
-            // Keep track of whether we've kept one item
-            bool keptOne = false;
-            filter.authors!.removeWhere((author) {
-              if (!keptOne &&
-                  foundEvents.any((event) => event.pubKey == author)) {
-                keptOne = true;
-                return false; // Keep the first matching item
-              }
-              return foundEvents.any((event) => event.pubKey == author);
-            });
-          } else if (foundEvents.length >= filter.limit!) {
-            // Keep track of whether we've kept one item
-            bool keptOne = false;
-            filter.authors!.removeWhere((author) {
-              if (!keptOne &&
-                  foundEvents.any((event) => event.pubKey == author)) {
-                keptOne = true;
-                return false; // Keep the first matching item
-              }
-              return foundEvents.any((event) => event.pubKey == author);
-            });
-          }
-        }
+        foundEvents.addAll(cached);
+        // WE CANNOT DO THIS, BECAUSE 1) kinds.length > 1,  2) only replaceable events have 1 event per pubKey+kind, normal events can have many per pubKey+kind
+        // TODO if kind.length == 1 and kind IS replaceable AND there is not limit/until/since AND it is NOT a subscription, then we can do some shit
+      //
+      //   // remove found authors from unresolved filter if it's not a subscription
+      //   if (!requestState.isSubscription && cached.isNotEmpty) {
+      //     if (filter.limit == null) {
+      //       // Keep track of whether we've kept one item
+      //       bool keptOne = false;
+      //       filter.authors!.removeWhere((author) {
+      //         if (!keptOne &&
+      //             foundEvents.any((event) => event.pubKey == author)) {
+      //           keptOne = true;
+      //           return false; // Keep the first matching item
+      //         }
+      //         return foundEvents.any((event) => event.pubKey == author);
+      //       });
+      //     } else if (foundEvents.length >= filter.limit!) {
+      //       // Keep track of whether we've kept one item
+      //       bool keptOne = false;
+      //       filter.authors!.removeWhere((author) {
+      //         if (!keptOne &&
+      //             foundEvents.any((event) => event.pubKey == author)) {
+      //           keptOne = true;
+      //           return false; // Keep the first matching item
+      //         }
+      //         return foundEvents.any((event) => event.pubKey == author);
+      //       });
+      //     }
+      //   }
       }
 
       if (filter.ids != null) {
@@ -68,17 +70,17 @@ class CacheRead {
           foundIdEvents.add(foundId);
         }
 
-        // Keep track of whether we've kept one item
-        bool keptOne = false;
         filter.ids!.removeWhere((id) {
-          if (!keptOne && foundIdEvents.any((event) => event.id == id)) {
-            keptOne = true;
-            return false; // Keep the first matching item
-          }
           return foundIdEvents.any((event) => event.id == id);
         });
 
+
         foundEvents.addAll(foundIdEvents);
+        if (filter.ids!.isEmpty) {
+          // if we have not more ids in filter, remove the filter entirely,
+          // otherwise it will send too broad filter to relay
+          requestState.unresolvedFilters.remove(filter);
+        }
       }
 
       // write found events to response stream

--- a/packages/ndk/test/usecases/cache_read_test.dart
+++ b/packages/ndk/test/usecases/cache_read_test.dart
@@ -22,7 +22,7 @@ void main() async {
       await myCacheManager.saveEvents(myEvens);
     });
 
-    test('cache read - all', () async {
+    test('cache read - all - BAD TEST', skip: true, () async {
       final NdkRequest myNdkRequest = NdkRequest.query(
         "id",
         filters: [
@@ -61,7 +61,7 @@ void main() async {
       }
     });
 
-    test('cache read - some missing', () async {
+    test('cache read - some missing - BAD TEST', skip:true,  () async {
       final NdkRequest myNdkRequest = NdkRequest.query("id",
           filters: [
             Filter(
@@ -98,7 +98,7 @@ void main() async {
       }
     });
 
-    test('cache read - author removal based on limit - remove', () async {
+    test('cache read - author removal based on limit - remove - BAD TEST', skip:true, () async {
       final CacheRead myUsecase = CacheRead(myCacheManager);
 
       // Test with limit
@@ -122,7 +122,7 @@ void main() async {
       expect(myRequestStateWithLimit.unresolvedFilters[0].authors, equals([]));
     });
 
-    test('cache read - not all in cache', () async {
+    test('cache read - not all in cache - BAD TEST', skip:true, () async {
       final CacheRead myUsecase = CacheRead(myCacheManager);
 
       // Test with limit
@@ -160,7 +160,7 @@ void main() async {
           ]));
     });
 
-    test('cache read - id filter', () async {
+    test('cache read - id filter with one missing', () async {
       final CacheManager myCacheManager = MemCacheManager();
       final CacheRead myUsecase = CacheRead(myCacheManager);
 
@@ -212,13 +212,65 @@ void main() async {
       expect(myRequestState.unresolvedFilters[0].ids, equals(['id3']));
     });
 
-    test('cache read - all in cache, cannot leave unresolved filters with empty authors and kind 1', () async {
-      final NdkRequest myNdkRequest = NdkRequest.query("id", filters: [
-        Filter(
-          authors: ['pubKey1', 'pubKey2'],
-          kinds: [1],
-        )
-      ],  timeoutDuration: Duration(seconds: 5));
+    test('cache read - id filter all in cache', () async {
+      final CacheManager myCacheManager = MemCacheManager();
+      final CacheRead myUsecase = CacheRead(myCacheManager);
+
+      final eventId0 =
+      Nip01Event(pubKey: "pubKey0", kind: 1, tags: [], content: "content0");
+      eventId0.id = "id0";
+      final eventId1 =
+      Nip01Event(pubKey: "pubKey1", kind: 1, tags: [], content: "content1");
+      eventId1.id = "id1";
+      final eventId2 =
+      Nip01Event(pubKey: "pubKey2", kind: 1, tags: [], content: "content2");
+      eventId2.id = "id2";
+
+      final List<Nip01Event> idEvents = [
+        eventId0,
+        eventId1,
+        eventId2,
+      ];
+
+      await myCacheManager.saveEvents(idEvents);
+
+      final NdkRequest myNdkRequest = NdkRequest.query(
+        "id-filter",
+        filters: [
+          Filter(
+            ids: ['id0', 'id1', 'id2'],
+            kinds: [1],
+          )
+        ],
+        timeoutDuration: Duration(seconds: 5),
+      );
+      final RequestState myRequestState = RequestState(myNdkRequest);
+
+      final streamController = StreamController<Nip01Event>();
+      final response = streamController.stream.toList();
+
+      await myUsecase.resolveUnresolvedFilters(
+        requestState: myRequestState,
+        outController: streamController,
+      );
+
+      await streamController.close();
+
+      final foundEvents = await response;
+      expect(foundEvents.length, equals(3));
+      expect(
+          foundEvents.map((e) => e.id).toSet(), equals({'id0', 'id1', 'id2'}));
+
+      expect(myRequestState.unresolvedFilters, equals([]));
+    });
+
+    test('cache read - has events for all authors', () async {
+      // ...but we cannot remove them from the filter because only replaceable events have 1 event per pubKey+kind, normal events can have many per pubKey+kind
+      final filter = Filter(
+        authors: ['pubKey1', 'pubKey2'],
+        kinds: [1],
+      );
+      final NdkRequest myNdkRequest = NdkRequest.query("id", filters: [ filter ],  timeoutDuration: Duration(seconds: 5));
       final RequestState myRequestState = RequestState(myNdkRequest);
       final CacheRead myUsecase = CacheRead(myCacheManager);
 
@@ -240,7 +292,7 @@ void main() async {
         expect(data, equals(myEvens));
       });
 
-      expect(myRequestState.unresolvedFilters, equals([]));
+      expect(myRequestState.unresolvedFilters, equals([filter]));
     });
 
   });


### PR DESCRIPTION
a tmp fix to keep filters working. Obiously our tests now fail but the test results look right acoring to the test.

This makes sure that we dont delete all authors, at least one is kept (that we know is in cache)