### PR TITLE
Optional pubkey in async signers

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -18,7 +18,7 @@ class Nip46EventSigner implements EventSigner {
 
   final _pendingRequests = <String, Completer<dynamic>>{};
 
-  String? _cachedPublicKey;
+  String? cachedPublicKey;
 
   late Bip340EventSigner localEventSigner;
 
@@ -27,6 +27,7 @@ class Nip46EventSigner implements EventSigner {
     required this.requests,
     required this.broadcast,
     this.authCallback,
+    this.cachedPublicKey,
   }) {
     final privKey = connection.privateKey;
     final pubKey = Bip340.getPublicKey(privKey);
@@ -169,7 +170,7 @@ class Nip46EventSigner implements EventSigner {
 
   @override
   String getPublicKey() {
-    if (_cachedPublicKey != null) return _cachedPublicKey!;
+    if (cachedPublicKey != null) return cachedPublicKey!;
     throw Exception('Use getPublicKeyAsync() first to cache the user pubkey');
   }
 
@@ -178,7 +179,7 @@ class Nip46EventSigner implements EventSigner {
 
     final publicKey = await remoteRequest(request: request);
 
-    _cachedPublicKey = publicKey;
+    cachedPublicKey = publicKey;
 
     return publicKey;
   }

--- a/packages/nip07_event_signer/lib/src/nip07_event_signer_web.dart
+++ b/packages/nip07_event_signer/lib/src/nip07_event_signer_web.dart
@@ -3,7 +3,9 @@ import 'package:ndk/ndk.dart';
 import 'js_interop.dart' as js;
 
 class Nip07EventSigner implements EventSigner {
-  String? _cachedPublicKey;
+  String? cachedPublicKey;
+
+  Nip07EventSigner({this.cachedPublicKey});
 
   @override
   bool canSign() {
@@ -70,10 +72,10 @@ class Nip07EventSigner implements EventSigner {
 
   @override
   String getPublicKey() {
-    if (_cachedPublicKey != null) return _cachedPublicKey!;
+    if (cachedPublicKey != null) return cachedPublicKey!;
 
     js.nostr!.getPublicKey().toDart.then((pubkey) {
-      _cachedPublicKey = pubkey.toDart;
+      cachedPublicKey = pubkey.toDart;
     });
 
     throw Exception("Use getPublicKeyAsync with Nip07EventSigner");
@@ -81,7 +83,7 @@ class Nip07EventSigner implements EventSigner {
 
   Future<String> getPublicKeyAsync() async {
     final pubkey = (await js.nostr!.getPublicKey().toDart).toDart;
-    _cachedPublicKey = pubkey;
+    cachedPublicKey = pubkey;
 
     return pubkey;
   }


### PR DESCRIPTION
Updated the constructor of Nip07EventSigner and Nip46EventSigner to accept a default pubkey.
Making `cachedPublicKey` public.