### PR TITLE
doc: publish guide

### DIFF
--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -13,9 +13,9 @@ Create a tag
 
 Push to git
 
-```git push origin v1.2.3 
-or
-git push --tags # push all local tags tags
+```
+git push origin v1.2.3
+
 ```
 
 > This will build the sample app and create a draft github release (gh actions).

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -41,7 +41,9 @@ Notice: the automated PR does just versioning and publish dry-run. The Publishin
 
 1.) either change the versions manually (also all dependencies) or run melos version (this will create a git commit)
 
-2.) commit your changes to git
+2.) run 'melos run format'
 
-3.) run `melos publish` check everything then run `melos publish --no-dry-run`. For a single package run `melos publish --<package name>`
+3.) commit your changes to git
+
+4.) run `melos publish` check everything then run `melos publish --no-dry-run`. For a single package run `melos publish --<package name>`
 

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -33,7 +33,9 @@ If you want a major release check 'Version as prerelease'!
 
 A new PR named 'chore(release): Publish packages' will open Review the changelog/versions, modify if needed.
 
+!!!
 Merging this PR will automatically publish the changed (packages with version bump) packages to pub.dev
+!!!
 
 Notice: the automated PR does just versioning and publish dry-run. The Publishing happens when this PR is merged.
 

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -42,10 +42,6 @@ Notice: the automated PR does just versioning and publish dry-run. The Publishin
 ## publish manually
 
 1. either change the versions manually (also all dependencies) or run melos version (this will create a git commit)
-
 2. run 'melos run format'
-
 3. commit your changes to git
-
 4. run `melos publish` check everything then run `melos publish --no-dry-run`. For a single package run `melos publish --<package name>`
-

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -41,11 +41,11 @@ Notice: the automated PR does just versioning and publish dry-run. The Publishin
 
 ## publish manually
 
-1.) either change the versions manually (also all dependencies) or run melos version (this will create a git commit)
+1. either change the versions manually (also all dependencies) or run melos version (this will create a git commit)
 
-2.) run 'melos run format'
+2. run 'melos run format'
 
-3.) commit your changes to git
+3. commit your changes to git
 
-4.) run `melos publish` check everything then run `melos publish --no-dry-run`. For a single package run `melos publish --<package name>`
+4. run `melos publish` check everything then run `melos publish --no-dry-run`. For a single package run `melos publish --<package name>`
 

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -33,11 +33,11 @@ If you want a major release check 'Version as prerelease'!
 
 A new PR named 'chore(release): Publish packages' will open Review the changelog/versions, modify if needed.
 
-!!!
 Merging this PR will automatically publish the changed (packages with version bump) packages to pub.dev
-!!!
 
+!!!
 Notice: the automated PR does just versioning and publish dry-run. The Publishing happens when this PR is merged.
+!!!
 
 ## publish manually
 

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -1,0 +1,47 @@
+---
+label: Publishing
+icon: rocket
+order: 100
+---
+
+# Publishing
+
+## publish to github
+
+Create a tag
+`git tag -a v1.2.3 -m "Release v1.2.3"`
+
+Push to git
+
+```git push origin v1.2.3 
+or
+git push --tags # push all local tags tags
+```
+
+> This will build the sample app and create a draft github release (gh actions).
+
+Wait for the sample app to build and review && publish on github release page [releases](https://github.com/relaystr/ndk/releases)
+
+
+## publish to pub.dev (automated)
+
+go to [manual release gh actions](https://github.com/relaystr/ndk/actions/workflows/prerelease-manual.yaml)
+
+For dev releases this is called automatically on each merge.
+
+If you want a major release check 'Version as prerelease'!
+
+A new PR named 'chore(release): Publish packages' will open Review the changelog/versions, modify if needed.
+
+Merging this PR will automatically publish the changed (packages with version bump) packages to pub.dev
+
+Notice: the automated PR does just versioning and publish dry-run. The Publishing happens when this PR is merged.
+
+## publish manually
+
+1.) either change the versions manually (also all dependencies) or run melos version (this will create a git commit)
+
+2.) commit your changes to git
+
+3.) run `melos publish` check everything then run `melos publish --no-dry-run`. For a single package run `melos publish --<package name>`
+


### PR DESCRIPTION
a guide to help with publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Publishing" guide standardizing release steps for GitHub and pub.dev: create annotated version tags to trigger automated builds and draft releases, guidance on waiting and publishing from Releases, pub.dev automation with manual-release gating and prerelease handling, and a documented manual workflow for bumping versions, running formatting and checks, performing dry-run publishes, and executing final package publishes (including single-package options).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->