### PR TITLE
fix: conditional web import to support wasm

### DIFF
--- a/packages/ndk_flutter/lib/verifiers/web_event_verifier.dart
+++ b/packages/ndk_flutter/lib/verifiers/web_event_verifier.dart
@@ -5,4 +5,4 @@
 library;
 
 export 'src/web_event_verifier_stub.dart'
-    if (dart.library.js) 'src/web_event_verifier_web.dart';
+    if (dart.library.js_interop) 'src/web_event_verifier_web.dart';

--- a/packages/nip07_event_signer/lib/nip07_event_signer.dart
+++ b/packages/nip07_event_signer/lib/nip07_event_signer.dart
@@ -3,4 +3,5 @@
 /// More dartdocs go here.
 library;
 
-export 'src/nip07_event_signer_stub.dart' if (dart.library.html) 'src/nip07_event_signer_web.dart';
+export 'src/nip07_event_signer_stub.dart'
+    if (dart.library.js_interop) 'src/nip07_event_signer_web.dart';


### PR DESCRIPTION
`dart.library.js_interop` instead of:
`dart.library.html`
`dart.library.js`

fixes wasm builds