### PR TITLE
fix: event tampering vulnerability

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/verifiers/bip340_event_verifier.dart
+++ b/packages/ndk/lib/data_layer/repositories/verifiers/bip340_event_verifier.dart
@@ -8,6 +8,7 @@ import '../../../domain_layer/repositories/event_verifier.dart';
 class Bip340EventVerifier implements EventVerifier {
   @override
   Future<bool> verify(Nip01Event event) async {
+    if (!event.isIdValid) return false;
     return bip340.verify(event.pubKey, event.id, event.sig);
   }
 }

--- a/packages/ndk/test/verifiers/event_id_verification_test.dart
+++ b/packages/ndk/test/verifiers/event_id_verification_test.dart
@@ -1,0 +1,52 @@
+import 'package:ndk/ndk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('verify real event', () async {
+    final event = Nip01Event.fromJson({
+      "id": "3c65c446bd71fa90e5c4177abf8526868dbc4b230b15ea8df3fa7ee33145993b",
+      "pubkey":
+          "52d4650e933525817021571f2e82859da3b5ad44e74ef6498a8af5ff8d7dcc83",
+      "created_at": 1766398063,
+      "kind": 1,
+      "tags": [],
+      "content": "content",
+      "sig":
+          "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607"
+    });
+
+    expect(await Bip340EventVerifier().verify(event), isTrue);
+  });
+
+  test('verify event with tampered id', () async {
+    final event = Nip01Event.fromJson({
+      "id": "3c65c446bd71fa90e5c4177abf8526868dbc4b230b15ea8df3fa7ee33145aaaa",
+      "pubkey":
+          "52d4650e933525817021571f2e82859da3b5ad44e74ef6498a8af5ff8d7dcc83",
+      "created_at": 1766398063,
+      "kind": 1,
+      "tags": [],
+      "content": "content",
+      "sig":
+          "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607"
+    });
+
+    expect(await Bip340EventVerifier().verify(event), isFalse);
+  });
+
+  test('verify event with tampered created at', () async {
+    final event = Nip01Event.fromJson({
+      "id": "3c65c446bd71fa90e5c4177abf8526868dbc4b230b15ea8df3fa7ee33145993b",
+      "pubkey":
+          "52d4650e933525817021571f2e82859da3b5ad44e74ef6498a8af5ff8d7dcc83",
+      "created_at": 1766394444,
+      "kind": 1,
+      "tags": [],
+      "content": "content",
+      "sig":
+          "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607"
+    });
+
+    expect(await Bip340EventVerifier().verify(event), isFalse);
+  });
+}


### PR DESCRIPTION
A bad relay can serve bad events and NDK will never notice. Bad events can be an event with the content updated by the relay operator.