### PR TITLE
fix: missing convert  dependency

### DIFF
--- a/packages/amber/pubspec.yaml
+++ b/packages/amber/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
   amberflutter: ^0.0.9
   plugin_platform_interface: ^2.1.8
+  convert: ^3.1.2
   ndk: ^0.6.0-dev.16
 
 dev_dependencies:

--- a/packages/ndk/pubspec.lock
+++ b/packages/ndk/pubspec.lock
@@ -257,14 +257,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  hex:
-    dependency: "direct main"
-    description:
-      name: hex
-      sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   http:
     dependency: "direct main"
     description:


### PR DESCRIPTION
missing convert dependency (caused by https://github.com/relaystr/ndk/pull/294) in  amber package