### PR TITLE
Fix connection to a bad relay blocking event delivery

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -216,7 +216,7 @@ class RelayManager<T> {
     if (relayConnectivity == null ||
         !relayConnectivity.relayTransport!.isOpen()) {
       if (!force &&
-          (relayConnectivity == null ||
+          (relayConnectivity != null &&
               !relayConnectivity.relay.wasLastConnectTryLongerThanSeconds(
                 FAIL_RELAY_CONNECT_TRY_AFTER_SECONDS,
               ))) {

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -130,10 +130,6 @@ class RelaySetsEngine implements NetworkEngine {
 
     if (state.request.explicitRelays != null &&
         state.request.explicitRelays!.isNotEmpty) {
-      // for (final url in state.request.explicitRelays!) {
-      //   await _relayManager.connectRelay(
-      //       dirtyUrl: url, connectionSource: ConnectionSource.explicit);
-      // }
       relaysForRequest = state.request.explicitRelays;
     } else {
       relaysForRequest = _bootstrapRelays;

--- a/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
+++ b/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
@@ -31,7 +31,7 @@ void main() async {
     late Ndk ndk;
 
     setUp(() async {
-      relay0 = MockRelay(name: "relay 0", explicitPort: 5097);
+      relay0 = MockRelay(name: "relay 0", explicitPort: 5101);
       await relay0.startServer();
 
       final cache = MemCacheManager();


### PR DESCRIPTION
Make reconnect to relays async to not block other relays responding immediately in RELAYS_SET engine

fixes #154 

@v0l try this on zapstream, should fix the 5s delay that `wss://relay.nostr.bg` bad relay was causing. 