### PR TITLE
fix: event source tracking

### DIFF
--- a/packages/ndk/lib/domain_layer/entities/broadcast_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/broadcast_state.dart
@@ -51,7 +51,7 @@ class BroadcastState {
 
   /// [networkController] used by relay manger to write responses
   StreamController<RelayBroadcastResponse> networkController =
-      StreamController<RelayBroadcastResponse>();
+      StreamController<RelayBroadcastResponse>.broadcast();
 
   /// stream of state updates \
   /// updates are sent when a relay responds, the whole state is sent \

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast.dart
@@ -71,6 +71,25 @@ class Broadcast {
     // register broadcast state
     _globalState.inFlightBroadcasts[nostrEvent.id] = broadcastState;
 
+    // Listen for broadcast responses to update cache sources
+    broadcastState.networkController.stream.listen((response) async {
+      if (response.broadcastSuccessful) {
+        final currentEvent = broadcastState.event;
+        if (currentEvent != null) {
+          final cachedEvent = await _cacheManager.loadEvent(currentEvent.id);
+          if (cachedEvent != null) {
+            final updatedSources = {
+              ...cachedEvent.sources,
+              response.relayUrl
+            }.toList();
+            final updatedEvent =
+                cachedEvent.copyWith(sources: updatedSources);
+            await _cacheManager.saveEvent(updatedEvent);
+          }
+        }
+      }
+    });
+
     // save event to cache if enabled
     if (mySaveToCache) {
       _cacheManager.saveEvent(nostrEvent);

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -23,7 +23,6 @@ import '../entities/relay_connectivity.dart';
 import '../entities/relay_info.dart';
 import '../entities/request_state.dart';
 import '../entities/tuple.dart';
-import '../repositories/cache_manager.dart';
 import '../repositories/nostr_transport.dart';
 import 'accounts/accounts.dart';
 import 'engines/network_engine.dart';
@@ -75,9 +74,6 @@ class RelayManager<T> {
   /// AUTH strategy: eager (on challenge) or lazy (on auth-required)
   final bool eagerAuth;
 
-  /// cache manager for updating event sources
-  final CacheManager? cacheManager;
-
   /// Creates a new relay manager.
   RelayManager({
     required this.globalState,
@@ -88,7 +84,6 @@ class RelayManager<T> {
     allowReconnect = true,
     this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
-    this.cacheManager,
   }) : _accounts = accounts {
     allowReconnectRelays = allowReconnect;
     _connectSeedRelays(urls: bootstrapRelays ?? DEFAULT_BOOTSTRAP_RELAYS);
@@ -507,25 +502,18 @@ class RelayManager<T> {
           !globalState
               .inFlightBroadcasts[eventId]!.networkController.isClosed) {
         // Update cache with source if broadcast was successful
-        if (success && cacheManager != null) {
+        if (success) {
           final broadcastState = globalState.inFlightBroadcasts[eventId];
           final event = broadcastState?.event;
           if (event != null) {
-            // Only update cache if event was already saved (saveToCache was true)
-            // Check if event exists in cache before updating sources
-            cacheManager!.loadEvent(eventId).then((cachedEvent) {
-              if (cachedEvent != null) {
-                // Merge existing sources with new relay URL, avoiding duplicates
-                final updatedSources = {
-                  ...event.sources,
-                  relayConnectivity.url
-                }.toList();
-                final updatedEvent = event.copyWith(sources: updatedSources);
-                cacheManager!.saveEvent(updatedEvent);
-                // Update the event in broadcast state
-                broadcastState!.event = updatedEvent;
-              }
-            });
+            // Merge existing sources with new relay URL, avoiding duplicates
+            final updatedSources = {
+              ...event.sources,
+              relayConnectivity.url
+            }.toList();
+            final updatedEvent = event.copyWith(sources: updatedSources);
+            // Update the event in broadcast state
+            broadcastState!.event = updatedEvent;
           }
         }
         

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -23,6 +23,7 @@ import '../entities/relay_connectivity.dart';
 import '../entities/relay_info.dart';
 import '../entities/request_state.dart';
 import '../entities/tuple.dart';
+import '../repositories/cache_manager.dart';
 import '../repositories/nostr_transport.dart';
 import 'accounts/accounts.dart';
 import 'engines/network_engine.dart';
@@ -74,6 +75,9 @@ class RelayManager<T> {
   /// AUTH strategy: eager (on challenge) or lazy (on auth-required)
   final bool eagerAuth;
 
+  /// cache manager for updating event sources
+  final CacheManager? cacheManager;
+
   /// Creates a new relay manager.
   RelayManager({
     required this.globalState,
@@ -84,6 +88,7 @@ class RelayManager<T> {
     allowReconnect = true,
     this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
+    this.cacheManager,
   }) : _accounts = accounts {
     allowReconnectRelays = allowReconnect;
     _connectSeedRelays(urls: bootstrapRelays ?? DEFAULT_BOOTSTRAP_RELAYS);
@@ -501,6 +506,29 @@ class RelayManager<T> {
       if (globalState.inFlightBroadcasts[eventId] != null &&
           !globalState
               .inFlightBroadcasts[eventId]!.networkController.isClosed) {
+        // Update cache with source if broadcast was successful
+        if (success && cacheManager != null) {
+          final broadcastState = globalState.inFlightBroadcasts[eventId];
+          final event = broadcastState?.event;
+          if (event != null) {
+            // Only update cache if event was already saved (saveToCache was true)
+            // Check if event exists in cache before updating sources
+            cacheManager!.loadEvent(eventId).then((cachedEvent) {
+              if (cachedEvent != null) {
+                // Merge existing sources with new relay URL, avoiding duplicates
+                final updatedSources = {
+                  ...event.sources,
+                  relayConnectivity.url
+                }.toList();
+                final updatedEvent = event.copyWith(sources: updatedSources);
+                cacheManager!.saveEvent(updatedEvent);
+                // Update the event in broadcast state
+                broadcastState!.event = updatedEvent;
+              }
+            });
+          }
+        }
+        
         globalState.inFlightBroadcasts[eventId]?.networkController.add(
           RelayBroadcastResponse(
             relayUrl: relayConnectivity.url,
@@ -659,7 +687,7 @@ class RelayManager<T> {
       }
 
       final eventWithSources =
-          event.copyWith(sources: [...event.sources, connectivity.url]);
+          event.copyWith(sources: {...event.sources, connectivity.url}.toList());
 
       if (state.networkController.isClosed) {
         // this might happen because relays even after we send a CLOSE subscription.id, they'll still send more events

--- a/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
@@ -345,7 +345,7 @@ class Requests {
   }) {
     final requestId = '$name-paginated-${Helpers.getRandomString(10)}';
     final aggregatedController = ReplaySubject<Nip01Event>();
-    final seenEventIds = <String>{};
+    final seenEvents = <String, Set<String>>{}; // event_id -> sources
 
     Future<void> paginate() async {
       final since = filter.since;
@@ -373,9 +373,20 @@ class Requests {
       final relayState = <String, _RelayPaginationState>{};
 
       for (final event in initialEvents) {
-        if (!seenEventIds.contains(event.id)) {
-          seenEventIds.add(event.id);
+        final existingSources = seenEvents[event.id];
+        if (existingSources == null) {
+          // First time seeing this event
+          seenEvents[event.id] = event.sources.toSet();
           aggregatedController.add(event);
+        } else {
+          // Merge sources if this event has new sources
+          if (event.sources.isNotEmpty) {
+            final newSources = existingSources..addAll(event.sources);
+            if (newSources.length > (seenEvents[event.id]?.length ?? 0)) {
+              seenEvents[event.id] = newSources;
+              aggregatedController.add(event.copyWith(sources: newSources.toList()));
+            }
+          }
         }
 
         // Track oldest timestamp per relay
@@ -453,9 +464,20 @@ class Requests {
 
           int? oldestTimestamp;
           for (final event in pageEvents) {
-            if (!seenEventIds.contains(event.id)) {
-              seenEventIds.add(event.id);
+            final existingSources = seenEvents[event.id];
+            if (existingSources == null) {
+              // First time seeing this event
+              seenEvents[event.id] = event.sources.toSet();
               aggregatedController.add(event);
+            } else {
+              // Merge sources if this event has new sources
+              if (event.sources.isNotEmpty) {
+                final newSources = existingSources..addAll(event.sources);
+                if (newSources.length > (seenEvents[event.id]?.length ?? 0)) {
+                  seenEvents[event.id] = newSources;
+                  aggregatedController.add(event.copyWith(sources: newSources.toList()));
+                }
+              }
             }
             // Track oldest timestamp for this relay
             if (oldestTimestamp == null || event.createdAt < oldestTimestamp) {

--- a/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
@@ -275,6 +275,7 @@ class Requests {
       trackingSet: state.returnedIds,
       outController: state.controller,
       eventOutFilters: _eventOutFilters,
+      cacheManager: _cacheWrite.cacheManager,
     )();
 
     // Record fetched ranges when network requests complete (EOSE received)

--- a/packages/ndk/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
+++ b/packages/ndk/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import '../../../shared/logger/logger.dart';
 import '../../entities/event_filter.dart';
 import '../../entities/nip_01_event.dart';
+import '../../repositories/cache_manager.dart';
 
 /// given a stream  with Nip01 events it tracks the id and adds the one to the provided stream controller \
 /// tracking of the happens in the tracking list
@@ -10,6 +11,7 @@ class StreamResponseCleaner {
   final List<Stream<Nip01Event>> _inputStreams;
   final StreamController<Nip01Event> _outController;
   final List<EventFilter> _eventOutFilters;
+  final CacheManager? _cacheManager;
 
   int get _numStreams => _inputStreams.length;
 
@@ -18,16 +20,19 @@ class StreamResponseCleaner {
   /// -  [trackingSet] a set of ids that are already returned \
   /// - [inputStreams] a list of streams that are be listened to \
   /// - [outController] the controller that is used to add the events to \
+  /// - [cacheManager] optional cache manager to persist event sources \
 
   StreamResponseCleaner({
     required Set<String> trackingSet,
     required List<Stream<Nip01Event>> inputStreams,
     required StreamController<Nip01Event> outController,
     required List<EventFilter> eventOutFilters,
-  })  : _trackingMap = {for (var id in trackingSet) id: {}},
+    CacheManager? cacheManager,
+  })  : _trackingMap = {for (final id in trackingSet) id: {}},
         _outController = outController,
         _inputStreams = inputStreams,
-        _eventOutFilters = eventOutFilters;
+        _eventOutFilters = eventOutFilters,
+        _cacheManager = cacheManager;
 
   void call() {
     for (final stream in _inputStreams) {
@@ -52,6 +57,8 @@ class StreamResponseCleaner {
             _trackingMap[event.id] = newSources;
             final mergedEvent = event.copyWith(sources: newSources.toList());
             _outController.add(mergedEvent);
+            // Update cache with merged sources
+            _updateCacheSources(event.id, newSources);
           }
         }
         return;
@@ -72,6 +79,19 @@ class StreamResponseCleaner {
       _canClose();
     }, onError: (error) {
       Logger.log.e(() => "⛔ $error ");
+    });
+  }
+
+  /// Updates the cache with merged sources for an event
+  void _updateCacheSources(String eventId, Set<String> sources) {
+    if (_cacheManager == null) return;
+    
+    // Load existing event from cache and update sources
+    _cacheManager.loadEvent(eventId).then((cachedEvent) {
+      if (cachedEvent != null) {
+        final updatedEvent = cachedEvent.copyWith(sources: sources.toList());
+        _cacheManager.saveEvent(updatedEvent);
+      }
     });
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
+++ b/packages/ndk/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
@@ -6,7 +6,7 @@ import '../../entities/nip_01_event.dart';
 /// given a stream  with Nip01 events it tracks the id and adds the one to the provided stream controller \
 /// tracking of the happens in the tracking list
 class StreamResponseCleaner {
-  final Set<String> _trackingSet;
+  final Map<String, Set<String>> _trackingMap; // event_id -> set of sources
   final List<Stream<Nip01Event>> _inputStreams;
   final StreamController<Nip01Event> _outController;
   final List<EventFilter> _eventOutFilters;
@@ -24,7 +24,7 @@ class StreamResponseCleaner {
     required List<Stream<Nip01Event>> inputStreams,
     required StreamController<Nip01Event> outController,
     required List<EventFilter> eventOutFilters,
-  })  : _trackingSet = trackingSet,
+  })  : _trackingMap = {for (var id in trackingSet) id: {}},
         _outController = outController,
         _inputStreams = inputStreams,
         _eventOutFilters = eventOutFilters;
@@ -37,16 +37,28 @@ class StreamResponseCleaner {
 
   void _addStreamListener(Stream<Nip01Event> stream) {
     stream.listen((event) {
-      // check if event id is in the set
-      if (_trackingSet.contains(event.id)) {
-        return;
-      }
-
       if (_outController.isClosed) {
         return;
       }
 
-      _trackingSet.add(event.id);
+      // check if event id is already seen
+      final existingSources = _trackingMap[event.id];
+      if (existingSources != null) {
+        // Event already seen - merge sources if this event has new sources
+        if (event.sources.isNotEmpty) {
+          final newSources = Set<String>.from(existingSources)..addAll(event.sources);
+          // Only emit if we have new sources to add
+          if (newSources.length > existingSources.length) {
+            _trackingMap[event.id] = newSources;
+            final mergedEvent = event.copyWith(sources: newSources.toList());
+            _outController.add(mergedEvent);
+          }
+        }
+        return;
+      }
+
+      // First time seeing this event
+      _trackingMap[event.id] = event.sources.toSet();
 
       // check against filters
       for (final filter in _eventOutFilters) {

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -122,7 +122,6 @@ class Initialization {
           bootstrapRelays: _ndkConfig.bootstrapRelays,
           eagerAuth: _ndkConfig.eagerAuth,
           authCallbackTimeout: _ndkConfig.authCallbackTimeout,
-          cacheManager: _ndkConfig.cache,
         );
 
         engine = RelaySetsEngine(
@@ -141,9 +140,7 @@ class Initialization {
           engineAdditionalDataFactory: JitEngineRelayConnectivityDataFactory(),
           eagerAuth: _ndkConfig.eagerAuth,
           authCallbackTimeout: _ndkConfig.authCallbackTimeout,
-          cacheManager: _ndkConfig.cache,
         );
-
         engine = JitEngine(
           cache: _ndkConfig.cache,
           ignoreRelays: _ndkConfig.ignoreRelays,

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -122,6 +122,7 @@ class Initialization {
           bootstrapRelays: _ndkConfig.bootstrapRelays,
           eagerAuth: _ndkConfig.eagerAuth,
           authCallbackTimeout: _ndkConfig.authCallbackTimeout,
+          cacheManager: _ndkConfig.cache,
         );
 
         engine = RelaySetsEngine(
@@ -140,6 +141,7 @@ class Initialization {
           engineAdditionalDataFactory: JitEngineRelayConnectivityDataFactory(),
           eagerAuth: _ndkConfig.eagerAuth,
           authCallbackTimeout: _ndkConfig.authCallbackTimeout,
+          cacheManager: _ndkConfig.cache,
         );
 
         engine = JitEngine(

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -33,6 +33,7 @@ class MockRelay {
   bool sendMalformedEvents;
   String? customWelcomeMessage;
   int? maxEventsPerRequest;
+  String? bannedWord;
 
   // NIP-46 Remote Signer Support
   static const int kNip46Kind = BunkerRequest.kKind;
@@ -58,6 +59,7 @@ class MockRelay {
     this.sendMalformedEvents = false,
     this.customWelcomeMessage,
     this.maxEventsPerRequest,
+    this.bannedWord,
     int? explicitPort,
   }) : _nip65s = nip65s {
     if (explicitPort != null) {
@@ -147,6 +149,16 @@ class MockRelay {
         if (eventJson[0] == "EVENT") {
           Nip01Event newEvent = Nip01EventModel.fromJson(eventJson[1]);
           if (verify(newEvent.pubKey, newEvent.id, newEvent.sig!)) {
+            // Check if event contains banned word
+            if (bannedWord != null && newEvent.content.contains(bannedWord!)) {
+              webSocket.add(jsonEncode([
+                "OK",
+                newEvent.id,
+                false,
+                "blocked: content contains banned word"
+              ]));
+              return;
+            }
             // Check auth for events if required (any authenticated user is OK)
             if (requireAuthForEvents && authenticatedPubkeys.isEmpty) {
               webSocket.add(jsonEncode([

--- a/packages/ndk/test/usecases/broadcast_sources_test.dart
+++ b/packages/ndk/test/usecases/broadcast_sources_test.dart
@@ -1,0 +1,44 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_event_verifier.dart';
+import '../mocks/mock_relay.dart';
+
+void main() async {
+  test("braodcast should update source", () async {
+    final relay = MockRelay(name: "relay");
+
+    await relay.startServer();
+
+    final ndk = Ndk(NdkConfig(
+      eventVerifier: MockEventVerifier(),
+      cache: MemCacheManager(),
+      bootstrapRelays: [relay.url],
+    ));
+
+    final keypair = Bip340.generatePrivateKey();
+    final signer = Bip340EventSigner(
+      privateKey: keypair.privateKey,
+      publicKey: keypair.publicKey,
+    );
+    ndk.accounts.loginExternalSigner(signer: signer);
+
+    final event = Nip01Event(
+      pubKey: keypair.publicKey,
+      kind: 1,
+      tags: [],
+      content: "content",
+    );
+
+    await ndk.broadcast.broadcast(nostrEvent: event).broadcastDoneFuture;
+
+    final localEvent = await ndk.config.cache.loadEvent(event.id);
+
+    expect(localEvent, isNotNull);
+    expect(localEvent!.sources, isNotEmpty);
+
+    await ndk.destroy();
+    await relay.stopServer();
+  });
+}

--- a/packages/ndk/test/usecases/broadcast_sources_test.dart
+++ b/packages/ndk/test/usecases/broadcast_sources_test.dart
@@ -6,16 +6,18 @@ import '../mocks/mock_event_verifier.dart';
 import '../mocks/mock_relay.dart';
 
 void main() async {
-  test("braodcast should update source", () async {
+  test("broadcast should update source", () async {
     final relay = MockRelay(name: "relay");
 
     await relay.startServer();
+    addTearDown(() => relay.stopServer());
 
     final ndk = Ndk(NdkConfig(
       eventVerifier: MockEventVerifier(),
       cache: MemCacheManager(),
       bootstrapRelays: [relay.url],
     ));
+    addTearDown(() => ndk.destroy());
 
     final keypair = Bip340.generatePrivateKey();
     final signer = Bip340EventSigner(
@@ -37,8 +39,5 @@ void main() async {
 
     expect(localEvent, isNotNull);
     expect(localEvent!.sources, isNotEmpty);
-
-    await ndk.destroy();
-    await relay.stopServer();
   });
 }

--- a/packages/ndk/test/usecases/stream_response_cleaner/event_sources_merge_test.dart
+++ b/packages/ndk/test/usecases/stream_response_cleaner/event_sources_merge_test.dart
@@ -1,0 +1,53 @@
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+import 'package:ndk/ndk.dart';
+
+import '../../mocks/mock_event_verifier.dart';
+import '../../mocks/mock_relay.dart';
+
+void main() async {
+  test("requests should update sources", () async {
+    final bannedWord = "cow";
+
+    final relay1 = MockRelay(name: "relay 1");
+    final relay2 = MockRelay(name: "relay 2");
+    final relay3 = MockRelay(name: "relay 2", bannedWord: bannedWord);
+
+    await relay1.startServer();
+    await relay2.startServer();
+    await relay3.startServer();
+
+    final ndk = Ndk(NdkConfig(
+      eventVerifier: MockEventVerifier(),
+      cache: MemCacheManager(),
+      bootstrapRelays: [relay1.url, relay2.url, relay3.url],
+    ));
+
+    final keypair = Bip340.generatePrivateKey();
+    final signer = Bip340EventSigner(
+      privateKey: keypair.privateKey,
+      publicKey: keypair.publicKey,
+    );
+    ndk.accounts.loginExternalSigner(signer: signer);
+
+    final event = Nip01Event(
+      pubKey: keypair.publicKey,
+      kind: 1,
+      tags: [],
+      content: bannedWord,
+    );
+    await ndk.broadcast.broadcast(nostrEvent: event).broadcastDoneFuture;
+
+    await ndk.config.cache.clearAll();
+
+    final query = ndk.requests.query(filter: Filter(ids: [event.id]));
+    final events = await query.future;
+
+    expect(events.first.sources.length, equals(2));
+
+    await ndk.destroy();
+    await relay1.stopServer();
+    await relay2.stopServer();
+    await relay3.stopServer();
+  });
+}

--- a/packages/ndk/test/usecases/stream_response_cleaner/event_sources_merge_test.dart
+++ b/packages/ndk/test/usecases/stream_response_cleaner/event_sources_merge_test.dart
@@ -43,7 +43,8 @@ void main() async {
     final query = ndk.requests.query(filter: Filter(ids: [event.id]));
     final events = await query.future;
 
-    expect(events.first.sources.length, equals(2));
+    // The last event should have all merged sources
+    expect(events.last.sources.length, equals(2));
 
     await ndk.destroy();
     await relay1.stopServer();

--- a/packages/ndk/test/usecases/stream_response_cleaner/event_sources_merge_test.dart
+++ b/packages/ndk/test/usecases/stream_response_cleaner/event_sources_merge_test.dart
@@ -11,17 +11,25 @@ void main() async {
 
     final relay1 = MockRelay(name: "relay 1");
     final relay2 = MockRelay(name: "relay 2");
-    final relay3 = MockRelay(name: "relay 2", bannedWord: bannedWord);
+    final relay3 = MockRelay(name: "relay 3", bannedWord: bannedWord);
 
     await relay1.startServer();
     await relay2.startServer();
     await relay3.startServer();
+
+    addTearDown(() async {
+      await relay1.stopServer();
+      await relay2.stopServer();
+      await relay3.stopServer();
+    });
 
     final ndk = Ndk(NdkConfig(
       eventVerifier: MockEventVerifier(),
       cache: MemCacheManager(),
       bootstrapRelays: [relay1.url, relay2.url, relay3.url],
     ));
+    
+    addTearDown(() => ndk.destroy());
 
     final keypair = Bip340.generatePrivateKey();
     final signer = Bip340EventSigner(
@@ -46,9 +54,9 @@ void main() async {
     // The last event should have all merged sources
     expect(events.last.sources.length, equals(2));
 
-    await ndk.destroy();
-    await relay1.stopServer();
-    await relay2.stopServer();
-    await relay3.stopServer();
+    final localEvent = await ndk.config.cache.loadEvent(event.id);
+
+    expect(localEvent, isNotNull);
+    expect(localEvent!.sources.length, equals(2));
   });
 }


### PR DESCRIPTION
Tests to demonstrate https://github.com/relaystr/ndk/issues/469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay content filtering with configurable banned-word blocking.
  * Persistent tracking and merging of event source lists across relays and broadcasts.

* **Improvements**
  * Broadcast flow now updates cached events with per-relay success sources; stream handling supports multiple listeners and avoids duplicate sources.
  * Request/stream processing aggregates sources and re-emits only when source sets grow.

* **Tests**
  * Added tests for broadcast source attribution and multi-relay source merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->