### PR TITLE
fix: handle null notifications list in GetInfoResponse

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/nwc/responses/get_info_response.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/responses/get_info_response.dart
@@ -33,7 +33,7 @@ class GetInfoResponse extends NwcResponse {
 
     Map<String, dynamic> result = input['result'] as Map<String, dynamic>;
     final methodsList = result["methods"] as List;
-    final notificationsList = result["notifications"] as List;
+    final notificationsList = result["notifications"] as List? ?? [];
 
     List<String> methods =
         methodsList.map((method) => method.toString()).toList();


### PR DESCRIPTION
Added a simple null-safe handling in `GetInfoResponse.deserialize()` method for the `notifications` field.

Fixes #114