### PR TITLE
fix: Handle null error value in NWC response deserialization

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/nwc/responses/nwc_response.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/responses/nwc_response.dart
@@ -16,7 +16,7 @@ class NwcResponse {
   });
 
   void deserializeError(Map<String, dynamic> input) {
-    if (input.containsKey('error')) {
+    if (input.containsKey('error') && input['error'] != null) {
       Map<String, dynamic> error = input['error'] as Map<String, dynamic>;
       errorCode = error["code"];
       errorMessage = error["message"];


### PR DESCRIPTION
The [deserializeError](https://github.com/relaystr/ndk/blob/master/packages/ndk/lib/domain_layer/usecases/nwc/responses/nwc_response.dart#L18) method in `NwcResponse` was attempting to cast the `error` field to a `Map<String, dynamic>` without checking if it was `null`. This caused connection failures when NWC wallet providers (like Rizful) send responses with `error: null` in their JSON payloads.

Example of problematic response format:
```json
{
  "result_type": "get_balance",
  "result": {"balance": 100000},
  "error": null
}
```

When this response was processed, the code would try to cast `null` to `Map<String, dynamic>`, causing a runtime error and preventing successful wallet connections.

This bug was discovered during testing of my app [Nostrpay](https://www.nostrpay.org/) with the [Rizful wallet](https://rizful.com/w) provider. Users reported connection failures when attempting to connect their Rizful wallet through NWC. The issue was reported in this [Stacker.news discussion](https://stacker.news/items/1294231/r/anipy?commentId=1294877).

I just added a null check before attempting to cast the error field to a Map.
