### PR TITLE
feat: add optional relayUrls param to getOptimizedFilters and handle …

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/fetched_ranges/fetched_ranges.dart
+++ b/packages/ndk/lib/domain_layer/usecases/fetched_ranges/fetched_ranges.dart
@@ -67,19 +67,38 @@ class FetchedRanges {
 
   /// Get optimized filters for each relay to fill gaps
   /// Returns a map of relay URL to list of filters covering only the gaps
+  /// If [relayUrls] is provided, only considers those relays
+  /// If a relay has no cached ranges, treats the entire [since, until] range as a gap
   Future<Map<String, List<Filter>>> getOptimizedFilters({
     required Filter filter,
     required int since,
     required int until,
+    List<String>? relayUrls,
   }) async {
     final fetchedRangesMap = await getForFilter(filter);
     final result = <String, List<Filter>>{};
 
-    for (final entry in fetchedRangesMap.entries) {
-      final relayUrl = entry.key;
-      final fetchedRanges = entry.value;
+    // If relayUrls is specified, only consider those relays
+    final relaysToCheck = relayUrls ?? fetchedRangesMap.keys.toList();
 
-      final gaps = fetchedRanges.findGaps(since, until);
+    for (final relayUrl in relaysToCheck) {
+      final fetchedRanges = fetchedRangesMap[relayUrl];
+
+      List<FetchedRangesGap> gaps;
+      if (fetchedRanges == null || fetchedRanges.ranges.isEmpty) {
+        // No cached ranges - entire range is a gap
+        gaps = [
+          FetchedRangesGap(
+            relayUrl: relayUrl,
+            since: since,
+            until: until,
+          )
+        ];
+      } else {
+        // Find gaps in existing ranges
+        gaps = fetchedRanges.getGaps(since, until);
+      }
+
       if (gaps.isNotEmpty) {
         result[relayUrl] = gaps.map((gap) {
           final gapFilter = filter.clone();

--- a/packages/ndk/pubspec.lock
+++ b/packages/ndk/pubspec.lock
@@ -444,9 +444,10 @@ packages:
   ndk_bip32_keys:
     dependency: "direct main"
     description:
-      path: "../bip32_keys"
-      relative: true
-    source: path
+      name: ndk_bip32_keys
+      sha256: "6bc311451646b6d488ca8e4c9907dc0e8486d93de752d5ab09c5c7b6c96238d8"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   ndk_cache_manager_test_suite:
     dependency: "direct dev"

--- a/packages/ndk/test/usecases/fetched_ranges/fetched_ranges_test.dart
+++ b/packages/ndk/test/usecases/fetched_ranges/fetched_ranges_test.dart
@@ -257,6 +257,55 @@ void main() {
 
       expect(optimized, isEmpty);
     });
+
+    test('returns full range as gap when cache is empty for specified relay', () async {
+      final filter = Filter(kinds: [1]);
+
+      // Don't add any ranges - cache is empty
+      final optimized = await fetchedRanges.getOptimizedFilters(
+        filter: filter,
+        since: 100,
+        until: 500,
+        relayUrls: ['wss://example.com'],
+      );
+
+      expect(optimized.containsKey('wss://example.com'), isTrue);
+      final filters = optimized['wss://example.com']!;
+      expect(filters.length, 1);
+      expect(filters[0].since, 100);
+      expect(filters[0].until, 500);
+      expect(filters[0].kinds, [1]);
+    });
+
+    test('respects relayUrls parameter and only checks specified relays', () async {
+      final filter = Filter(kinds: [1]);
+
+      await fetchedRanges.addRange(
+        filter: filter,
+        relayUrl: 'wss://relay1.example.com',
+        since: 200,
+        until: 300,
+      );
+
+      await fetchedRanges.addRange(
+        filter: filter,
+        relayUrl: 'wss://relay2.example.com',
+        since: 150,
+        until: 350,
+      );
+
+      // Only check relay1
+      final optimized = await fetchedRanges.getOptimizedFilters(
+        filter: filter,
+        since: 100,
+        until: 500,
+        relayUrls: ['wss://relay1.example.com'],
+      );
+
+      expect(optimized.length, 1);
+      expect(optimized.containsKey('wss://relay1.example.com'), isTrue);
+      expect(optimized.containsKey('wss://relay2.example.com'), isFalse);
+    });
   });
 
   group('FetchedRanges.reachedOldest', () {


### PR DESCRIPTION
…empty cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optimization queries now support optional relay URL filtering to restrict gap analysis to specified relay subsets
  * Gap analysis now treats entire time intervals as gaps when relay cache entries are unavailable

* **Tests**
  * Added test coverage for optimization behavior when relay cache entries are missing
  * Added test coverage validating that relay-filtered queries return only specified relay results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->