### PR TITLE
feat: add writeUrls getter to UserRelayList

### DIFF
--- a/packages/ndk/lib/domain_layer/entities/user_relay_list.dart
+++ b/packages/ndk/lib/domain_layer/entities/user_relay_list.dart
@@ -23,6 +23,10 @@ class UserRelayList {
       .where((entry) => entry.value.isRead)
       .map((entry) => entry.key);
 
+  Iterable<String> get writeUrls => relays.entries
+      .where((entry) => entry.value.isWrite)
+      .map((entry) => entry.key);
+
   static UserRelayList fromNip65(Nip65 nip65) {
     return UserRelayList(
         pubKey: nip65.pubKey,

--- a/packages/ndk/lib/shared/nips/nip65/relay_ranking.dart
+++ b/packages/ndk/lib/shared/nips/nip65/relay_ranking.dart
@@ -21,8 +21,7 @@ RelayRankingResult rankRelays({
     if (direction.isRead) {
       relevantUrls = userRelay.readUrls;
     } else {
-      relevantUrls = userRelay.urls
-          .where((url) => userRelay.relays[url]?.isWrite ?? false);
+      relevantUrls = userRelay.writeUrls;
     }
 
     for (final relayUrl in relevantUrls) {

--- a/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
+++ b/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
@@ -60,6 +60,27 @@ void main() async {
       expect(cache0, isNot(equals(cache1)));
     });
 
+    test('readUrls and writeUrls', () {
+      final event = Nip01Event(
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        pubKey: key0.publicKey,
+        kind: Nip65.kKind,
+        content: "",
+        tags: [
+          ['r', 'wss://relay.read', 'read'],
+          ['r', 'wss://relay.write', 'write'],
+          ['r', 'wss://relay.readwrite'],
+        ],
+      );
+      final nip65 = Nip65.fromEvent(event);
+      final userRelayList = UserRelayList.fromNip65(nip65);
+
+      expect(userRelayList.readUrls.toList(),
+          ['wss://relay.read', 'wss://relay.readwrite']);
+      expect(userRelayList.writeUrls.toList(),
+          ['wss://relay.write', 'wss://relay.readwrite']);
+    });
+
     test('getSingleUserRelayList - cache', () async {
       final rcv =
           await ndk.userRelayLists.getSingleUserRelayList(key0.publicKey);


### PR DESCRIPTION
- Add `writeUrls` getter on `UserRelayList` (symmetric to existing `readUrls`)
- Refactor `relay_ranking.dart` to use the new getter instead of manual filtering
- Add unit test covering both `readUrls` and `writeUrls`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Relay selection and ranking now more efficiently identifies write-capable relays in user relay lists.
  * Enhanced relay coverage tracking for improved relay selection performance.

* **Tests**
  * Added comprehensive test coverage for read and write relay URL identification from user relay lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->