### PR TITLE
fix: treat 2xx HTTP statuses as success [codex]

### DIFF
--- a/packages/ndk/lib/data_layer/data_sources/http_request.dart
+++ b/packages/ndk/lib/data_layer/data_sources/http_request.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:rxdart/rxdart.dart';
 
+bool _isSuccessStatus(int statusCode) => statusCode >= 200 && statusCode < 300;
+
 /// Upload progress information
 class UploadProgress {
   final int sentBytes;
@@ -36,7 +38,7 @@ class HttpRequestDS {
         Uri.parse(url).replace(scheme: 'https'),
         headers: {"Accept": "application/json"});
 
-    if (response.statusCode != 200) {
+    if (!_isSuccessStatus(response.statusCode)) {
       return throw Exception(
           "error fetching STATUS: ${response.statusCode}, ${response.body},Link: $url");
     }
@@ -54,7 +56,7 @@ class HttpRequestDS {
       headers: headers,
     );
 
-    if (response.statusCode != 200) {
+    if (!_isSuccessStatus(response.statusCode)) {
       throw Exception(
           "error fetching STATUS: ${response.statusCode}, ${response.body}, Link: $url");
     }
@@ -116,7 +118,7 @@ class HttpRequestDS {
         final streamedResponse = await _client.send(request);
         final response = await http.Response.fromStream(streamedResponse);
 
-        if (response.statusCode != 200) {
+        if (!_isSuccessStatus(response.statusCode)) {
           final error = Exception(
               "error fetching STATUS: ${response.statusCode}, Link: $url");
           progressSubject.addError(error);
@@ -154,7 +156,7 @@ class HttpRequestDS {
       headers: headers,
     );
 
-    if (response.statusCode != 200) {
+    if (!_isSuccessStatus(response.statusCode)) {
       throw Exception(
           "error fetching STATUS: ${response.statusCode}, ${response.body}, Link: $url,  ");
     }
@@ -171,7 +173,7 @@ class HttpRequestDS {
       headers: headers,
     );
 
-    if (response.statusCode != 200) {
+    if (!_isSuccessStatus(response.statusCode)) {
       throw Exception(
           "error fetching STATUS: ${response.statusCode}, ${response.body}, Link: $url");
     }
@@ -188,7 +190,7 @@ class HttpRequestDS {
       headers: headers,
     );
 
-    if (response.statusCode != 200) {
+    if (!_isSuccessStatus(response.statusCode)) {
       throw Exception(
           "error fetching STATUS: ${response.statusCode}, ${response.body}, Link: $url");
     }
@@ -209,7 +211,7 @@ class HttpRequestDS {
 
     final streamedResponse = await _client.send(request);
 
-    if (streamedResponse.statusCode != 200) {
+    if (!_isSuccessStatus(streamedResponse.statusCode)) {
       throw Exception(
           "error fetching STATUS: ${streamedResponse.statusCode}, Link: $url");
     }
@@ -226,7 +228,7 @@ class HttpRequestDS {
       headers: headers,
     );
 
-    if (response.statusCode != 200) {
+    if (!_isSuccessStatus(response.statusCode)) {
       throw Exception(
           "error fetching STATUS: ${response.statusCode}, ${response.body}, Link: $url");
     }

--- a/packages/ndk/lib/data_layer/repositories/blossom/blossom_impl.dart
+++ b/packages/ndk/lib/data_layer/repositories/blossom/blossom_impl.dart
@@ -15,6 +15,8 @@ import '../../data_sources/http_request.dart';
 import '../../io/file_io.dart';
 import '../../models/nip_01_event_model.dart';
 
+bool _isSuccessStatus(int statusCode) => statusCode >= 200 && statusCode < 300;
+
 class BlossomRepositoryImpl implements BlossomRepository {
   final HttpRequestDS client;
   final FileIO fileIO;
@@ -473,7 +475,7 @@ class BlossomRepositoryImpl implements BlossomRepository {
         },
       );
 
-      if (response.statusCode != 200) {
+      if (!_isSuccessStatus(response.statusCode)) {
         return BlobUploadResult(
           serverUrl: serverUrl,
           success: false,
@@ -565,7 +567,7 @@ class BlossomRepositoryImpl implements BlossomRepository {
           url: Uri.parse('$url/$sha256'),
         );
 
-        if (response.statusCode == 200) {
+        if (_isSuccessStatus(response.statusCode)) {
           return '$url/$sha256';
         }
         lastError = Exception('HTTP ${response.statusCode}');
@@ -732,9 +734,10 @@ class BlossomRepositoryImpl implements BlossomRepository {
 
       return BlobDeleteResult(
         serverUrl: serverUrl,
-        success: response.statusCode == 200,
-        error:
-            response.statusCode != 200 ? 'HTTP ${response.statusCode}' : null,
+        success: _isSuccessStatus(response.statusCode),
+        error: !_isSuccessStatus(response.statusCode)
+            ? 'HTTP ${response.statusCode}'
+            : null,
       );
     } catch (e) {
       return BlobDeleteResult(

--- a/packages/ndk/test/mocks/mock_blossom_server.dart
+++ b/packages/ndk/test/mocks/mock_blossom_server.dart
@@ -12,12 +12,20 @@ class MockBlossomServer {
   // In-memory storage for blobs
   final Map<String, _BlobEntry> _blobs = {};
   final int port;
+  final int uploadStatusCode;
+  final int mirrorStatusCode;
+  final int deleteStatusCode;
   HttpServer? _server;
 
   /// report kind
   static const int kReport = 1984;
 
-  MockBlossomServer({this.port = 3000});
+  MockBlossomServer({
+    this.port = 3000,
+    this.uploadStatusCode = 200,
+    this.mirrorStatusCode = 200,
+    this.deleteStatusCode = 200,
+  });
 
   Router _createRouter() {
     final router = Router();
@@ -82,8 +90,9 @@ class MockBlossomServer {
         uploadedAt: DateTime.now(),
       );
 
-      return Response.ok(
-        json.encode({
+      return Response(
+        uploadStatusCode,
+        body: json.encode({
           'url': 'http://localhost:$port/$sha256',
           'sha256': sha256,
           'size': data.length,
@@ -163,7 +172,7 @@ class MockBlossomServer {
       }
 
       _blobs.remove(sha256);
-      return Response(200);
+      return Response(deleteStatusCode);
     });
 
     router.put('/mirror', (Request request) async {
@@ -231,8 +240,9 @@ class MockBlossomServer {
 
         httpClient.close();
         // Return the same descriptor format as upload
-        return Response.ok(
-          json.encode({
+        return Response(
+          mirrorStatusCode,
+          body: json.encode({
             'url': 'http://localhost:$port/$computedSha256',
             'sha256': computedSha256,
             'size': data.length,

--- a/packages/ndk/test/usecases/files/blossom_test.dart
+++ b/packages/ndk/test/usecases/files/blossom_test.dart
@@ -19,6 +19,7 @@ import '../../mocks/mock_event_verifier.dart';
 
 const int primaryServerPort = 30000;
 const int secondaryServerPort = 30001;
+const int statusServerPort = 30002;
 
 void main() {
   late MockBlossomServer server;
@@ -77,6 +78,26 @@ void main() {
       );
       expect(utf8.decode(getResponse.data), equals('Hello, Blossom!'));
       expect(utf8.decode(getResponseAuth.data), equals('Hello, Blossom!'));
+    });
+
+    test('Upload accepts Created response status', () async {
+      final createdServer = MockBlossomServer(
+        port: statusServerPort,
+        uploadStatusCode: 201,
+      );
+      await createdServer.start();
+      addTearDown(createdServer.stop);
+
+      final testData = Uint8List.fromList(utf8.encode('Hello, Created!'));
+
+      final uploadResponse = await client.uploadBlob(
+        data: testData,
+        serverUrls: ['http://localhost:$statusServerPort'],
+      );
+
+      expect(uploadResponse.first.success, true);
+      expect(uploadResponse.first.descriptor, isNotNull);
+      expect(uploadResponse.first.descriptor!.size, equals(testData.length));
     });
 
     test('Upload and check blob', () async {
@@ -189,6 +210,30 @@ void main() {
       );
       //check that something throws an error
       expect(getResponse, throwsException);
+    });
+
+    test('Delete accepts Accepted response status', () async {
+      final acceptedServer = MockBlossomServer(
+        port: statusServerPort,
+        deleteStatusCode: 202,
+      );
+      await acceptedServer.start();
+      addTearDown(acceptedServer.stop);
+
+      final testData = Uint8List.fromList(utf8.encode('Delete accepted'));
+
+      final uploadResponse = await client.uploadBlob(
+        data: testData,
+        serverUrls: ['http://localhost:$statusServerPort'],
+      );
+      expect(uploadResponse.first.success, true);
+
+      final deleteResponse = await client.deleteBlob(
+        sha256: uploadResponse.first.descriptor!.sha256,
+        serverUrls: ['http://localhost:$statusServerPort'],
+      );
+
+      expect(deleteResponse.first.success, true);
     });
   });
 
@@ -521,6 +566,36 @@ void main() {
 
       expect(utf8.decode(fromServer1.data), equals(myData));
       expect(utf8.decode(fromServer2.data), equals(myData));
+    });
+
+    test('mirrorToServers accepts Created response status', () async {
+      final mirrorServer = MockBlossomServer(
+        port: statusServerPort,
+        mirrorStatusCode: 201,
+      );
+      await mirrorServer.start();
+      addTearDown(mirrorServer.stop);
+
+      final myData = "mirror created status test";
+      final testData = Uint8List.fromList(utf8.encode(myData));
+
+      final uploadResponse = await client.uploadBlob(
+        data: testData,
+        serverUrls: ['http://localhost:$primaryServerPort'],
+      );
+      expect(uploadResponse.first.success, true);
+
+      final sha256 = uploadResponse.first.descriptor!.sha256;
+      final blossomUrl =
+          Uri.parse('http://localhost:$primaryServerPort/$sha256');
+
+      final mirrorResponse = await client.mirrorToServers(
+        blossomUrl: blossomUrl,
+        targetServerUrls: ['http://localhost:$statusServerPort'],
+      );
+
+      expect(mirrorResponse.first.success, true);
+      expect(mirrorResponse.first.descriptor?.sha256, equals(sha256));
     });
 
     test('mirrorToServers should mirror to multiple servers simultaneously',


### PR DESCRIPTION
## Summary

- Treat HTTP response statuses in the 2xx range as successful in the shared NDK HTTP request data source.
- Keep Blossom mirror, blob existence checks, and delete result handling aligned with that 2xx success rule.
- Add Blossom tests covering upload 201 Created, mirror 201 Created, and delete 202 Accepted responses.

## Why

Blossom servers may return 201 Created for a successful PUT /upload. The previous strict 200 check caused successful uploads to be reported as failures.

## Validation

- dart analyze lib/data_layer/data_sources/http_request.dart lib/data_layer/repositories/blossom/blossom_impl.dart test/mocks/mock_blossom_server.dart test/usecases/files/blossom_test.dart
- dart test test/usecases/files/blossom_test.dart
