### PR TITLE
fix: min sdk 3.6 for hooks

### DIFF
--- a/packages/ndk/pubspec.yaml
+++ b/packages/ndk/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - nostr
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 platforms:
   android:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required Dart SDK version to 3.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->