### PR TITLE
fix: parse public tags on private list

### DIFF
--- a/packages/ndk/lib/domain_layer/entities/nip_51_list.dart
+++ b/packages/ndk/lib/domain_layer/entities/nip_51_list.dart
@@ -287,6 +287,11 @@ class Nip51Set extends Nip51List {
       elements: [],
     );
     set.id = event.id;
+
+    // private sets can also have public tags (like title, description, image etc)
+    set.parseTags(event.tags, private: false);
+    set.parseSetTags(event.tags);
+
     if (Helpers.isNotBlank(event.content) &&
         signer != null &&
         signer.canSign()) {
@@ -305,14 +310,9 @@ class Nip51Set extends Nip51List {
               );
         List<dynamic> tags = jsonDecode(json ?? '');
         set.parseTags(tags, private: true);
-        set.parseSetTags(tags);
       } catch (e) {
-        set.name = "<invalid encrypted content>";
         Logger.log.d(() => e);
       }
-    } else {
-      set.parseTags(event.tags, private: false);
-      set.parseSetTags(event.tags);
     }
     return set;
   }

--- a/packages/ndk/test/usecases/lists/lists_test.dart
+++ b/packages/ndk/test/usecases/lists/lists_test.dart
@@ -468,5 +468,60 @@ void main() async {
       expect(parsedSet.elements.first.value, "wss://encrypted-relay.com");
       expect(parsedSet.elements.first.private, true);
     });
+
+    test(
+        'fromEvent preserves metadata (title/description/image) alongside private elements',
+        () async {
+      // Regression test for: when a set has encrypted private elements AND
+      // public metadata tags, parsing with a full signer must retain both.
+      // Previously, parseSetTags was called only on the decrypted content
+      // (which never contains title/description/image), so metadata was silently
+      // dropped for any set that had private content.
+      final original = Nip51Set(
+        pubKey: key1.publicKey,
+        kind: Nip51List.kRelaySet,
+        name: "metadata-set",
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        title: "My Relay Set",
+        description: "A set with both private relays and metadata",
+        image: "https://example.com/image.png",
+        elements: [
+          Nip51ListElement(
+            tag: Nip51List.kRelay,
+            value: "wss://private-relay.com",
+            private: true,
+          ),
+          Nip51ListElement(
+            tag: Nip51List.kRelay,
+            value: "wss://public-relay.com",
+            private: false,
+          ),
+        ],
+      );
+
+      // Serialize: private relay goes into encrypted content, metadata stays
+      // as public tags on the event.
+      final event = await original.toEvent(signer1);
+      final signedEvent = await signer1.sign(event);
+
+      // Deserialize with a full signer (can decrypt).
+      final parsed = await Nip51Set.fromEvent(signedEvent, signer1);
+
+      expect(parsed, isNotNull);
+      // Metadata must survive even though private content was decrypted.
+      expect(parsed!.title, "My Relay Set");
+      expect(parsed.description, "A set with both private relays and metadata");
+      expect(parsed.image, "https://example.com/image.png");
+      // Both private and public elements must be present.
+      expect(parsed.elements.length, 2);
+      expect(
+          parsed.elements
+              .any((e) => e.value == "wss://private-relay.com" && e.private),
+          isTrue);
+      expect(
+          parsed.elements
+              .any((e) => e.value == "wss://public-relay.com" && !e.private),
+          isTrue);
+    });
   });
 }


### PR DESCRIPTION
Private nip51 lists/sets can have public elements like:
`title, description, image` 

Currently we ignore public tags when private `content` is available. This PR fixes this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where public metadata (title, description, image) of lists could be lost when the list contains encrypted private elements. The app now correctly preserves all public list information during parsing.

* **Tests**
  * Added test coverage to verify metadata retention in encrypted list scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->