### PR TITLE
[codex] Preserve NIP-46 signed created_at

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -257,9 +257,14 @@ class Nip46EventSigner implements EventSigner {
       request: request,
       event: event,
     );
-    final signedEvent = jsonDecode(signedEventJson);
 
-    return event.copyWith(id: signedEvent["id"], sig: signedEvent["sig"]);
+    final signedEvent = Nip01EventModel.fromJson(jsonDecode(signedEventJson));
+
+    return event.copyWith(
+      id: signedEvent.id,
+      createdAt: signedEvent.createdAt,
+      sig: signedEvent.sig,
+    );
   }
 
   Future<String> ping() async {

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -21,7 +21,8 @@ class MockRelay {
   Map<KeyPair, Nip01Event>? textNotes;
   Map<String, Nip01Event> _contactLists = {};
   Map<String, Nip01Event> _metadatas = {};
-  Map<String, Nip01Event> _nip85Assertions = {}; // NIP-85 assertions keyed by "author:dTag"
+  Map<String, Nip01Event> _nip85Assertions =
+      {}; // NIP-85 assertions keyed by "author:dTag"
   final Set<Nip01Event> _storedEvents = {}; // Store received events
 
   // Track all connected clients with their subscriptions
@@ -34,6 +35,8 @@ class MockRelay {
   bool sendMalformedEvents;
   String? customWelcomeMessage;
   int? maxEventsPerRequest;
+  int signEventCreatedAtOffsetSeconds;
+  String? signEventContentOverride;
 
   // NIP-46 Remote Signer Support
   static const int kNip46Kind = BunkerRequest.kKind;
@@ -59,6 +62,8 @@ class MockRelay {
     this.sendMalformedEvents = false,
     this.customWelcomeMessage,
     this.maxEventsPerRequest,
+    this.signEventCreatedAtOffsetSeconds = 0,
+    this.signEventContentOverride,
     int? explicitPort,
   }) : _nip65s = nip65s {
     if (explicitPort != null) {
@@ -678,9 +683,13 @@ class MockRelay {
           final Nip01Event eventToSign = Nip01Event(
             pubKey: remoteSignerPublicKey,
             kind: eventData["kind"] ?? 1,
-            tags: List<List<String>>.from(eventData["tags"] ?? []),
-            content: eventData["content"] ?? "",
-            createdAt: eventData["created_at"] ?? eventData["createdAt"] ?? 0,
+            tags: (eventData["tags"] as List<dynamic>? ?? [])
+                .map((tag) => List<String>.from(tag))
+                .toList(),
+            content: signEventContentOverride ?? eventData["content"] ?? "",
+            createdAt:
+                (eventData["created_at"] ?? eventData["createdAt"] ?? 0) +
+                    signEventCreatedAtOffsetSeconds,
           );
 
           final Nip01Event signedEvent = Nip01Utils.signWithPrivateKey(

--- a/packages/ndk/test/signers/nip46_event_signer_test.dart
+++ b/packages/ndk/test/signers/nip46_event_signer_test.dart
@@ -67,6 +67,54 @@ void main() {
 
       expect(signedEvent.id, isNotNull);
       expect(signedEvent.sig, isNotNull);
+      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
+    });
+
+    test('sign should preserve created_at returned by remote signer', () async {
+      mockRelay.signEventCreatedAtOffsetSeconds = 11;
+
+      final event = Nip01Event(
+        pubKey: MockRelay.remoteSignerPublicKey,
+        kind: 1,
+        tags: [],
+        content: 'Hello after bunker delay',
+        createdAt: 1234567890,
+      );
+
+      final signedEvent = await signer.sign(event);
+
+      expect(signedEvent.createdAt, equals(event.createdAt + 11));
+      expect(signedEvent.id, isNot(equals(event.id)));
+      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
+      expect(
+        await Bip340EventVerifier(useIsolate: false).verify(signedEvent),
+        isTrue,
+      );
+    });
+
+    test('sign should keep the requested event body from local event',
+        () async {
+      mockRelay.signEventCreatedAtOffsetSeconds = 11;
+      mockRelay.signEventContentOverride = 'mutated by remote signer';
+
+      final event = Nip01Event(
+        pubKey: MockRelay.remoteSignerPublicKey,
+        kind: 1,
+        tags: [
+          ['t', 'test']
+        ],
+        content: 'requested content',
+        createdAt: 1234567890,
+      );
+
+      final signedEvent = await signer.sign(event);
+
+      expect(signedEvent.pubKey, equals(event.pubKey));
+      expect(signedEvent.kind, equals(event.kind));
+      expect(signedEvent.tags, equals(event.tags));
+      expect(signedEvent.content, equals(event.content));
+      expect(signedEvent.createdAt, equals(event.createdAt + 11));
+      expect(Nip01Utils.isIdValid(signedEvent), isFalse);
     });
 
     test('getPublicKey should throw when not cached', () {


### PR DESCRIPTION
## What changed

- Copy `created_at` from the NIP-46 `sign_event` response in addition to `id` and `sig`.
- Keep the original local event body (`kind`, `content`, `tags`, and `pubkey`) as the returned event body.
- Add regression coverage for a remote signer that returns a later `created_at`, plus a test proving remote content changes are not accepted as the returned body.

## Why

NIP-46 `sign_event` returns a complete signed event. Some bunkers can normalize or overwrite `created_at` while signing, especially when a request is delayed. The returned `id` and signature are then valid for the event using that returned timestamp.

Previously NDK copied only `id` and `sig` onto the original local event. If the bunker returned a newer `created_at`, the resulting event body no longer matched the signed hash and relays rejected it as an invalid id/signature.

This patch copies only the timestamp needed to preserve the signed hash while keeping the event content/tags/kind requested by the app as the authoritative returned body.

## Validation

- `dart test test/signers/nip46_event_signer_test.dart`
- `dart analyze` exits 0, with existing info-level lints in examples/tests.
