### PR TITLE
fix: blossom media auth type [codex]

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
+++ b/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
@@ -79,14 +79,15 @@ class Blossom {
     final dataSha256 = sha256.convert(data);
 
     final signer = _getSigner(customSigner);
+    final authType = serverMediaOptimisation ? "media" : "upload";
 
     final Nip01Event myAuthorization = Nip01Event(
-      content: "upload",
+      content: authType,
       pubKey: signer.getPublicKey(),
       kind: kBlossom,
       createdAt: now,
       tags: [
-        ["t", "upload"],
+        ["t", authType],
         ["x", dataSha256.toString()],
         ["expiration", "${now + BLOSSOM_AUTH_EXPIRATION.inMilliseconds}"],
       ],
@@ -160,13 +161,14 @@ class Blossom {
     }
 
     // Create authorization event with file hash
+    final authType = serverMediaOptimisation ? "media" : "upload";
     final Nip01Event myAuthorization = Nip01Utils.createEventCalculateId(
-      content: "upload",
+      content: authType,
       pubKey: signer.getPublicKey(),
       kind: kBlossom,
       createdAt: now,
       tags: [
-        ["t", "upload"],
+        ["t", authType],
         ["x", fileHash],
         ["expiration", "${now + BLOSSOM_AUTH_EXPIRATION.inMilliseconds}"],
       ],

--- a/packages/ndk/test/mocks/mock_blossom_server.dart
+++ b/packages/ndk/test/mocks/mock_blossom_server.dart
@@ -94,6 +94,52 @@ class MockBlossomServer {
       );
     });
 
+    // PUT /media - Upload Media Blob
+    router.put('/media', (Request request) async {
+      // Check for authorization header
+      final authHeader = request.headers['authorization'];
+
+      if (authHeader == null) {
+        return Response.forbidden('Missing authorization');
+      }
+
+      try {
+        final authEvent =
+            json.decode(utf8.decode(base64Decode(authHeader.split(' ')[1])));
+        if (!_verifyAuthEvent(authEvent, 'media')) {
+          return Response.forbidden('Invalid authorization event');
+        }
+      } catch (e) {
+        return Response.forbidden('Invalid authorization format');
+      }
+
+      // Read the request body
+      final bytes = await request.read().expand((chunk) => chunk).toList();
+      final data = Uint8List.fromList(bytes);
+
+      final sha256 = _computeSha256(data);
+      final contentType =
+          request.headers['content-type'] ?? 'application/octet-stream';
+
+      _blobs[sha256] = _BlobEntry(
+        data: data,
+        contentType: contentType,
+        uploader: 'test_pubkey',
+        uploadedAt: DateTime.now(),
+      );
+
+      return Response.ok(
+        json.encode({
+          'url': 'http://localhost:$port/$sha256',
+          'sha256': sha256,
+          'size': data.length,
+          'type': contentType,
+          'uploaded': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    });
+
     // GET /list/<pubkey> - List Blobs
     router.get('/list/<pubkey>', (Request request, String pubkey) {
       final authHeader = request.headers['authorization'];

--- a/packages/ndk/test/usecases/files/blossom_test.dart
+++ b/packages/ndk/test/usecases/files/blossom_test.dart
@@ -141,6 +141,20 @@ void main() {
       expect(utf8.decode(getResponse.data), equals('Hello World!'));
     });
 
+    test('Upload media uses media authorization type', () async {
+      final testData = Uint8List.fromList(utf8.encode('Hello, Blossom media!'));
+
+      final uploadResponse = await client.uploadBlob(
+        data: testData,
+        serverUrls: ['http://localhost:${server.port}'],
+        contentType: 'image/png',
+        serverMediaOptimisation: true,
+      );
+
+      expect(uploadResponse.first.success, true);
+      expect(uploadResponse.first.descriptor, isNotNull);
+    });
+
     test('List blobs for user', () async {
       // Upload some test blobs first
       final testData1 = Uint8List.fromList(utf8.encode('Test 1'));
@@ -685,6 +699,26 @@ void main() {
       );
 
       expect(utf8.decode(getResponse.data), equals(testContent));
+    });
+
+    test('uploadBlobFromFile media uses media authorization type', () async {
+      final testFile = File('${tempDir.path}/test_media_upload.png');
+      final testContent = 'Hello from media file upload test!';
+      await testFile.writeAsString(testContent);
+
+      final uploadResults = <BlobUploadResult>[];
+      await for (final progress in client.uploadBlobFromFile(
+        filePath: testFile.path,
+        serverUrls: ['http://localhost:$primaryServerPort'],
+        contentType: 'image/png',
+        serverMediaOptimisation: true,
+      )) {
+        uploadResults.addAll(progress.completedUploads);
+      }
+
+      expect(uploadResults.any((result) => result.success), true);
+      expect(uploadResults.firstWhere((result) => result.success).descriptor,
+          isNotNull);
     });
 
     test('uploadBlobFromFile emits phase-aware BlobUploadProgress stream',


### PR DESCRIPTION
## Summary
- use `media` BUD-11 auth type when `serverMediaOptimisation` uploads to `/media`
- keep regular blob uploads on the existing `upload` auth type
- add mock `/media` coverage for byte and file uploads

## Why
Media uploads were still signing Blossom authorization events with `t=upload`, so servers that require auth for `/media` rejected optimized uploads.

## Validation
- `dart test test/usecases/files/blossom_test.dart`
- `dart analyze lib/domain_layer/usecases/files/blossom.dart test/mocks/mock_blossom_server.dart test/usecases/files/blossom_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optimized media uploads with server-side processing. When enabled, uploads benefit from improved resource handling and more efficient processing.

* **Tests**
  * Added integration tests to validate media upload functionality with optimization enabled, covering multiple upload methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->