### PR TITLE
fix: validate nsec/npub prefix before decoding

### DIFF
--- a/packages/ndk/pubspec.lock
+++ b/packages/ndk/pubspec.lock
@@ -444,9 +444,10 @@ packages:
   ndk_bip32_keys:
     dependency: "direct main"
     description:
-      path: "../bip32_keys"
-      relative: true
-    source: path
+      name: ndk_bip32_keys
+      sha256: "6bc311451646b6d488ca8e4c9907dc0e8486d93de752d5ab09c5c7b6c96238d8"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   ndk_cache_manager_test_suite:
     dependency: "direct dev"

--- a/packages/ndk_flutter/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/packages/ndk_flutter/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -31,14 +31,19 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin flutter_secure_storage, com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.github.dart_lang.jni.JniPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin jni, com.github.dart_lang.jni.JniPlugin", e);
+    }
+    try {
+      flutterEngine.getPlugins().add(new com.github.dart_lang.jni_flutter.JniFlutterPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin jni_flutter, com.github.dart_lang.jni_flutter.JniFlutterPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new dev.steenbakker.mobile_scanner.MobileScannerPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin mobile_scanner, dev.steenbakker.mobile_scanner.MobileScannerPlugin", e);
-    }
-    try {
-      flutterEngine.getPlugins().add(new io.flutter.plugins.pathprovider.PathProviderPlugin());
-    } catch (Exception e) {
-      Log.e(TAG, "Error registering plugin path_provider_android, io.flutter.plugins.pathprovider.PathProviderPlugin", e);
     }
     try {
       flutterEngine.getPlugins().add(new io.flutter.plugins.urllauncher.UrlLauncherPlugin());

--- a/packages/ndk_flutter/lib/widgets/login/n_login.dart
+++ b/packages/ndk_flutter/lib/widgets/login/n_login.dart
@@ -279,6 +279,8 @@ class _NLoginState extends State<NLogin> {
   }
 
   Future<void> loginWithNpub(String npub) async {
+    if (!Nip19.isPubkey(npub)) return;
+
     String pubkey;
     try {
       pubkey = Nip19.decode(npub);
@@ -296,6 +298,8 @@ class _NLoginState extends State<NLogin> {
   }
 
   Future<void> loginWithNsec(String nsec) async {
+    if (!Nip19.isPrivateKey(nsec)) return;
+
     String privateKey;
     try {
       privateKey = Nip19.decode(nsec);

--- a/packages/sample-app/ios/Flutter/Debug.xcconfig
+++ b/packages/sample-app/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/sample-app/ios/Flutter/Release.xcconfig
+++ b/packages/sample-app/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/sample-app/ios/Podfile
+++ b/packages/sample-app/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/packages/sample-app/macos/Flutter/Flutter-Debug.xcconfig
+++ b/packages/sample-app/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/packages/sample-app/macos/Flutter/Flutter-Release.xcconfig
+++ b/packages/sample-app/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/packages/sample-app/macos/Podfile
+++ b/packages/sample-app/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/packages/sample-app/pubspec.lock
+++ b/packages/sample-app/pubspec.lock
@@ -611,7 +611,7 @@ packages:
       path: "../ndk"
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.8.2-dev.1"
   ndk_bip32_keys:
     dependency: transitive
     description:
@@ -626,14 +626,14 @@ packages:
       path: "../drift"
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.1-dev.1"
   ndk_flutter:
     dependency: "direct main"
     description:
       path: "../ndk_flutter"
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.8.2-dev.1"
   nested:
     dependency: transitive
     description:
@@ -648,7 +648,7 @@ packages:
       path: "../nip07_event_signer"
       relative: true
     source: path
-    version: "1.0.9"
+    version: "1.0.10-dev.1"
   objective_c:
     dependency: transitive
     description:


### PR DESCRIPTION
Verify npub and nsec prefix when login with NLogin widget. It fix the issue where we can paste a npub in the nsec field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened login credential validation to prevent processing of improperly formatted inputs before authentication attempts.

* **Chores**
  * Updated iOS and macOS build configurations and dependency management systems.
  * Reorganized native plugin integration for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->