### PR TITLE
chore: export nip19

### DIFF
--- a/packages/ndk/lib/ndk.dart
+++ b/packages/ndk/lib/ndk.dart
@@ -99,3 +99,10 @@ export 'shared/logger/console_output.dart';
  */
 
 export 'shared/event_filters/tag_count_event_filter.dart';
+
+/**
+ * Nip 19
+ * 
+ */
+
+export 'shared/nips/nip19/nip19.dart';


### PR DESCRIPTION
export nip19 so it can be directly accessed