### PR TITLE
fix: wasm compatible conditional import

### DIFF
--- a/packages/ndk_flutter/lib/verifiers/web_event_verifier.dart
+++ b/packages/ndk_flutter/lib/verifiers/web_event_verifier.dart
@@ -5,4 +5,4 @@
 library;
 
 export 'src/web_event_verifier_stub.dart'
-    if (dart.library.html) 'src/web_event_verifier_web.dart';
+    if (dart.library.js) 'src/web_event_verifier_web.dart';


### PR DESCRIPTION
use  ` if (dart.library.js) ` for wasm compatible import