### PR TITLE
chore: version bump

### DIFF
--- a/packages/isar/pubspec.lock
+++ b/packages/isar/pubspec.lock
@@ -359,7 +359,7 @@ packages:
       path: "../ndk"
       relative: true
     source: path
-    version: "0.6.0-dev.20"
+    version: "0.6.0"
   node_preamble:
     dependency: transitive
     description:

--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ndk_isar
 description: Nostr Development Kit - the most performant lib for all your nostr usecases
-version: 0.2.3-dev.23
+version: 0.2.3
 homepage: https://github.com/relaystr/ndk
 
 environment:
@@ -16,7 +16,7 @@ platforms:
 
 dependencies:
   isar: ^4.0.0-dev.14
-  ndk: ^0.6.0-dev.20
+  ndk: ^0.6.0
 
 dev_dependencies:
   build_runner: ^2.4.11


### PR DESCRIPTION
needed to release isar manually because it depends on a prerelease version
`isar: ^4.0.0-dev.14`