### PR TITLE
fix flanky test, any order

### DIFF
--- a/packages/ndk/test/usecases/cache_read_test.dart
+++ b/packages/ndk/test/usecases/cache_read_test.dart
@@ -88,7 +88,7 @@ void main() async {
       );
 
       await response.then((data) {
-        expect(data, equals(myEvens));
+        expect(data, unorderedEquals(myEvens));
       });
 
       //await expectLater(myRequestState.stream, emitsInAnyOrder(myEvens));
@@ -294,7 +294,9 @@ void main() async {
         expect(data, equals(myEvens));
       });
 
-      expect(myRequestState.unresolvedFilters, equals([filter]));
+      /// expect in any order
+
+      expect(myRequestState.unresolvedFilters, unorderedEquals([filter]));
     });
   });
 }


### PR DESCRIPTION
fixes flanky test, where cache responds in any order
```
❌ test/usecases/cache_read_test.dart: CacheRead cache read - has events for all authors (failed)
  Expected: [
              Nip01Event:Nip01Event{pubKey: pubKey1, createdAt: 1759316888, kind: 1, tags: [], content: content1_a, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey1, createdAt: 1759316889, kind: 1, tags: [], content: content1_b, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey1, createdAt: 1759316889, kind: 1, tags: [], content: content1_c, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey2, createdAt: 1759316889, kind: 1, tags: [], content: content2_a, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey2, createdAt: 1759316889, kind: 1, tags: [], content: content2_b, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey2, createdAt: 1759316889, kind: 1, tags: [], content: content2_c, sources: []}
            ]
    Actual: [
              Nip01Event:Nip01Event{pubKey: pubKey1, createdAt: 1759316889, kind: 1, tags: [], content: content1_b, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey1, createdAt: 1759316889, kind: 1, tags: [], content: content1_c, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey2, createdAt: 1759316889, kind: 1, tags: [], content: content2_a, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey2, createdAt: 1759316889, kind: 1, tags: [], content: content2_b, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey2, createdAt: 1759316889, kind: 1, tags: [], content: content2_c, sources: []},
              Nip01Event:Nip01Event{pubKey: pubKey1, createdAt: 1759316888, kind: 1, tags: [], content: content1_a, sources: []}
            ]
     Which: at location [0] is Nip01Event:<Nip01Event{pubKey: pubKey1, createdAt: 1759316889, kind: 1, tags: [], content: content1_b, sources: []}> instead of Nip01Event:<Nip01Event{pubKey: pubKey1, createdAt: 1759316888, kind: 1, tags: [], content: content1_a, sources: []}>
     ```