### PR TITLE
fix: nip59 seal should be signed

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -126,7 +126,10 @@ class GiftWrap {
       content: encryptedContent,
     );
 
-    return sealEvent;
+    // Sign the seal event (required by NIP-59)
+    final signedSeal = await signer.sign(sealEvent);
+
+    return signedSeal;
   }
 
   /// Unseals a sealed event to retrieve the rumor

--- a/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
+++ b/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
@@ -180,5 +180,36 @@ void main() {
       // Verify the seal uses the custom signer's pubkey
       expect(seal.pubKey, equals(key3.publicKey));
     });
+
+    test('Seal event should be signed (NIP-59 requirement)', () async {
+      // Create a rumor
+      final rumor = await giftWrapService.createRumor(
+        content: 'Test message',
+        kind: 1,
+        tags: [],
+      );
+
+      // Wrap the rumor in a gift wrap
+      final giftWrap = await giftWrapService.toGiftWrap(
+        rumor: rumor,
+        recipientPubkey: key2.publicKey,
+      );
+
+      // Login as recipient to unwrap
+      ndk.accounts
+          .loginPrivateKey(pubkey: key2.publicKey, privkey: key2.privateKey!);
+
+      // Unwrap the gift wrap to get the seal
+      final seal = await giftWrapService.unwrapEvent(wrappedEvent: giftWrap);
+
+      // Verify that the seal event is signed (NIP-59 requirement)
+      // According to NIP-59, the seal event (kind 13) must be signed
+      final isSealSigned = await Bip340EventVerifier().verify(seal);
+      expect(
+        isSealSigned,
+        isTrue,
+        reason: 'NIP-59 requires seal events (kind 13) to be signed',
+      );
+    });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gift wrap sealing now properly produces NIP-59-compliant sealed events with correct signatures.

* **Tests**
  * Added test to verify seal event signatures are properly included and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->