### PR TITLE
[codex] add configurable signer and NIP-44 cryptography

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/cryptography/default_nip44_cryptography.dart
+++ b/packages/ndk/lib/data_layer/repositories/cryptography/default_nip44_cryptography.dart
@@ -1,0 +1,24 @@
+import '../../../domain_layer/repositories/nip44_cryptography.dart';
+import '../../../shared/nips/nip44/nip44.dart';
+
+class DefaultNip44Cryptography implements Nip44Cryptography {
+  const DefaultNip44Cryptography();
+
+  @override
+  Future<String> encrypt({
+    required String plaintext,
+    required String privateKey,
+    required String publicKey,
+  }) {
+    return Nip44.encryptMessage(plaintext, privateKey, publicKey);
+  }
+
+  @override
+  Future<String> decrypt({
+    required String ciphertext,
+    required String privateKey,
+    required String publicKey,
+  }) {
+    return Nip44.decryptMessage(ciphertext, privateKey, publicKey);
+  }
+}

--- a/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
@@ -6,7 +6,8 @@ import '../../../shared/nips/nip01/helpers.dart';
 import '../../../shared/nips/nip04/nip04.dart';
 import '../../../shared/nips/nip01/bip340.dart';
 import '../../../domain_layer/repositories/event_signer.dart';
-import '../../../shared/nips/nip44/nip44.dart';
+import '../../../domain_layer/repositories/nip44_cryptography.dart';
+import '../cryptography/default_nip44_cryptography.dart';
 
 /// Pure Dart Event Signer
 class Bip340EventSigner implements EventSigner {
@@ -16,11 +17,15 @@ class Bip340EventSigner implements EventSigner {
   /// hex public key
   String publicKey;
 
+  final Nip44Cryptography _nip44Cryptography;
+
   /// Get a new event signer with the given keys
   Bip340EventSigner({
     required this.privateKey,
     required this.publicKey,
-  });
+    Nip44Cryptography? nip44Cryptography,
+  }) : _nip44Cryptography =
+            nip44Cryptography ?? const DefaultNip44Cryptography();
 
   @override
   Future<Nip01Event> sign(Nip01Event event) async {
@@ -55,10 +60,10 @@ class Bip340EventSigner implements EventSigner {
     required String plaintext,
     required String recipientPubKey,
   }) {
-    return Nip44.encryptMessage(
-      plaintext,
-      privateKey!,
-      recipientPubKey,
+    return _nip44Cryptography.encrypt(
+      plaintext: plaintext,
+      privateKey: privateKey!,
+      publicKey: recipientPubKey,
     );
   }
 
@@ -67,10 +72,10 @@ class Bip340EventSigner implements EventSigner {
     required String ciphertext,
     required String senderPubKey,
   }) {
-    return Nip44.decryptMessage(
-      ciphertext,
-      privateKey!,
-      senderPubKey,
+    return _nip44Cryptography.decrypt(
+      ciphertext: ciphertext,
+      privateKey: privateKey!,
+      publicKey: senderPubKey,
     );
   }
 

--- a/packages/ndk/lib/data_layer/repositories/signers/default_event_signer_factory.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/default_event_signer_factory.dart
@@ -1,0 +1,12 @@
+import '../../../domain_layer/repositories/event_signer.dart';
+import 'bip340_event_signer.dart';
+
+EventSigner defaultEventSignerFactory({
+  required String publicKey,
+  String? privateKey,
+}) {
+  return Bip340EventSigner(
+    privateKey: privateKey,
+    publicKey: publicKey,
+  );
+}

--- a/packages/ndk/lib/data_layer/repositories/signers/default_event_signer_factory.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/default_event_signer_factory.dart
@@ -1,4 +1,5 @@
 import '../../../domain_layer/repositories/event_signer.dart';
+import '../../../domain_layer/repositories/nip44_cryptography.dart';
 import 'bip340_event_signer.dart';
 
 EventSigner defaultEventSignerFactory({
@@ -9,4 +10,16 @@ EventSigner defaultEventSignerFactory({
     privateKey: privateKey,
     publicKey: publicKey,
   );
+}
+
+EventSignerFactory buildDefaultEventSignerFactory({
+  required Nip44Cryptography nip44Cryptography,
+}) {
+  return ({required String publicKey, String? privateKey}) {
+    return Bip340EventSigner(
+      privateKey: privateKey,
+      publicKey: publicKey,
+      nip44Cryptography: nip44Cryptography,
+    );
+  };
 }

--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -8,6 +8,7 @@ import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../../domain_layer/usecases/bunkers/models/bunker_request.dart';
+import 'default_event_signer_factory.dart';
 
 /// Internal class to track a pending request with its completer and metadata
 class _PendingRequestEntry {
@@ -30,12 +31,13 @@ class Nip46EventSigner implements EventSigner {
 
   String? cachedPublicKey;
 
-  late Bip340EventSigner localEventSigner;
+  late EventSigner localEventSigner;
 
   Nip46EventSigner({
     required this.connection,
     required this.requests,
     required this.broadcast,
+    EventSigner? localEventSigner,
     this.authCallback,
     this.cachedPublicKey,
   }) {
@@ -47,10 +49,11 @@ class Nip46EventSigner implements EventSigner {
 
     final keyPair = KeyPair(privKey, pubKey, privKeyHr, pubKeyHr);
 
-    localEventSigner = Bip340EventSigner(
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey,
-    );
+    this.localEventSigner = localEventSigner ??
+        defaultEventSignerFactory(
+          publicKey: keyPair.publicKey,
+          privateKey: keyPair.privateKey,
+        );
 
     listenRelays();
   }
@@ -61,7 +64,7 @@ class Nip46EventSigner implements EventSigner {
       filter: Filter(
         authors: [connection.remotePubkey],
         kinds: [BunkerRequest.kKind],
-        pTags: [localEventSigner.publicKey],
+        pTags: [localEventSigner.getPublicKey()],
       ),
     );
 
@@ -134,7 +137,7 @@ class Nip46EventSigner implements EventSigner {
 
     final requestEvent = Nip01Event(
       createdAt: 0,
-      pubKey: localEventSigner.publicKey,
+      pubKey: localEventSigner.getPublicKey(),
       kind: BunkerRequest.kKind,
       tags: [
         ["p", connection.remotePubkey],

--- a/packages/ndk/lib/domain_layer/repositories/event_signer.dart
+++ b/packages/ndk/lib/domain_layer/repositories/event_signer.dart
@@ -1,6 +1,11 @@
 import '../entities/nip_01_event.dart';
 import '../entities/pending_signer_request.dart';
 
+typedef EventSignerFactory = EventSigner Function({
+  required String publicKey,
+  String? privateKey,
+});
+
 abstract class EventSigner {
   /// Signs the given event and returns the signed event
   Future<Nip01Event> sign(Nip01Event event);

--- a/packages/ndk/lib/domain_layer/repositories/nip44_cryptography.dart
+++ b/packages/ndk/lib/domain_layer/repositories/nip44_cryptography.dart
@@ -1,0 +1,13 @@
+abstract class Nip44Cryptography {
+  Future<String> encrypt({
+    required String plaintext,
+    required String privateKey,
+    required String publicKey,
+  });
+
+  Future<String> decrypt({
+    required String ciphertext,
+    required String privateKey,
+    required String publicKey,
+  });
+}

--- a/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
+++ b/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:rxdart/rxdart.dart';
 
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../../entities/account.dart';
 import '../../entities/nip_01_event.dart';
 import '../../repositories/event_signer.dart';
@@ -12,6 +12,11 @@ import '../bunkers/models/nostr_connect.dart';
 
 /// A usecase that handles accounts
 class Accounts {
+  final EventSignerFactory _eventSignerFactory;
+
+  Accounts({EventSignerFactory? eventSignerFactory})
+      : _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
+
   /// pubKey -> Account
   final Map<String, Account> accounts = {};
   String? _loggedPubkey;
@@ -31,7 +36,7 @@ class Accounts {
     addAccount(
         pubkey: pubkey,
         type: AccountType.privateKey,
-        signer: Bip340EventSigner(privateKey: privkey, publicKey: pubkey));
+        signer: _eventSignerFactory(publicKey: pubkey, privateKey: privkey));
     _loggedPubkey = pubkey;
     _notifyAuthStateChange();
   }
@@ -49,7 +54,7 @@ class Accounts {
     addAccount(
         pubkey: pubkey,
         type: AccountType.publicKey,
-        signer: Bip340EventSigner(privateKey: null, publicKey: pubkey));
+        signer: _eventSignerFactory(publicKey: pubkey));
     _loggedPubkey = pubkey;
     _notifyAuthStateChange();
   }

--- a/packages/ndk/lib/domain_layer/usecases/bunkers/bunkers.dart
+++ b/packages/ndk/lib/domain_layer/usecases/bunkers/bunkers.dart
@@ -3,13 +3,14 @@ import 'dart:convert';
 
 import 'package:ndk/domain_layer/usecases/bunkers/models/nostr_connect.dart';
 
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../../../data_layer/repositories/signers/nip46_event_signer.dart';
 import 'models/bunker_request.dart';
 import 'models/bunker_connection.dart';
 import '../../../shared/nips/nip01/bip340.dart';
 import '../../entities/filter.dart';
 import '../../entities/nip_01_event.dart';
+import '../../repositories/event_signer.dart';
 import '../broadcast/broadcast.dart';
 import '../requests/requests.dart';
 
@@ -17,14 +18,17 @@ import '../requests/requests.dart';
 class Bunkers {
   final Broadcast _broadcast;
   final Requests _requests;
+  final EventSignerFactory _eventSignerFactory;
 
   static const int kMaxWaitingTimeForConnectionSeconds = 600;
 
   Bunkers({
     required Broadcast broadcast,
     required Requests requests,
+    EventSignerFactory? eventSignerFactory,
   })  : _broadcast = broadcast,
-        _requests = requests;
+        _requests = requests,
+        _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
 
   /// Connects to a bunker using a bunker URL (bunker://)
   /// authCallback is called with the auth URL if the bunker requires authentication
@@ -50,9 +54,9 @@ class Bunkers {
     }
 
     final keyPair = Bip340.generatePrivateKey();
-    final localEventSigner = Bip340EventSigner(
-      privateKey: keyPair.privateKey,
+    final localEventSigner = _eventSignerFactory(
       publicKey: keyPair.publicKey,
+      privateKey: keyPair.privateKey,
     );
 
     final request = BunkerRequest(
@@ -66,7 +70,7 @@ class Bunkers {
     );
 
     final requestEvent = Nip01Event(
-      pubKey: localEventSigner.publicKey,
+      pubKey: localEventSigner.getPublicKey(),
       kind: BunkerRequest.kKind,
       tags: [
         ["p", remotePubkey],
@@ -83,7 +87,7 @@ class Bunkers {
       filter: Filter(
         authors: [remotePubkey],
         kinds: [BunkerRequest.kKind],
-        pTags: [localEventSigner.publicKey],
+        pTags: [localEventSigner.getPublicKey()],
         since: someTimeAgo(),
       ),
     );
@@ -116,7 +120,7 @@ class Bunkers {
 
       if (response["result"] == "ack") {
         result = BunkerConnection(
-          privateKey: localEventSigner.privateKey!,
+          privateKey: keyPair.privateKey!,
           remotePubkey: remotePubkey,
           relays: relays,
         );
@@ -141,16 +145,16 @@ class Bunkers {
     }
 
     final keyPair = nostrConnect.keyPair;
-    final localEventSigner = Bip340EventSigner(
-      privateKey: keyPair.privateKey,
+    final localEventSigner = _eventSignerFactory(
       publicKey: keyPair.publicKey,
+      privateKey: keyPair.privateKey,
     );
 
     final subscription = _requests.subscription(
       explicitRelays: relays,
       filter: Filter(
         kinds: [BunkerRequest.kKind],
-        pTags: [localEventSigner.publicKey],
+        pTags: [localEventSigner.getPublicKey()],
         since: someTimeAgo(),
       ),
     );
@@ -167,7 +171,7 @@ class Bunkers {
 
       if (response["result"] == secret) {
         result = BunkerConnection(
-          privateKey: localEventSigner.privateKey!,
+          privateKey: keyPair.privateKey!,
           remotePubkey: event.pubKey,
           relays: relays,
         );
@@ -189,6 +193,10 @@ class Bunkers {
       connection: connection,
       requests: _requests,
       broadcast: _broadcast,
+      localEventSigner: _eventSignerFactory(
+        publicKey: Bip340.getPublicKey(connection.privateKey),
+        privateKey: connection.privateKey,
+      ),
       authCallback: authCallback,
     );
   }

--- a/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
+++ b/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 
 import '../../../config/blossom_config.dart';
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../../../shared/nips/nip01/bip340.dart';
 import '../../entities/blob_upload_progress.dart';
 import '../../entities/blossom_blobs.dart';
@@ -32,14 +32,17 @@ class Blossom {
   final BlossomUserServerList _userServerList;
   final BlossomRepository _blossomImpl;
   final Accounts _accounts;
+  final EventSignerFactory _eventSignerFactory;
 
   Blossom({
     required BlossomUserServerList blossomUserServerList,
     required BlossomRepository blossomRepository,
     required Accounts accounts,
+    EventSignerFactory? eventSignerFactory,
   })  : _accounts = accounts,
         _userServerList = blossomUserServerList,
-        _blossomImpl = blossomRepository;
+        _blossomImpl = blossomRepository,
+        _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
 
   /// Gets the signer to use for blossom operations
   /// Priority: customSigner > logged in account signer > temporary signer
@@ -52,9 +55,9 @@ class Blossom {
 
     // Create a temporary signer if no account is logged in
     final keyPair = Bip340.generatePrivateKey();
-    return Bip340EventSigner(
-      privateKey: keyPair.privateKey,
+    return _eventSignerFactory(
       publicKey: keyPair.publicKey,
+      privateKey: keyPair.privateKey,
     );
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import '../../../data_layer/models/nip_01_event_model.dart';
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../../entities/nip_01_event.dart';
 import '../../repositories/event_signer.dart';
 import '../accounts/accounts.dart';
@@ -12,8 +12,12 @@ class GiftWrap {
   static const int kGiftWrapEventkind = 1059;
 
   final Accounts accounts;
+  final EventSignerFactory _eventSignerFactory;
 
-  GiftWrap({required this.accounts});
+  GiftWrap({
+    required this.accounts,
+    EventSignerFactory? eventSignerFactory,
+  }) : _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
 
   /// Returns the signer to use for signing operations.
   /// Uses [customSigner] if provided, otherwise falls back to logged-in account's signer.
@@ -47,6 +51,7 @@ class GiftWrap {
     final giftWrap = await wrapEvent(
       recipientPublicKey: recipientPubkey,
       sealEvent: sealedRumor,
+      eventSignerFactory: _eventSignerFactory,
     );
     return giftWrap;
   }
@@ -163,12 +168,13 @@ class GiftWrap {
     required String recipientPublicKey,
     required Nip01Event sealEvent,
     List<List<String>>? additionalTags,
+    EventSignerFactory? eventSignerFactory,
   }) async {
     // Generate a random one-time-use keypair
     final ephemeralKeys = Bip340.generatePrivateKey();
-    final ephemeralSigner = Bip340EventSigner(
-      privateKey: ephemeralKeys.privateKey,
+    final ephemeralSigner = (eventSignerFactory ?? defaultEventSignerFactory)(
       publicKey: ephemeralKeys.publicKey,
+      privateKey: ephemeralKeys.privateKey,
     );
 
     final encryptedSeal = await ephemeralSigner.encryptNip44(
@@ -200,12 +206,7 @@ class GiftWrap {
       pubKey: ephemeralKeys.publicKey,
     );
 
-    // Sign with ephemeral key
-    final signature = Bip340.sign(giftWrapEvent.id, ephemeralKeys.privateKey!);
-
-    final gWEventSigned = giftWrapEvent.copyWith(sig: signature);
-
-    return gWEventSigned;
+    return ephemeralSigner.sign(giftWrapEvent);
   }
 
   /// Unwraps a gift wrap to get the seal event

--- a/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
+++ b/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
@@ -1,6 +1,6 @@
 import 'package:rxdart/rxdart.dart';
 
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../../../shared/nips/nip01/helpers.dart';
 import '../../entities/filter.dart';
 import '../../entities/nip_01_event.dart';
@@ -21,6 +21,7 @@ class Lists {
   final CacheManager _cacheManager;
   final Broadcast _broadcast;
   final Accounts _accounts;
+  final EventSignerFactory _eventSignerFactory;
 
   /// Creates a Lists usecase instance.
   Lists({
@@ -28,10 +29,12 @@ class Lists {
     required CacheManager cacheManager,
     required Broadcast broadcast,
     required Accounts accounts,
+    EventSignerFactory? eventSignerFactory,
   })  : _cacheManager = cacheManager,
         _requests = requests,
         _broadcast = broadcast,
-        _accounts = accounts;
+        _accounts = accounts,
+        _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
 
   EventSigner? get _eventSigner {
     return _accounts.getLoggedAccount()?.signer;
@@ -112,7 +115,7 @@ class Lists {
     bool forceRefresh = false,
     Duration timeout = const Duration(seconds: 5),
   }) async {
-    final signer = Bip340EventSigner(privateKey: null, publicKey: publicKey);
+    final signer = _eventSignerFactory(publicKey: publicKey);
 
     Nip51List? list =
         !forceRefresh ? await _getCachedNip51List(kind, signer) : null;
@@ -383,7 +386,7 @@ class Lists {
       }
       mySigner = _eventSigner!;
     } else {
-      mySigner = Bip340EventSigner(privateKey: null, publicKey: publicKey);
+      mySigner = _eventSignerFactory(publicKey: publicKey);
     }
 
     return _getSets(kind, mySigner, forceRefresh: forceRefresh);
@@ -655,7 +658,7 @@ class Lists {
     required String publicKey,
     bool forceRefresh = false,
   }) async {
-    final mySigner = Bip340EventSigner(privateKey: null, publicKey: publicKey);
+    final mySigner = _eventSignerFactory(publicKey: publicKey);
     return getNip51RelaySets(kind, mySigner, forceRefresh: forceRefresh);
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:ndk/domain_layer/usecases/nwc/requests/get_budget.dart';
 import 'package:ndk/ndk.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import 'package:ndk/shared/nips/nip04/nip04.dart';
 import 'package:ndk/shared/nips/nip44/nip44.dart';
 
@@ -43,13 +44,16 @@ class Nwc {
 
   final Requests _requests;
   final Broadcast _broadcast;
+  final EventSignerFactory _eventSignerFactory;
 
   /// main constructor
   Nwc({
     required Requests requests,
     required Broadcast broadcast,
+    EventSignerFactory? eventSignerFactory,
   })  : _requests = requests,
-        _broadcast = broadcast;
+        _broadcast = broadcast,
+        _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
 
   final Map<String, Completer<NwcResponse>> _inflighRequests = {};
   final Map<String, Timer> _inflighRequestTimers = {};
@@ -87,7 +91,10 @@ class Nwc {
         .future;
     if (infoEvent.isNotEmpty) {
       final event = infoEvent.first;
-      final connection = NwcConnection(parsedUri);
+      final connection = NwcConnection(
+        parsedUri,
+        eventSignerFactory: _eventSignerFactory,
+      );
       connection.useETagForEachRequest = useETagForEachRequest;
       connection.ignoreCapabilitiesCheck = ignoreCapabilitiesCheck;
 
@@ -125,7 +132,12 @@ class Nwc {
       completer.complete(connection);
     } else {
       onError?.call("not found");
-      completer.complete(NwcConnection(parsedUri));
+      completer.complete(
+        NwcConnection(
+          parsedUri,
+          eventSignerFactory: _eventSignerFactory,
+        ),
+      );
     }
     return completer.future;
   }

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bip340/bip340.dart';
 import 'package:ndk/ndk.dart';
+import '../../../data_layer/repositories/signers/default_event_signer_factory.dart';
 import 'nwc_notification.dart';
 
 import 'responses/nwc_response.dart';
@@ -10,6 +11,7 @@ import 'responses/nwc_response.dart';
 class NwcConnection {
   NostrWalletConnectUri uri;
   EventSigner? _signer;
+  final EventSignerFactory _eventSignerFactory;
   GetInfoResponse? info;
   NdkResponse? subscription;
   StreamSubscription<Nip01Event>? _streamSubscription;
@@ -61,11 +63,16 @@ class NwcConnection {
 
   Set<String> permissions = {};
 
-  NwcConnection(this.uri);
+  NwcConnection(
+    this.uri, {
+    EventSignerFactory? eventSignerFactory,
+  }) : _eventSignerFactory = eventSignerFactory ?? defaultEventSignerFactory;
 
   EventSigner get signer {
-    _signer ??= Bip340EventSigner(
-        privateKey: uri.secret, publicKey: getPublicKey(uri.secret));
+    _signer ??= _eventSignerFactory(
+      publicKey: getPublicKey(uri.secret),
+      privateKey: uri.secret,
+    );
     return _signer!;
   }
 

--- a/packages/ndk/lib/ndk.dart
+++ b/packages/ndk/lib/ndk.dart
@@ -57,9 +57,11 @@ export 'domain_layer/entities/account.dart';
 /// signers / verifiers
 export 'domain_layer/repositories/event_verifier.dart';
 export 'domain_layer/repositories/event_signer.dart';
+export 'domain_layer/repositories/nip44_cryptography.dart';
 export 'data_layer/repositories/verifiers/bip340_event_verifier.dart';
 export 'data_layer/repositories/verifiers/rust_event_verifier.dart';
 export 'data_layer/repositories/signers/bip340_event_signer.dart';
+export 'data_layer/repositories/cryptography/default_nip44_cryptography.dart';
 export 'domain_layer/entities/pending_signer_request.dart';
 export 'domain_layer/entities/signer_request_cancelled_exception.dart';
 export 'domain_layer/entities/signer_request_rejected_exception.dart';

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -113,7 +113,9 @@ class Initialization {
     // Configure global WebSocket User-Agent on dart:io platforms
     configureDefaultUserAgent(ndkConfig.userAgent);
 
-    accounts = Accounts();
+    accounts = Accounts(
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
+    );
 
     switch (_ndkConfig.engine) {
       case NdkEngine.RELAY_SETS:
@@ -193,7 +195,11 @@ class Initialization {
     );
 
     // Initialize nwc and cashu before walletsOperationsRepo since they are dependencies
-    nwc = Nwc(requests: requests, broadcast: broadcast);
+    nwc = Nwc(
+      requests: requests,
+      broadcast: broadcast,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
+    );
 
     if (_ndkConfig.walletsRepo == null) {
       // auto detect if the provided cache manager has wallets capabilities.
@@ -219,6 +225,7 @@ class Initialization {
     bunkers = Bunkers(
       broadcast: broadcast,
       requests: requests,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     follows = Follows(
@@ -247,6 +254,7 @@ class Initialization {
       cacheManager: _ndkConfig.cache,
       broadcast: broadcast,
       accounts: accounts,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     relaySets = RelaySets(
@@ -285,6 +293,7 @@ class Initialization {
       blossomRepository: blossomRepository,
       accounts: accounts,
       blossomUserServerList: blossomUserServerList,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     files = Files(blossom: blossom);
@@ -303,7 +312,10 @@ class Initialization {
       requests.fetchedRanges = fetchedRanges;
     }
 
-    giftWrap = GiftWrap(accounts: accounts);
+    giftWrap = GiftWrap(
+      accounts: accounts,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
+    );
 
     connectivity = Connectivy(relayManager);
 

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -8,8 +8,10 @@ import '../domain_layer/entities/event_filter.dart';
 import '../domain_layer/entities/nip_85.dart';
 import '../domain_layer/repositories/cache_manager.dart';
 import '../domain_layer/repositories/event_signer.dart';
+import '../domain_layer/repositories/nip44_cryptography.dart';
 import '../domain_layer/repositories/event_verifier.dart';
 import '../domain_layer/repositories/wallets_repo.dart';
+import '../data_layer/repositories/cryptography/default_nip44_cryptography.dart';
 import '../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../shared/logger/log_level.dart';
 
@@ -23,6 +25,9 @@ class NdkConfig {
 
   /// Factory used when NDK needs to construct a signer internally.
   EventSignerFactory eventSignerFactory;
+
+  /// Cryptography used for local NIP-44 encryption/decryption.
+  Nip44Cryptography nip44Cryptography;
 
   /// The cache manager (DB) used to store and retrieve Nostr data. E.g MemCacheManager()
   CacheManager cache;
@@ -103,7 +108,8 @@ class NdkConfig {
   NdkConfig({
     required this.eventVerifier,
     required this.cache,
-    this.eventSignerFactory = defaultEventSignerFactory,
+    EventSignerFactory? eventSignerFactory,
+    Nip44Cryptography? nip44Cryptography,
     this.walletsRepo,
     this.engine = NdkEngine.RELAY_SETS,
     this.ignoreRelays = const [],
@@ -121,7 +127,13 @@ class NdkConfig {
     this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
     this.defaultTrustedProviders = DEFAULT_NIP85_PROVIDERS,
-  });
+  })  : nip44Cryptography =
+            nip44Cryptography ?? const DefaultNip44Cryptography(),
+        eventSignerFactory = eventSignerFactory ??
+            buildDefaultEventSignerFactory(
+              nip44Cryptography:
+                  nip44Cryptography ?? const DefaultNip44Cryptography(),
+            );
 }
 
 /// Enum representing different engine modes for Nostr network operations.

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -7,8 +7,10 @@ import '../domain_layer/entities/cashu/cashu_user_seedphrase.dart';
 import '../domain_layer/entities/event_filter.dart';
 import '../domain_layer/entities/nip_85.dart';
 import '../domain_layer/repositories/cache_manager.dart';
+import '../domain_layer/repositories/event_signer.dart';
 import '../domain_layer/repositories/event_verifier.dart';
 import '../domain_layer/repositories/wallets_repo.dart';
+import '../data_layer/repositories/signers/default_event_signer_factory.dart';
 import '../shared/logger/log_level.dart';
 
 /// Configuration class for the Nostr Development Kit (NDK)
@@ -18,6 +20,9 @@ import '../shared/logger/log_level.dart';
 class NdkConfig {
   /// The verifier used to validate Nostr events. E.g. RustEventVerifier(), Bip340EventVerifier
   EventVerifier eventVerifier;
+
+  /// Factory used when NDK needs to construct a signer internally.
+  EventSignerFactory eventSignerFactory;
 
   /// The cache manager (DB) used to store and retrieve Nostr data. E.g MemCacheManager()
   CacheManager cache;
@@ -98,6 +103,7 @@ class NdkConfig {
   NdkConfig({
     required this.eventVerifier,
     required this.cache,
+    this.eventSignerFactory = defaultEventSignerFactory,
     this.walletsRepo,
     this.engine = NdkEngine.RELAY_SETS,
     this.ignoreRelays = const [],

--- a/packages/ndk/test/signers/bip340_event_signer_test.dart
+++ b/packages/ndk/test/signers/bip340_event_signer_test.dart
@@ -3,6 +3,39 @@ import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:test/test.dart';
 
+class _RecordingNip44Cryptography implements Nip44Cryptography {
+  String? lastEncryptPlaintext;
+  String? lastEncryptPrivateKey;
+  String? lastEncryptPublicKey;
+  String? lastDecryptCiphertext;
+  String? lastDecryptPrivateKey;
+  String? lastDecryptPublicKey;
+
+  @override
+  Future<String> encrypt({
+    required String plaintext,
+    required String privateKey,
+    required String publicKey,
+  }) async {
+    lastEncryptPlaintext = plaintext;
+    lastEncryptPrivateKey = privateKey;
+    lastEncryptPublicKey = publicKey;
+    return 'enc:$plaintext:$publicKey';
+  }
+
+  @override
+  Future<String> decrypt({
+    required String ciphertext,
+    required String privateKey,
+    required String publicKey,
+  }) async {
+    lastDecryptCiphertext = ciphertext;
+    lastDecryptPrivateKey = privateKey;
+    lastDecryptPublicKey = publicKey;
+    return 'dec:$ciphertext:$publicKey';
+  }
+}
+
 void main() {
   group('Bip340EventSigner', () {
     late Bip340EventSigner signer;
@@ -145,6 +178,35 @@ void main() {
         expect(decrypted, equals(message));
 
         await otherSigner.dispose();
+      });
+
+      test('delegates NIP-44 operations to configured cryptography', () async {
+        final crypto = _RecordingNip44Cryptography();
+        final customSigner = Bip340EventSigner(
+          privateKey: keyPair.privateKey,
+          publicKey: keyPair.publicKey,
+          nip44Cryptography: crypto,
+        );
+
+        final encrypted = await customSigner.encryptNip44(
+          plaintext: 'hello',
+          recipientPubKey: 'recipient-pubkey',
+        );
+        final decrypted = await customSigner.decryptNip44(
+          ciphertext: 'ciphertext',
+          senderPubKey: 'sender-pubkey',
+        );
+
+        expect(encrypted, 'enc:hello:recipient-pubkey');
+        expect(decrypted, 'dec:ciphertext:sender-pubkey');
+        expect(crypto.lastEncryptPlaintext, 'hello');
+        expect(crypto.lastEncryptPrivateKey, keyPair.privateKey);
+        expect(crypto.lastEncryptPublicKey, 'recipient-pubkey');
+        expect(crypto.lastDecryptCiphertext, 'ciphertext');
+        expect(crypto.lastDecryptPrivateKey, keyPair.privateKey);
+        expect(crypto.lastDecryptPublicKey, 'sender-pubkey');
+
+        await customSigner.dispose();
       });
     });
   });

--- a/packages/ndk/test/usecases/accounts_test.dart
+++ b/packages/ndk/test/usecases/accounts_test.dart
@@ -58,6 +58,33 @@ class _RecordingSigner implements EventSigner {
   Future<Nip01Event> sign(Nip01Event event) async => event.copyWith(sig: 'sig');
 }
 
+class _RecordingNip44Cryptography implements Nip44Cryptography {
+  String? lastEncryptPlaintext;
+  String? lastEncryptPrivateKey;
+  String? lastEncryptPublicKey;
+
+  @override
+  Future<String> decrypt({
+    required String ciphertext,
+    required String privateKey,
+    required String publicKey,
+  }) async {
+    return 'dec:$ciphertext:$publicKey';
+  }
+
+  @override
+  Future<String> encrypt({
+    required String plaintext,
+    required String privateKey,
+    required String publicKey,
+  }) async {
+    lastEncryptPlaintext = plaintext;
+    lastEncryptPrivateKey = privateKey;
+    lastEncryptPublicKey = publicKey;
+    return 'enc:$plaintext:$publicKey';
+  }
+}
+
 void main() async {
   group('accounts', () {
     KeyPair key0 = Bip340.generatePrivateKey();
@@ -143,6 +170,37 @@ void main() async {
         key0.publicKey,
       );
       expect(customNdk.accounts.canSign, isTrue);
+    });
+
+    test('loginPrivateKey uses configured nip44Cryptography by default',
+        () async {
+      final crypto = _RecordingNip44Cryptography();
+      final customNdk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [],
+          nip44Cryptography: crypto,
+        ),
+      );
+
+      customNdk.accounts.loginPrivateKey(
+        pubkey: key0.publicKey,
+        privkey: key0.privateKey!,
+      );
+
+      final signer = customNdk.accounts.getLoggedAccount()!.signer;
+      final encrypted = await signer.encryptNip44(
+        plaintext: 'hello',
+        recipientPubKey: key1.publicKey,
+      );
+
+      expect(encrypted, 'enc:hello:${key1.publicKey}');
+      expect(crypto.lastEncryptPlaintext, 'hello');
+      expect(crypto.lastEncryptPrivateKey, key0.privateKey);
+      expect(crypto.lastEncryptPublicKey, key1.publicKey);
+
+      await customNdk.destroy();
     });
 
     test('loginExternalSigner', () {

--- a/packages/ndk/test/usecases/accounts_test.dart
+++ b/packages/ndk/test/usecases/accounts_test.dart
@@ -2,6 +2,61 @@ import 'package:test/test.dart';
 import 'package:ndk/ndk.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _RecordingSigner implements EventSigner {
+  _RecordingSigner({
+    required this.publicKey,
+    required this.privateKey,
+  });
+
+  final String publicKey;
+  final String? privateKey;
+
+  @override
+  bool canSign() => privateKey != null;
+
+  @override
+  bool cancelRequest(String requestId) => false;
+
+  @override
+  Future<String?> decrypt(String msg, String destPubKey, {String? id}) async =>
+      null;
+
+  @override
+  Future<String?> decryptNip44({
+    required String ciphertext,
+    required String senderPubKey,
+  }) async =>
+      null;
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<String?> encrypt(String msg, String destPubKey, {String? id}) async =>
+      null;
+
+  @override
+  Future<String?> encryptNip44({
+    required String plaintext,
+    required String recipientPubKey,
+  }) async =>
+      null;
+
+  @override
+  String getPublicKey() => publicKey;
+
+  @override
+  List<PendingSignerRequest> get pendingRequests => const [];
+
+  @override
+  Stream<List<PendingSignerRequest>> get pendingRequestsStream =>
+      BehaviorSubject<List<PendingSignerRequest>>.seeded(const []).stream;
+
+  @override
+  Future<Nip01Event> sign(Nip01Event event) async => event.copyWith(sig: 'sig');
+}
 
 void main() async {
   group('accounts', () {
@@ -56,6 +111,38 @@ void main() async {
       expect(ndk.accounts.canSign, true);
       ndk.accounts.logout();
       expect(ndk.accounts.isNotLoggedIn, true);
+    });
+
+    test('loginPrivateKey uses configured eventSignerFactory', () {
+      final customNdk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [],
+          eventSignerFactory: ({
+            required String publicKey,
+            String? privateKey,
+          }) {
+            return _RecordingSigner(
+              publicKey: publicKey,
+              privateKey: privateKey,
+            );
+          },
+        ),
+      );
+
+      customNdk.accounts.loginPrivateKey(
+        pubkey: key0.publicKey,
+        privkey: key0.privateKey!,
+      );
+
+      expect(customNdk.accounts.getLoggedAccount()!.signer,
+          isA<_RecordingSigner>());
+      expect(
+        customNdk.accounts.getLoggedAccount()!.signer.getPublicKey(),
+        key0.publicKey,
+      );
+      expect(customNdk.accounts.canSign, isTrue);
     });
 
     test('loginExternalSigner', () {


### PR DESCRIPTION
## What changed

This PR adds two small configuration seams for NDK cryptography:

- `eventSignerFactory` in `NdkConfig`, used whenever NDK needs to construct a signer internally
- `nip44Cryptography` in `NdkConfig`, used by the default local `Bip340EventSigner` for NIP-44 encrypt/decrypt

Together these changes let downstream apps swap in faster or platform-backed cryptography without carrying local patches across bunker, gift-wrap, NWC, Blossom, and other internally-created signer paths.

## Why

NDK previously hardcoded `Bip340EventSigner` construction in several internal flows, and that signer hardcoded the built-in NIP-44 implementation. That made it difficult for downstream apps to reuse an existing optimized signer or NIP-44 backend consistently.

The main impact is that apps can now:

- keep local private-key flows on a custom signer implementation
- keep bunker session-local crypto on the same fast path
- override local NIP-44 encrypt/decrypt independently when they do want to use the default signer type

## Impact

- No behavior change for existing users unless they opt into the new config fields
- Existing defaults continue to use the built-in signer and NIP-44 implementation
- Downstream apps get a single config-level way to inject custom cryptography

## Validation

- `dart test test/usecases/accounts_test.dart test/signers/nip46_event_signer_test.dart test/usecases/gift_wrap/gift_wrap_test.dart`
- `dart test test/signers/bip340_event_signer_test.dart test/usecases/accounts_test.dart`
- `dart analyze` on the touched config/signer files
