### PR TITLE
fix: preserve NIP-46 signed fields

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -257,9 +257,14 @@ class Nip46EventSigner implements EventSigner {
       request: request,
       event: event,
     );
-    final signedEvent = jsonDecode(signedEventJson);
 
-    return event.copyWith(id: signedEvent["id"], sig: signedEvent["sig"]);
+    final signedEvent = Nip01EventModel.fromJson(jsonDecode(signedEventJson));
+
+    return event.copyWith(
+      id: signedEvent.id,
+      createdAt: signedEvent.createdAt,
+      sig: signedEvent.sig,
+    );
   }
 
   Future<String> ping() async {

--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -260,11 +260,7 @@ class Nip46EventSigner implements EventSigner {
 
     final signedEvent = Nip01EventModel.fromJson(jsonDecode(signedEventJson));
 
-    return event.copyWith(
-      id: signedEvent.id,
-      createdAt: signedEvent.createdAt,
-      sig: signedEvent.sig,
-    );
+    return signedEvent;
   }
 
   Future<String> ping() async {

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -21,7 +21,8 @@ class MockRelay {
   Map<KeyPair, Nip01Event>? textNotes;
   Map<String, Nip01Event> _contactLists = {};
   Map<String, Nip01Event> _metadatas = {};
-  Map<String, Nip01Event> _nip85Assertions = {}; // NIP-85 assertions keyed by "author:dTag"
+  Map<String, Nip01Event> _nip85Assertions =
+      {}; // NIP-85 assertions keyed by "author:dTag"
   final Set<Nip01Event> _storedEvents = {}; // Store received events
 
   // Track all connected clients with their subscriptions
@@ -34,6 +35,8 @@ class MockRelay {
   bool sendMalformedEvents;
   String? customWelcomeMessage;
   int? maxEventsPerRequest;
+  int signEventCreatedAtOffsetSeconds;
+  String? signEventContentOverride;
 
   // NIP-46 Remote Signer Support
   static const int kNip46Kind = BunkerRequest.kKind;
@@ -59,6 +62,8 @@ class MockRelay {
     this.sendMalformedEvents = false,
     this.customWelcomeMessage,
     this.maxEventsPerRequest,
+    this.signEventCreatedAtOffsetSeconds = 0,
+    this.signEventContentOverride,
     int? explicitPort,
   }) : _nip65s = nip65s {
     if (explicitPort != null) {
@@ -678,9 +683,13 @@ class MockRelay {
           final Nip01Event eventToSign = Nip01Event(
             pubKey: remoteSignerPublicKey,
             kind: eventData["kind"] ?? 1,
-            tags: List<List<String>>.from(eventData["tags"] ?? []),
-            content: eventData["content"] ?? "",
-            createdAt: eventData["created_at"] ?? eventData["createdAt"] ?? 0,
+            tags: (eventData["tags"] as List<dynamic>? ?? [])
+                .map((tag) => List<String>.from(tag))
+                .toList(),
+            content: signEventContentOverride ?? eventData["content"] ?? "",
+            createdAt:
+                (eventData["created_at"] ?? eventData["createdAt"] ?? 0) +
+                    signEventCreatedAtOffsetSeconds,
           );
 
           final Nip01Event signedEvent = Nip01Utils.signWithPrivateKey(

--- a/packages/ndk/test/signers/nip46_event_signer_test.dart
+++ b/packages/ndk/test/signers/nip46_event_signer_test.dart
@@ -67,33 +67,9 @@ void main() {
 
       expect(signedEvent.id, isNotNull);
       expect(signedEvent.sig, isNotNull);
-      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
     });
 
-    test('sign should preserve created_at returned by remote signer', () async {
-      mockRelay.signEventCreatedAtOffsetSeconds = 11;
-
-      final event = Nip01Event(
-        pubKey: MockRelay.remoteSignerPublicKey,
-        kind: 1,
-        tags: [],
-        content: 'Hello after bunker delay',
-        createdAt: 1234567890,
-      );
-
-      final signedEvent = await signer.sign(event);
-
-      expect(signedEvent.createdAt, equals(event.createdAt + 11));
-      expect(signedEvent.id, isNot(equals(event.id)));
-      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
-      expect(
-        await Bip340EventVerifier(useIsolate: false).verify(signedEvent),
-        isTrue,
-      );
-    });
-
-    test('sign should keep the requested event body from local event',
-        () async {
+    test('sign should use event body returned by remote signer', () async {
       mockRelay.signEventCreatedAtOffsetSeconds = 11;
       mockRelay.signEventContentOverride = 'mutated by remote signer';
 
@@ -109,12 +85,14 @@ void main() {
 
       final signedEvent = await signer.sign(event);
 
-      expect(signedEvent.pubKey, equals(event.pubKey));
-      expect(signedEvent.kind, equals(event.kind));
-      expect(signedEvent.tags, equals(event.tags));
-      expect(signedEvent.content, equals(event.content));
+      // Remote signer is allowed to modify the event before signing.
+      expect(signedEvent.content, equals('mutated by remote signer'));
       expect(signedEvent.createdAt, equals(event.createdAt + 11));
-      expect(Nip01Utils.isIdValid(signedEvent), isFalse);
+      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
+      expect(
+        await Bip340EventVerifier(useIsolate: false).verify(signedEvent),
+        isTrue,
+      );
     });
 
     test('getPublicKey should throw when not cached', () {

--- a/packages/ndk/test/signers/nip46_event_signer_test.dart
+++ b/packages/ndk/test/signers/nip46_event_signer_test.dart
@@ -67,6 +67,54 @@ void main() {
 
       expect(signedEvent.id, isNotNull);
       expect(signedEvent.sig, isNotNull);
+      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
+    });
+
+    test('sign should preserve created_at returned by remote signer', () async {
+      mockRelay.signEventCreatedAtOffsetSeconds = 11;
+
+      final event = Nip01Event(
+        pubKey: MockRelay.remoteSignerPublicKey,
+        kind: 1,
+        tags: [],
+        content: 'Hello after bunker delay',
+        createdAt: 1234567890,
+      );
+
+      final signedEvent = await signer.sign(event);
+
+      expect(signedEvent.createdAt, equals(event.createdAt + 11));
+      expect(signedEvent.id, isNot(equals(event.id)));
+      expect(Nip01Utils.isIdValid(signedEvent), isTrue);
+      expect(
+        await Bip340EventVerifier(useIsolate: false).verify(signedEvent),
+        isTrue,
+      );
+    });
+
+    test('sign should keep the requested event body from local event',
+        () async {
+      mockRelay.signEventCreatedAtOffsetSeconds = 11;
+      mockRelay.signEventContentOverride = 'mutated by remote signer';
+
+      final event = Nip01Event(
+        pubKey: MockRelay.remoteSignerPublicKey,
+        kind: 1,
+        tags: [
+          ['t', 'test']
+        ],
+        content: 'requested content',
+        createdAt: 1234567890,
+      );
+
+      final signedEvent = await signer.sign(event);
+
+      expect(signedEvent.pubKey, equals(event.pubKey));
+      expect(signedEvent.kind, equals(event.kind));
+      expect(signedEvent.tags, equals(event.tags));
+      expect(signedEvent.content, equals(event.content));
+      expect(signedEvent.createdAt, equals(event.createdAt + 11));
+      expect(Nip01Utils.isIdValid(signedEvent), isFalse);
     });
 
     test('getPublicKey should throw when not cached', () {


### PR DESCRIPTION
From https://github.com/relaystr/ndk/pull/598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how signed events from remote signers are processed.

* **Tests**
  * Enhanced testing capabilities for remote signer scenarios.
  * Added validation for remote signer event modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->