### PR TITLE
fix: wallet streams repeated listen breaks stream connection

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/wallets/wallets.dart
+++ b/packages/ndk/lib/domain_layer/usecases/wallets/wallets.dart
@@ -71,16 +71,22 @@ class Wallets {
   bool _recentActivated = false;
 
   /// public-facing stream of combined balances, grouped by currency.
-  late final Stream<List<WalletBalance>> combinedBalances =
-      _combinedBalancesSubject.stream.doOnListen(_activateBalances);
+  Stream<List<WalletBalance>> get combinedBalances {
+    _activateBalances();
+    return _combinedBalancesSubject.stream;
+  }
 
   /// public-facing stream of combined pending transactions.
-  late final Stream<List<WalletTransaction>> combinedPendingTransactions =
-      _combinedPendingTransactionsSubject.stream.doOnListen(_activatePending);
+  Stream<List<WalletTransaction>> get combinedPendingTransactions {
+    _activatePending();
+    return _combinedPendingTransactionsSubject.stream;
+  }
 
   /// public-facing stream of combined recent transactions.
-  late final Stream<List<WalletTransaction>> combinedRecentTransactions =
-      _combinedRecentTransactionsSubject.stream.doOnListen(_activateRecent);
+  Stream<List<WalletTransaction>> get combinedRecentTransactions {
+    _activateRecent();
+    return _combinedRecentTransactionsSubject.stream;
+  }
 
   void _activateBalances() {
     if (_balancesActivated) return;


### PR DESCRIPTION
`doOnListen` wraps the broadcast `BehaviorSubject.stream` in a single-subscription stream transformer.
=> it can only be listen to once.

Fix expose the behavior subject stream via a getter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated wallet stream properties to activate on property access rather than on first listener subscription, changing the timing of data fetching for combined balances and transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->