### PR TITLE
feat: event signer factory

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
@@ -9,11 +9,44 @@ import '../../../domain_layer/repositories/event_signer.dart';
 import '../../../shared/nips/nip44/nip44.dart';
 
 /// Default factory for creating Bip340EventSigner instances
-EventSigner bip340EventSignerFactory({
-  String? privateKey,
-  required String publicKey,
-}) =>
-    Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+class Bip340EventSignerFactory implements LocalEventSignerFactory {
+  const Bip340EventSignerFactory();
+  @override
+  EventSigner create({
+    String? privateKey,
+    String? publicKey,
+  }) {
+    final derivedPublicKey =
+        publicKey ?? (privateKey != null ? derivePublicKey(privateKey) : null);
+
+    if (derivedPublicKey == null) {
+      throw Exception('Either publicKey or privateKey must be provided');
+    }
+
+    return Bip340EventSigner(
+      privateKey: privateKey,
+      publicKey: derivedPublicKey,
+    );
+  }
+
+  @override
+  String derivePublicKey(String privateKey) {
+    return Bip340.getPublicKey(privateKey);
+  }
+
+  @override
+  (String, String) generateKeyPair() {
+    final keyPair = Bip340.generatePrivateKey();
+
+    return (keyPair.privateKey!, keyPair.publicKey);
+  }
+
+  @override
+  EventSigner createWithNewKeyPair() {
+    final (privateKey, publicKey) = generateKeyPair();
+    return create(privateKey: privateKey, publicKey: publicKey);
+  }
+}
 
 /// Pure Dart Event Signer
 class Bip340EventSigner implements EventSigner {

--- a/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
@@ -8,6 +8,13 @@ import '../../../shared/nips/nip01/bip340.dart';
 import '../../../domain_layer/repositories/event_signer.dart';
 import '../../../shared/nips/nip44/nip44.dart';
 
+/// Default factory for creating Bip340EventSigner instances
+EventSigner bip340EventSignerFactory({
+  String? privateKey,
+  required String publicKey,
+}) =>
+    Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+
 /// Pure Dart Event Signer
 class Bip340EventSigner implements EventSigner {
   /// hex private key

--- a/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/bip340_event_signer.dart
@@ -20,7 +20,7 @@ class Bip340EventSignerFactory implements LocalEventSignerFactory {
         publicKey ?? (privateKey != null ? derivePublicKey(privateKey) : null);
 
     if (derivedPublicKey == null) {
-      throw Exception('Either publicKey or privateKey must be provided');
+      throw ArgumentError('Either publicKey or privateKey must be provided');
     }
 
     return Bip340EventSigner(

--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -31,7 +31,7 @@ class Nip46EventSigner implements EventSigner {
   String? cachedPublicKey;
 
   late EventSigner localEventSigner;
-  final EventSignerFactory eventSignerFactory;
+  final LocalEventSignerFactory eventSignerFactory;
 
   Nip46EventSigner({
     required this.connection,
@@ -49,8 +49,8 @@ class Nip46EventSigner implements EventSigner {
 
     final keyPair = KeyPair(privKey, pubKey, privKeyHr, pubKeyHr);
 
-    localEventSigner = eventSignerFactory(
-      privateKey: keyPair.privateKey,
+    localEventSigner = eventSignerFactory.create(
+      privateKey: keyPair.privateKey!,
       publicKey: keyPair.publicKey,
     );
 

--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -30,7 +30,8 @@ class Nip46EventSigner implements EventSigner {
 
   String? cachedPublicKey;
 
-  late Bip340EventSigner localEventSigner;
+  late EventSigner localEventSigner;
+  final EventSignerFactory eventSignerFactory;
 
   Nip46EventSigner({
     required this.connection,
@@ -38,6 +39,7 @@ class Nip46EventSigner implements EventSigner {
     required this.broadcast,
     this.authCallback,
     this.cachedPublicKey,
+    required this.eventSignerFactory,
   }) {
     final privKey = connection.privateKey;
     final pubKey = Bip340.getPublicKey(privKey);
@@ -47,7 +49,7 @@ class Nip46EventSigner implements EventSigner {
 
     final keyPair = KeyPair(privKey, pubKey, privKeyHr, pubKeyHr);
 
-    localEventSigner = Bip340EventSigner(
+    localEventSigner = eventSignerFactory(
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
     );
@@ -61,7 +63,7 @@ class Nip46EventSigner implements EventSigner {
       filter: Filter(
         authors: [connection.remotePubkey],
         kinds: [BunkerRequest.kKind],
-        pTags: [localEventSigner.publicKey],
+        pTags: [localEventSigner.getPublicKey()],
       ),
     );
 
@@ -134,7 +136,7 @@ class Nip46EventSigner implements EventSigner {
 
     final requestEvent = Nip01Event(
       createdAt: 0,
-      pubKey: localEventSigner.publicKey,
+      pubKey: localEventSigner.getPublicKey(),
       kind: BunkerRequest.kKind,
       tags: [
         ["p", connection.remotePubkey],

--- a/packages/ndk/lib/domain_layer/repositories/event_signer.dart
+++ b/packages/ndk/lib/domain_layer/repositories/event_signer.dart
@@ -2,7 +2,7 @@ import '../entities/nip_01_event.dart';
 import '../entities/pending_signer_request.dart';
 
 /// Factory function for creating EventSigner instances
-///! If pubklicKey is not provided, it must be derived from the privateKey!
+///! If publicKey is not provided, it must be derived from the privateKey!
 abstract class LocalEventSignerFactory {
   /// Creates an EventSigner instance.
   ///

--- a/packages/ndk/lib/domain_layer/repositories/event_signer.dart
+++ b/packages/ndk/lib/domain_layer/repositories/event_signer.dart
@@ -1,6 +1,12 @@
 import '../entities/nip_01_event.dart';
 import '../entities/pending_signer_request.dart';
 
+/// Factory function type for creating EventSigner instances
+typedef EventSignerFactory = EventSigner Function({
+  String? privateKey,
+  required String publicKey,
+});
+
 abstract class EventSigner {
   /// Signs the given event and returns the signed event
   Future<Nip01Event> sign(Nip01Event event);

--- a/packages/ndk/lib/domain_layer/repositories/event_signer.dart
+++ b/packages/ndk/lib/domain_layer/repositories/event_signer.dart
@@ -1,8 +1,10 @@
 import '../entities/nip_01_event.dart';
 import '../entities/pending_signer_request.dart';
 
-/// Factory function for creating EventSigner instances
-///! If publicKey is not provided, it must be derived from the privateKey!
+/// Factory for creating [EventSigner] instances.
+///
+/// If [LocalEventSignerFactory.create] is called without a `publicKey`,
+/// implementations must derive it from the `privateKey`.
 abstract class LocalEventSignerFactory {
   /// Creates an EventSigner instance.
   ///

--- a/packages/ndk/lib/domain_layer/repositories/event_signer.dart
+++ b/packages/ndk/lib/domain_layer/repositories/event_signer.dart
@@ -1,11 +1,32 @@
 import '../entities/nip_01_event.dart';
 import '../entities/pending_signer_request.dart';
 
-/// Factory function type for creating EventSigner instances
-typedef EventSignerFactory = EventSigner Function({
-  String? privateKey,
-  required String publicKey,
-});
+/// Factory function for creating EventSigner instances
+///! If pubklicKey is not provided, it must be derived from the privateKey!
+abstract class LocalEventSignerFactory {
+  /// Creates an EventSigner instance.
+  ///
+  /// If [publicKey] is null, implementations MUST derive it from [privateKey].
+  /// At least one of [privateKey] or [publicKey] must be provided!
+  EventSigner create({
+    String? privateKey,
+    String? publicKey,
+  });
+
+  /// Derives a public key from a private key.
+  /// Implementations MUST provide the derivation logic.
+  String derivePublicKey(String privateKey);
+
+  /// Generates a new keypair.
+  /// Returns a record with (privateKey, publicKey).
+  (String privateKey, String publicKey) generateKeyPair();
+
+  /// Generates a new EventSigner with a fresh keypair.
+  EventSigner createWithNewKeyPair() {
+    final (privateKey, publicKey) = generateKeyPair();
+    return create(privateKey: privateKey, publicKey: publicKey);
+  }
+}
 
 abstract class EventSigner {
   /// Signs the given event and returns the signed event

--- a/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
+++ b/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
@@ -12,7 +12,7 @@ import '../bunkers/models/nostr_connect.dart';
 /// A usecase that handles accounts
 class Accounts {
   /// Factory for creating EventSigner instances
-  final EventSignerFactory eventSignerFactory;
+  final LocalEventSignerFactory eventSignerFactory;
 
   /// pubKey -> Account
   final Map<String, Account> accounts = {};
@@ -36,7 +36,8 @@ class Accounts {
     addAccount(
         pubkey: pubkey,
         type: AccountType.privateKey,
-        signer: eventSignerFactory(privateKey: privkey, publicKey: pubkey));
+        signer:
+            eventSignerFactory.create(privateKey: privkey, publicKey: pubkey));
     _loggedPubkey = pubkey;
     _notifyAuthStateChange();
   }
@@ -54,7 +55,7 @@ class Accounts {
     addAccount(
         pubkey: pubkey,
         type: AccountType.publicKey,
-        signer: eventSignerFactory(privateKey: null, publicKey: pubkey));
+        signer: eventSignerFactory.create(privateKey: null, publicKey: pubkey));
     _loggedPubkey = pubkey;
     _notifyAuthStateChange();
   }

--- a/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
+++ b/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:rxdart/rxdart.dart';
 
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
 import '../../entities/account.dart';
 import '../../entities/nip_01_event.dart';
 import '../../repositories/event_signer.dart';
@@ -12,12 +11,18 @@ import '../bunkers/models/nostr_connect.dart';
 
 /// A usecase that handles accounts
 class Accounts {
+  /// Factory for creating EventSigner instances
+  final EventSignerFactory eventSignerFactory;
+
   /// pubKey -> Account
   final Map<String, Account> accounts = {};
   String? _loggedPubkey;
 
   /// Stream controller for authentication state changes
   final _stateController = BehaviorSubject<Account?>();
+
+  /// Creates a new Accounts instance with the given event signer factory
+  Accounts(this.eventSignerFactory);
 
   /// Stream of authentication state changes
   /// Emits the current Account when logged in, or null when logged out
@@ -31,7 +36,7 @@ class Accounts {
     addAccount(
         pubkey: pubkey,
         type: AccountType.privateKey,
-        signer: Bip340EventSigner(privateKey: privkey, publicKey: pubkey));
+        signer: eventSignerFactory(privateKey: privkey, publicKey: pubkey));
     _loggedPubkey = pubkey;
     _notifyAuthStateChange();
   }
@@ -49,7 +54,7 @@ class Accounts {
     addAccount(
         pubkey: pubkey,
         type: AccountType.publicKey,
-        signer: Bip340EventSigner(privateKey: null, publicKey: pubkey));
+        signer: eventSignerFactory(privateKey: null, publicKey: pubkey));
     _loggedPubkey = pubkey;
     _notifyAuthStateChange();
   }

--- a/packages/ndk/lib/domain_layer/usecases/bunkers/bunkers.dart
+++ b/packages/ndk/lib/domain_layer/usecases/bunkers/bunkers.dart
@@ -7,7 +7,6 @@ import '../../../data_layer/repositories/signers/nip46_event_signer.dart';
 import '../../../domain_layer/repositories/event_signer.dart';
 import 'models/bunker_request.dart';
 import 'models/bunker_connection.dart';
-import '../../../shared/nips/nip01/bip340.dart';
 import '../../entities/filter.dart';
 import '../../entities/nip_01_event.dart';
 import '../broadcast/broadcast.dart';
@@ -17,14 +16,14 @@ import '../requests/requests.dart';
 class Bunkers {
   final Broadcast _broadcast;
   final Requests _requests;
-  final EventSignerFactory _eventSignerFactory;
+  final LocalEventSignerFactory _eventSignerFactory;
 
   static const int kMaxWaitingTimeForConnectionSeconds = 600;
 
   Bunkers({
     required Broadcast broadcast,
     required Requests requests,
-    required EventSignerFactory eventSignerFactory,
+    required LocalEventSignerFactory eventSignerFactory,
   })  : _broadcast = broadcast,
         _requests = requests,
         _eventSignerFactory = eventSignerFactory;
@@ -52,10 +51,11 @@ class Bunkers {
       throw ArgumentError('Secret parameter is required in bunker URL');
     }
 
-    final keyPair = Bip340.generatePrivateKey();
-    final localEventSigner = _eventSignerFactory(
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey,
+    final keyPair = _eventSignerFactory.generateKeyPair();
+
+    final localEventSigner = _eventSignerFactory.create(
+      privateKey: keyPair.$1,
+      publicKey: keyPair.$2,
     );
 
     final request = BunkerRequest(
@@ -119,7 +119,7 @@ class Bunkers {
 
       if (response["result"] == "ack") {
         result = BunkerConnection(
-          privateKey: keyPair.privateKey!,
+          privateKey: keyPair.$1,
           remotePubkey: remotePubkey,
           relays: relays,
         );
@@ -144,8 +144,8 @@ class Bunkers {
     }
 
     final keyPair = nostrConnect.keyPair;
-    final localEventSigner = _eventSignerFactory(
-      privateKey: keyPair.privateKey,
+    final localEventSigner = _eventSignerFactory.create(
+      privateKey: keyPair.privateKey!,
       publicKey: keyPair.publicKey,
     );
 

--- a/packages/ndk/lib/domain_layer/usecases/bunkers/bunkers.dart
+++ b/packages/ndk/lib/domain_layer/usecases/bunkers/bunkers.dart
@@ -3,8 +3,8 @@ import 'dart:convert';
 
 import 'package:ndk/domain_layer/usecases/bunkers/models/nostr_connect.dart';
 
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
 import '../../../data_layer/repositories/signers/nip46_event_signer.dart';
+import '../../../domain_layer/repositories/event_signer.dart';
 import 'models/bunker_request.dart';
 import 'models/bunker_connection.dart';
 import '../../../shared/nips/nip01/bip340.dart';
@@ -17,14 +17,17 @@ import '../requests/requests.dart';
 class Bunkers {
   final Broadcast _broadcast;
   final Requests _requests;
+  final EventSignerFactory _eventSignerFactory;
 
   static const int kMaxWaitingTimeForConnectionSeconds = 600;
 
   Bunkers({
     required Broadcast broadcast,
     required Requests requests,
+    required EventSignerFactory eventSignerFactory,
   })  : _broadcast = broadcast,
-        _requests = requests;
+        _requests = requests,
+        _eventSignerFactory = eventSignerFactory;
 
   /// Connects to a bunker using a bunker URL (bunker://)
   /// authCallback is called with the auth URL if the bunker requires authentication
@@ -50,7 +53,7 @@ class Bunkers {
     }
 
     final keyPair = Bip340.generatePrivateKey();
-    final localEventSigner = Bip340EventSigner(
+    final localEventSigner = _eventSignerFactory(
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
     );
@@ -66,7 +69,7 @@ class Bunkers {
     );
 
     final requestEvent = Nip01Event(
-      pubKey: localEventSigner.publicKey,
+      pubKey: localEventSigner.getPublicKey(),
       kind: BunkerRequest.kKind,
       tags: [
         ["p", remotePubkey],
@@ -83,7 +86,7 @@ class Bunkers {
       filter: Filter(
         authors: [remotePubkey],
         kinds: [BunkerRequest.kKind],
-        pTags: [localEventSigner.publicKey],
+        pTags: [localEventSigner.getPublicKey()],
         since: someTimeAgo(),
       ),
     );
@@ -116,7 +119,7 @@ class Bunkers {
 
       if (response["result"] == "ack") {
         result = BunkerConnection(
-          privateKey: localEventSigner.privateKey!,
+          privateKey: keyPair.privateKey!,
           remotePubkey: remotePubkey,
           relays: relays,
         );
@@ -141,7 +144,7 @@ class Bunkers {
     }
 
     final keyPair = nostrConnect.keyPair;
-    final localEventSigner = Bip340EventSigner(
+    final localEventSigner = _eventSignerFactory(
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
     );
@@ -150,7 +153,7 @@ class Bunkers {
       explicitRelays: relays,
       filter: Filter(
         kinds: [BunkerRequest.kKind],
-        pTags: [localEventSigner.publicKey],
+        pTags: [localEventSigner.getPublicKey()],
         since: someTimeAgo(),
       ),
     );
@@ -167,7 +170,7 @@ class Bunkers {
 
       if (response["result"] == secret) {
         result = BunkerConnection(
-          privateKey: localEventSigner.privateKey!,
+          privateKey: nostrConnect.keyPair.privateKey!,
           remotePubkey: event.pubKey,
           relays: relays,
         );
@@ -190,6 +193,7 @@ class Bunkers {
       requests: _requests,
       broadcast: _broadcast,
       authCallback: authCallback,
+      eventSignerFactory: _eventSignerFactory,
     );
   }
 }

--- a/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
+++ b/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 
 import '../../../config/blossom_config.dart';
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
 import '../../../shared/nips/nip01/bip340.dart';
 import '../../entities/blob_upload_progress.dart';
 import '../../entities/blossom_blobs.dart';
@@ -32,14 +31,17 @@ class Blossom {
   final BlossomUserServerList _userServerList;
   final BlossomRepository _blossomImpl;
   final Accounts _accounts;
+  final EventSignerFactory _eventSignerFactory;
 
   Blossom({
     required BlossomUserServerList blossomUserServerList,
     required BlossomRepository blossomRepository,
     required Accounts accounts,
+    required EventSignerFactory eventSignerFactory,
   })  : _accounts = accounts,
         _userServerList = blossomUserServerList,
-        _blossomImpl = blossomRepository;
+        _blossomImpl = blossomRepository,
+        _eventSignerFactory = eventSignerFactory;
 
   /// Gets the signer to use for blossom operations
   /// Priority: customSigner > logged in account signer > temporary signer
@@ -52,7 +54,7 @@ class Blossom {
 
     // Create a temporary signer if no account is logged in
     final keyPair = Bip340.generatePrivateKey();
-    return Bip340EventSigner(
+    return _eventSignerFactory(
       privateKey: keyPair.privateKey,
       publicKey: keyPair.publicKey,
     );

--- a/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
+++ b/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
@@ -31,13 +31,13 @@ class Blossom {
   final BlossomUserServerList _userServerList;
   final BlossomRepository _blossomImpl;
   final Accounts _accounts;
-  final EventSignerFactory _eventSignerFactory;
+  final LocalEventSignerFactory _eventSignerFactory;
 
   Blossom({
     required BlossomUserServerList blossomUserServerList,
     required BlossomRepository blossomRepository,
     required Accounts accounts,
-    required EventSignerFactory eventSignerFactory,
+    required LocalEventSignerFactory eventSignerFactory,
   })  : _accounts = accounts,
         _userServerList = blossomUserServerList,
         _blossomImpl = blossomRepository,
@@ -54,8 +54,8 @@ class Blossom {
 
     // Create a temporary signer if no account is logged in
     final keyPair = Bip340.generatePrivateKey();
-    return _eventSignerFactory(
-      privateKey: keyPair.privateKey,
+    return _eventSignerFactory.create(
+      privateKey: keyPair.privateKey!,
       publicKey: keyPair.publicKey,
     );
   }

--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -234,7 +234,6 @@ class GiftWrap {
     required LocalEventSignerFactory eventSignerFactory,
   }) async {
     // Generate a random one-time-use keypair
-    //final ephemeralKeys = Bip340.generatePrivateKey();
     final ephemeralSigner = eventSignerFactory.createWithNewKeyPair();
 
     final encryptedSeal = await ephemeralSigner.encryptNip44(

--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -6,7 +6,6 @@ import '../../entities/nip_01_event.dart';
 import '../../repositories/event_signer.dart';
 import '../../repositories/event_verifier.dart';
 import '../accounts/accounts.dart';
-import '../../../shared/nips/nip01/bip340.dart';
 
 class GiftWrap {
   static const int kSealEventKind = 13;
@@ -14,7 +13,7 @@ class GiftWrap {
 
   final Accounts accounts;
   final EventVerifier eventVerifier;
-  final EventSignerFactory eventSignerFactory;
+  final LocalEventSignerFactory eventSignerFactory;
 
   GiftWrap({
     required this.accounts,
@@ -232,14 +231,11 @@ class GiftWrap {
     required String recipientPublicKey,
     required Nip01Event sealEvent,
     List<List<String>>? additionalTags,
-    required EventSignerFactory eventSignerFactory,
+    required LocalEventSignerFactory eventSignerFactory,
   }) async {
     // Generate a random one-time-use keypair
-    final ephemeralKeys = Bip340.generatePrivateKey();
-    final ephemeralSigner = eventSignerFactory(
-      privateKey: ephemeralKeys.privateKey,
-      publicKey: ephemeralKeys.publicKey,
-    );
+    //final ephemeralKeys = Bip340.generatePrivateKey();
+    final ephemeralSigner = eventSignerFactory.createWithNewKeyPair();
 
     final encryptedSeal = await ephemeralSigner.encryptNip44(
       plaintext: Nip01EventModel.fromEntity(sealEvent).toJsonString(),
@@ -267,7 +263,7 @@ class GiftWrap {
       content: encryptedSeal,
       tags: tags,
       createdAt: now,
-      pubKey: ephemeralKeys.publicKey,
+      pubKey: ephemeralSigner.getPublicKey(),
     );
 
     final gWEventSigned = await ephemeralSigner.sign(giftWrapEvent);

--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -270,10 +270,7 @@ class GiftWrap {
       pubKey: ephemeralKeys.publicKey,
     );
 
-    // Sign with ephemeral key
-    final signature = Bip340.sign(giftWrapEvent.id, ephemeralKeys.privateKey!);
-
-    final gWEventSigned = giftWrapEvent.copyWith(sig: signature);
+    final gWEventSigned = await ephemeralSigner.sign(giftWrapEvent);
 
     return gWEventSigned;
   }

--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import '../../../data_layer/models/nip_01_event_model.dart';
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
 import '../../entities/gift_wrap_unwrap_result.dart';
 import '../../entities/nip_01_event.dart';
 import '../../repositories/event_signer.dart';
@@ -15,8 +14,13 @@ class GiftWrap {
 
   final Accounts accounts;
   final EventVerifier eventVerifier;
+  final EventSignerFactory eventSignerFactory;
 
-  GiftWrap({required this.accounts, required this.eventVerifier});
+  GiftWrap({
+    required this.accounts,
+    required this.eventVerifier,
+    required this.eventSignerFactory,
+  });
 
   /// Returns the signer to use for signing operations.
   /// Uses [customSigner] if provided, otherwise falls back to logged-in account's signer.
@@ -50,6 +54,7 @@ class GiftWrap {
     final giftWrap = await wrapEvent(
       recipientPublicKey: recipientPubkey,
       sealEvent: sealedRumor,
+      eventSignerFactory: eventSignerFactory,
     );
     return giftWrap;
   }
@@ -221,15 +226,17 @@ class GiftWrap {
   /// wraps a sealed msg \
   /// [recipientPublicKey] the reciever of the rumor \
   /// [sealEvent] not wrapped event \
+  /// [eventSignerFactory] factory to create event signers \
   /// [returns] giftWrapEvent
   static Future<Nip01Event> wrapEvent({
     required String recipientPublicKey,
     required Nip01Event sealEvent,
     List<List<String>>? additionalTags,
+    required EventSignerFactory eventSignerFactory,
   }) async {
     // Generate a random one-time-use keypair
     final ephemeralKeys = Bip340.generatePrivateKey();
-    final ephemeralSigner = Bip340EventSigner(
+    final ephemeralSigner = eventSignerFactory(
       privateKey: ephemeralKeys.privateKey,
       publicKey: ephemeralKeys.publicKey,
     );

--- a/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
+++ b/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
@@ -20,7 +20,7 @@ class Lists {
   final CacheManager _cacheManager;
   final Broadcast _broadcast;
   final Accounts _accounts;
-  final EventSignerFactory _eventSignerFactory;
+  final LocalEventSignerFactory _eventSignerFactory;
 
   /// Creates a Lists usecase instance.
   Lists({
@@ -28,7 +28,7 @@ class Lists {
     required CacheManager cacheManager,
     required Broadcast broadcast,
     required Accounts accounts,
-    required EventSignerFactory eventSignerFactory,
+    required LocalEventSignerFactory eventSignerFactory,
   })  : _cacheManager = cacheManager,
         _requests = requests,
         _broadcast = broadcast,
@@ -114,7 +114,8 @@ class Lists {
     bool forceRefresh = false,
     Duration timeout = const Duration(seconds: 5),
   }) async {
-    final signer = _eventSignerFactory(privateKey: null, publicKey: publicKey);
+    final signer =
+        _eventSignerFactory.create(privateKey: null, publicKey: publicKey);
 
     Nip51List? list =
         !forceRefresh ? await _getCachedNip51List(kind, signer) : null;
@@ -385,7 +386,8 @@ class Lists {
       }
       mySigner = _eventSigner!;
     } else {
-      mySigner = _eventSignerFactory(privateKey: null, publicKey: publicKey);
+      mySigner =
+          _eventSignerFactory.create(privateKey: null, publicKey: publicKey);
     }
 
     return _getSets(kind, mySigner, forceRefresh: forceRefresh);
@@ -658,7 +660,7 @@ class Lists {
     bool forceRefresh = false,
   }) async {
     final mySigner =
-        _eventSignerFactory(privateKey: null, publicKey: publicKey);
+        _eventSignerFactory.create(privateKey: null, publicKey: publicKey);
     return getNip51RelaySets(kind, mySigner, forceRefresh: forceRefresh);
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
+++ b/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
@@ -1,6 +1,5 @@
 import 'package:rxdart/rxdart.dart';
 
-import '../../../data_layer/repositories/signers/bip340_event_signer.dart';
 import '../../../shared/nips/nip01/helpers.dart';
 import '../../entities/filter.dart';
 import '../../entities/nip_01_event.dart';
@@ -21,6 +20,7 @@ class Lists {
   final CacheManager _cacheManager;
   final Broadcast _broadcast;
   final Accounts _accounts;
+  final EventSignerFactory _eventSignerFactory;
 
   /// Creates a Lists usecase instance.
   Lists({
@@ -28,10 +28,12 @@ class Lists {
     required CacheManager cacheManager,
     required Broadcast broadcast,
     required Accounts accounts,
+    required EventSignerFactory eventSignerFactory,
   })  : _cacheManager = cacheManager,
         _requests = requests,
         _broadcast = broadcast,
-        _accounts = accounts;
+        _accounts = accounts,
+        _eventSignerFactory = eventSignerFactory;
 
   EventSigner? get _eventSigner {
     return _accounts.getLoggedAccount()?.signer;
@@ -112,7 +114,7 @@ class Lists {
     bool forceRefresh = false,
     Duration timeout = const Duration(seconds: 5),
   }) async {
-    final signer = Bip340EventSigner(privateKey: null, publicKey: publicKey);
+    final signer = _eventSignerFactory(privateKey: null, publicKey: publicKey);
 
     Nip51List? list =
         !forceRefresh ? await _getCachedNip51List(kind, signer) : null;
@@ -383,7 +385,7 @@ class Lists {
       }
       mySigner = _eventSigner!;
     } else {
-      mySigner = Bip340EventSigner(privateKey: null, publicKey: publicKey);
+      mySigner = _eventSignerFactory(privateKey: null, publicKey: publicKey);
     }
 
     return _getSets(kind, mySigner, forceRefresh: forceRefresh);
@@ -655,7 +657,8 @@ class Lists {
     required String publicKey,
     bool forceRefresh = false,
   }) async {
-    final mySigner = Bip340EventSigner(privateKey: null, publicKey: publicKey);
+    final mySigner =
+        _eventSignerFactory(privateKey: null, publicKey: publicKey);
     return getNip51RelaySets(kind, mySigner, forceRefresh: forceRefresh);
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
@@ -43,13 +43,13 @@ class Nwc {
 
   final Requests _requests;
   final Broadcast _broadcast;
-  final EventSignerFactory _eventSignerFactory;
+  final LocalEventSignerFactory _eventSignerFactory;
 
   /// main constructor
   Nwc({
     required Requests requests,
     required Broadcast broadcast,
-    required EventSignerFactory eventSignerFactory,
+    required LocalEventSignerFactory eventSignerFactory,
   })  : _requests = requests,
         _broadcast = broadcast,
         _eventSignerFactory = eventSignerFactory;

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
@@ -43,13 +43,16 @@ class Nwc {
 
   final Requests _requests;
   final Broadcast _broadcast;
+  final EventSignerFactory _eventSignerFactory;
 
   /// main constructor
   Nwc({
     required Requests requests,
     required Broadcast broadcast,
+    required EventSignerFactory eventSignerFactory,
   })  : _requests = requests,
-        _broadcast = broadcast;
+        _broadcast = broadcast,
+        _eventSignerFactory = eventSignerFactory;
 
   final Map<String, Completer<NwcResponse>> _inflighRequests = {};
   final Map<String, Timer> _inflighRequestTimers = {};
@@ -87,7 +90,10 @@ class Nwc {
         .future;
     if (infoEvent.isNotEmpty) {
       final event = infoEvent.first;
-      final connection = NwcConnection(parsedUri);
+      final connection = NwcConnection(
+        parsedUri,
+        eventSignerFactory: _eventSignerFactory,
+      );
       connection.useETagForEachRequest = useETagForEachRequest;
       connection.ignoreCapabilitiesCheck = ignoreCapabilitiesCheck;
 
@@ -125,7 +131,10 @@ class Nwc {
       completer.complete(connection);
     } else {
       onError?.call("not found");
-      completer.complete(NwcConnection(parsedUri));
+      completer.complete(NwcConnection(
+        parsedUri,
+        eventSignerFactory: _eventSignerFactory,
+      ));
     }
     return completer.future;
   }

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:bip340/bip340.dart';
 import 'package:ndk/ndk.dart';
 import 'nwc_notification.dart';
 
@@ -60,13 +59,12 @@ class NwcConnection {
   List<String> supportedEncryptions = ["nip04"];
 
   Set<String> permissions = {};
-  final EventSignerFactory eventSignerFactory;
+  final LocalEventSignerFactory eventSignerFactory;
 
   NwcConnection(this.uri, {required this.eventSignerFactory});
 
   EventSigner get signer {
-    _signer ??= eventSignerFactory(
-        privateKey: uri.secret, publicKey: getPublicKey(uri.secret));
+    _signer ??= eventSignerFactory.create(privateKey: uri.secret);
     return _signer!;
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
@@ -60,11 +60,12 @@ class NwcConnection {
   List<String> supportedEncryptions = ["nip04"];
 
   Set<String> permissions = {};
+  final EventSignerFactory eventSignerFactory;
 
-  NwcConnection(this.uri);
+  NwcConnection(this.uri, {required this.eventSignerFactory});
 
   EventSigner get signer {
-    _signer ??= Bip340EventSigner(
+    _signer ??= eventSignerFactory(
         privateKey: uri.secret, publicKey: getPublicKey(uri.secret));
     return _signer!;
   }

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -193,7 +193,11 @@ class Initialization {
     );
 
     // Initialize nwc and cashu before walletsOperationsRepo since they are dependencies
-    nwc = Nwc(requests: requests, broadcast: broadcast);
+    nwc = Nwc(
+      requests: requests,
+      broadcast: broadcast,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
+    );
 
     if (_ndkConfig.walletsRepo == null) {
       // auto detect if the provided cache manager has wallets capabilities.
@@ -309,6 +313,7 @@ class Initialization {
     giftWrap = GiftWrap(
       accounts: accounts,
       eventVerifier: _ndkConfig.eventVerifier,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     connectivity = Connectivy(relayManager);

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -113,7 +113,7 @@ class Initialization {
     // Configure global WebSocket User-Agent on dart:io platforms
     configureDefaultUserAgent(ndkConfig.userAgent);
 
-    accounts = Accounts();
+    accounts = Accounts(_ndkConfig.eventSignerFactory);
 
     switch (_ndkConfig.engine) {
       case NdkEngine.RELAY_SETS:
@@ -219,6 +219,7 @@ class Initialization {
     bunkers = Bunkers(
       broadcast: broadcast,
       requests: requests,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     follows = Follows(
@@ -247,6 +248,7 @@ class Initialization {
       cacheManager: _ndkConfig.cache,
       broadcast: broadcast,
       accounts: accounts,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     relaySets = RelaySets(
@@ -285,6 +287,7 @@ class Initialization {
       blossomRepository: blossomRepository,
       accounts: accounts,
       blossomUserServerList: blossomUserServerList,
+      eventSignerFactory: _ndkConfig.eventSignerFactory,
     );
 
     files = Files(blossom: blossom);

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -3,10 +3,12 @@ import '../config/nip85_defaults.dart';
 import '../config/broadcast_defaults.dart';
 import '../config/logger_defaults.dart';
 import '../config/request_defaults.dart';
+import '../data_layer/repositories/signers/bip340_event_signer.dart';
 import '../domain_layer/entities/cashu/cashu_user_seedphrase.dart';
 import '../domain_layer/entities/event_filter.dart';
 import '../domain_layer/entities/nip_85.dart';
 import '../domain_layer/repositories/cache_manager.dart';
+import '../domain_layer/repositories/event_signer.dart';
 import '../domain_layer/repositories/event_verifier.dart';
 import '../domain_layer/repositories/wallets_repo.dart';
 import '../shared/logger/log_level.dart';
@@ -24,6 +26,9 @@ class NdkConfig {
 
   /// The wallets repository used to manage wallet data. E.g MemWalletsRepo()
   WalletsRepo? walletsRepo;
+
+  /// Factory for creating EventSigner instances. Defaults to Bip340EventSigner.
+  EventSignerFactory eventSignerFactory;
 
   /// The engine mode to use for Nostr network operations (inbox/outbox mode).
   ///
@@ -88,6 +93,7 @@ class NdkConfig {
   ///
   /// [eventVerifier] The verifier used to validate Nostr events. \
   /// [cache] The cache manager for storing and retrieving Nostr data. \
+  /// [eventSignerFactory] Factory for creating EventSigner instances (defaults to Bip340EventSigner). \
   /// [engine] The engine mode to use (defaults to RELAY_SETS). \
   /// [ignoreRelays] A list of relay URLs to ignore (defaults to an empty list). \
   /// [bootstrapRelays] A list of initial relay URLs (defaults to DEFAULT_BOOTSTRAP_RELAYS). \
@@ -98,6 +104,7 @@ class NdkConfig {
   NdkConfig({
     required this.eventVerifier,
     required this.cache,
+    this.eventSignerFactory = bip340EventSignerFactory,
     this.walletsRepo,
     this.engine = NdkEngine.RELAY_SETS,
     this.ignoreRelays = const [],

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -28,7 +28,7 @@ class NdkConfig {
   WalletsRepo? walletsRepo;
 
   /// Factory for creating EventSigner instances. Defaults to Bip340EventSigner.
-  EventSignerFactory eventSignerFactory;
+  LocalEventSignerFactory eventSignerFactory;
 
   /// The engine mode to use for Nostr network operations (inbox/outbox mode).
   ///
@@ -104,7 +104,7 @@ class NdkConfig {
   NdkConfig({
     required this.eventVerifier,
     required this.cache,
-    this.eventSignerFactory = bip340EventSignerFactory,
+    this.eventSignerFactory = const Bip340EventSignerFactory(),
     this.walletsRepo,
     this.engine = NdkEngine.RELAY_SETS,
     this.ignoreRelays = const [],

--- a/packages/ndk/lib/test_utils/cache_manager_test_suite.dart
+++ b/packages/ndk/lib/test_utils/cache_manager_test_suite.dart
@@ -64,11 +64,7 @@ void runCacheManagerTestSuite({
   required CacheManagerFactory createCacheManager,
   CacheManagerTearDown? cleanUp,
 }) {
-  final eventSignerFactory = ({
-    String? privateKey,
-    required String publicKey,
-  }) =>
-      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+  final eventSignerFactory = Bip340EventSignerFactory();
 
   group('$name CacheManager Test Suite', () {
     late CacheManager cacheManager;
@@ -126,7 +122,7 @@ void runCacheManagerTestSuite({
 // ============================================================================
 
 void _runEventTests(CacheManager Function() getCacheManager,
-    EventSignerFactory eventSignerFactory) {
+    LocalEventSignerFactory eventSignerFactory) {
   test('saveEvent and loadEvent', () async {
     final cacheManager = getCacheManager();
     final event = Nip01Event(
@@ -396,11 +392,11 @@ void _runEventTests(CacheManager Function() getCacheManager,
     final key1 = Bip340.generatePrivateKey();
     final key2 = Bip340.generatePrivateKey();
     final key3 = Bip340.generatePrivateKey();
-    final signer1 = eventSignerFactory(
+    final signer1 = eventSignerFactory.create(
         privateKey: key1.privateKey, publicKey: key1.publicKey);
-    final signer2 = eventSignerFactory(
+    final signer2 = eventSignerFactory.create(
         privateKey: key2.privateKey, publicKey: key2.publicKey);
-    final signer3 = eventSignerFactory(
+    final signer3 = eventSignerFactory.create(
         privateKey: key3.privateKey, publicKey: key3.publicKey);
 
     final event1 = await signer1.sign(Nip01Event(

--- a/packages/ndk/lib/test_utils/cache_manager_test_suite.dart
+++ b/packages/ndk/lib/test_utils/cache_manager_test_suite.dart
@@ -26,6 +26,7 @@ import 'package:test/test.dart';
 
 import '../entities.dart';
 import '../domain_layer/repositories/cache_manager.dart';
+import '../domain_layer/repositories/event_signer.dart';
 import '../shared/nips/nip01/bip340.dart';
 import '../data_layer/repositories/signers/bip340_event_signer.dart';
 
@@ -63,6 +64,12 @@ void runCacheManagerTestSuite({
   required CacheManagerFactory createCacheManager,
   CacheManagerTearDown? cleanUp,
 }) {
+  final eventSignerFactory = ({
+    String? privateKey,
+    required String publicKey,
+  }) =>
+      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+
   group('$name CacheManager Test Suite', () {
     late CacheManager cacheManager;
 
@@ -77,7 +84,7 @@ void runCacheManagerTestSuite({
     });
 
     group('Event Operations', () {
-      _runEventTests(() => cacheManager);
+      _runEventTests(() => cacheManager, eventSignerFactory);
     });
 
     group('Metadata Operations', () {
@@ -118,7 +125,8 @@ void runCacheManagerTestSuite({
 // Event Tests
 // ============================================================================
 
-void _runEventTests(CacheManager Function() getCacheManager) {
+void _runEventTests(CacheManager Function() getCacheManager,
+    EventSignerFactory eventSignerFactory) {
   test('saveEvent and loadEvent', () async {
     final cacheManager = getCacheManager();
     final event = Nip01Event(
@@ -388,11 +396,11 @@ void _runEventTests(CacheManager Function() getCacheManager) {
     final key1 = Bip340.generatePrivateKey();
     final key2 = Bip340.generatePrivateKey();
     final key3 = Bip340.generatePrivateKey();
-    final signer1 = Bip340EventSigner(
+    final signer1 = eventSignerFactory(
         privateKey: key1.privateKey, publicKey: key1.publicKey);
-    final signer2 = Bip340EventSigner(
+    final signer2 = eventSignerFactory(
         privateKey: key2.privateKey, publicKey: key2.publicKey);
-    final signer3 = Bip340EventSigner(
+    final signer3 = eventSignerFactory(
         privateKey: key3.privateKey, publicKey: key3.publicKey);
 
     final event1 = await signer1.sign(Nip01Event(

--- a/packages/ndk/test/nips/nip04_test.dart
+++ b/packages/ndk/test/nips/nip04_test.dart
@@ -2,11 +2,18 @@ import 'dart:convert';
 
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
+import 'package:ndk/domain_layer/repositories/event_signer.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:ndk/shared/nips/nip04/nip04.dart';
 import 'package:test/test.dart';
 
 void main() {
+  EventSigner eventSignerFactory({
+    String? privateKey,
+    required String publicKey,
+  }) =>
+      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+
   group('Nip04', () {
     test('decrypt', () async {
       const priv =
@@ -14,7 +21,7 @@ void main() {
       const pub =
           "b1a5c93edcc8d586566fde53a20bdb50049a97b15483cb763854e57016e0fa3d";
 
-      Bip340EventSigner signer = Bip340EventSigner(
+      EventSigner signer = eventSignerFactory(
         privateKey: priv,
         publicKey: pub,
       );
@@ -45,7 +52,7 @@ void main() {
       const pub =
           "b1a5c93edcc8d586566fde53a20bdb50049a97b15483cb763854e57016e0fa3d";
 
-      Bip340EventSigner signer = Bip340EventSigner(
+      EventSigner signer = eventSignerFactory(
         privateKey: priv,
         publicKey: pub,
       );

--- a/packages/ndk/test/nips/nip51_test.dart
+++ b/packages/ndk/test/nips/nip51_test.dart
@@ -1,12 +1,19 @@
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
 import 'package:ndk/domain_layer/entities/nip_01_event.dart';
+import 'package:ndk/domain_layer/repositories/event_signer.dart';
 import 'package:ndk/shared/nips/nip01/helpers.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:ndk/domain_layer/entities/nip_51_list.dart';
 import 'package:test/test.dart';
 
 void main() {
+  EventSigner eventSignerFactory({
+    String? privateKey,
+    required String publicKey,
+  }) =>
+      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+
   group('Nip51 Relay Sets', () {
     test('fromEvent public', () async {
       final event = Nip01Event(
@@ -35,7 +42,7 @@ void main() {
     });
     test('fromEvent private', () async {
       KeyPair key1 = Bip340.generatePrivateKey();
-      Bip340EventSigner signer = Bip340EventSigner(
+      EventSigner signer = eventSignerFactory(
         privateKey: key1.privateKey,
         publicKey: key1.publicKey,
       );
@@ -80,7 +87,7 @@ void main() {
     });
     test('fromEvent private', () async {
       KeyPair key1 = Bip340.generatePrivateKey();
-      Bip340EventSigner signer = Bip340EventSigner(
+      EventSigner signer = eventSignerFactory(
         privateKey: key1.privateKey,
         publicKey: key1.publicKey,
       );
@@ -99,7 +106,7 @@ void main() {
 
     test('toEvent, fromEvent set metadata', () async {
       KeyPair key1 = Bip340.generatePrivateKey();
-      Bip340EventSigner signer = Bip340EventSigner(
+      EventSigner signer = eventSignerFactory(
         privateKey: key1.privateKey,
         publicKey: key1.publicKey,
       );

--- a/packages/ndk/test/signers/bip340_event_signer_test.dart
+++ b/packages/ndk/test/signers/bip340_event_signer_test.dart
@@ -148,4 +148,190 @@ void main() {
       });
     });
   });
+
+  group('Bip340EventSignerFactory', () {
+    late Bip340EventSignerFactory factory;
+
+    setUp(() {
+      factory = const Bip340EventSignerFactory();
+    });
+
+    group('derivePublicKey', () {
+      test('derives correct public key from private key', () {
+        final keyPair = Bip340.generatePrivateKey();
+        final derivedPubKey = factory.derivePublicKey(keyPair.privateKey!);
+
+        expect(derivedPubKey, equals(keyPair.publicKey));
+      });
+
+      test('derived public key is consistent', () {
+        final keyPair = Bip340.generatePrivateKey();
+        final derivedPubKey1 = factory.derivePublicKey(keyPair.privateKey!);
+        final derivedPubKey2 = factory.derivePublicKey(keyPair.privateKey!);
+
+        expect(derivedPubKey1, equals(derivedPubKey2));
+      });
+    });
+
+    group('generateKeyPair', () {
+      test('generates valid keypair', () {
+        final (privateKey, publicKey) = factory.generateKeyPair();
+
+        expect(privateKey, isNotEmpty);
+        expect(publicKey, isNotEmpty);
+      });
+
+      test('generated public key matches derived public key', () {
+        final (privateKey, publicKey) = factory.generateKeyPair();
+        final derivedPubKey = factory.derivePublicKey(privateKey);
+
+        expect(publicKey, equals(derivedPubKey));
+      });
+
+      test('generates unique keypairs', () {
+        final (privKey1, pubKey1) = factory.generateKeyPair();
+        final (privKey2, pubKey2) = factory.generateKeyPair();
+
+        expect(privKey1, isNot(equals(privKey2)));
+        expect(pubKey1, isNot(equals(pubKey2)));
+      });
+    });
+
+    group('create', () {
+      test('creates signer with both keys provided', () async {
+        final keyPair = Bip340.generatePrivateKey();
+        final signer = factory.create(
+          privateKey: keyPair.privateKey,
+          publicKey: keyPair.publicKey,
+        );
+
+        expect(signer.getPublicKey(), equals(keyPair.publicKey));
+        expect(signer.canSign(), isTrue);
+
+        await signer.dispose();
+      });
+
+      test('creates signer with only private key (derives public key)',
+          () async {
+        final keyPair = Bip340.generatePrivateKey();
+        final signer = factory.create(
+          privateKey: keyPair.privateKey,
+        );
+
+        expect(signer.getPublicKey(), equals(keyPair.publicKey));
+        expect(signer.canSign(), isTrue);
+
+        await signer.dispose();
+      });
+
+      test('creates read-only signer with only public key', () async {
+        final keyPair = Bip340.generatePrivateKey();
+        final signer = factory.create(
+          publicKey: keyPair.publicKey,
+        );
+
+        expect(signer.getPublicKey(), equals(keyPair.publicKey));
+        expect(signer.canSign(), isFalse);
+
+        await signer.dispose();
+      });
+
+      test('throws exception when neither key is provided', () {
+        expect(
+          () => factory.create(),
+          throwsException,
+        );
+      });
+
+      test('derived public key can sign valid events', () async {
+        final keyPair = Bip340.generatePrivateKey();
+        final signer = factory.create(
+          privateKey: keyPair.privateKey,
+          // publicKey NOT provided - should be derived
+        );
+
+        final event = Nip01Event(
+          pubKey: signer.getPublicKey(),
+          kind: 1,
+          tags: [],
+          content: 'Test with derived public key',
+        );
+
+        final signedEvent = await signer.sign(event);
+        final verifier = Bip340EventVerifier();
+        final isValid = await verifier.verify(signedEvent);
+
+        expect(isValid, isTrue);
+
+        await signer.dispose();
+      });
+
+      test('uses provided public key even if derivation would differ',
+          () async {
+        final keyPair1 = Bip340.generatePrivateKey();
+        final keyPair2 = Bip340.generatePrivateKey();
+
+        // Intentionally mismatched keys
+        final signer = factory.create(
+          privateKey: keyPair1.privateKey,
+          publicKey: keyPair2.publicKey, // Different public key
+        );
+
+        // Should use the provided public key, not derived
+        expect(signer.getPublicKey(), equals(keyPair2.publicKey));
+        expect(signer.getPublicKey(), isNot(equals(keyPair1.publicKey)));
+
+        await signer.dispose();
+      });
+    });
+
+    group('createWithNewKeyPair', () {
+      test('creates signer with fresh keypair', () async {
+        final signer = factory.createWithNewKeyPair();
+
+        expect(signer.getPublicKey(), isNotEmpty);
+        expect(signer.canSign(), isTrue);
+
+        await signer.dispose();
+      });
+
+      test('creates unique signers each time', () async {
+        final signer1 = factory.createWithNewKeyPair();
+        final signer2 = factory.createWithNewKeyPair();
+
+        expect(signer1.getPublicKey(), isNot(equals(signer2.getPublicKey())));
+
+        await signer1.dispose();
+        await signer2.dispose();
+      });
+
+      test('created signer can sign valid events', () async {
+        final signer = factory.createWithNewKeyPair();
+
+        final event = Nip01Event(
+          pubKey: signer.getPublicKey(),
+          kind: 1,
+          tags: [],
+          content: 'Test with new keypair',
+        );
+
+        final signedEvent = await signer.sign(event);
+        final verifier = Bip340EventVerifier();
+        final isValid = await verifier.verify(signedEvent);
+
+        expect(isValid, isTrue);
+
+        await signer.dispose();
+      });
+    });
+
+    group('factory is const', () {
+      test('same instance when created with const', () {
+        const factory1 = Bip340EventSignerFactory();
+        const factory2 = Bip340EventSignerFactory();
+
+        expect(identical(factory1, factory2), isTrue);
+      });
+    });
+  });
 }

--- a/packages/ndk/test/signers/bip340_event_signer_test.dart
+++ b/packages/ndk/test/signers/bip340_event_signer_test.dart
@@ -236,10 +236,10 @@ void main() {
         await signer.dispose();
       });
 
-      test('throws exception when neither key is provided', () {
+      test('throws ArgumentError when neither key is provided', () {
         expect(
           () => factory.create(),
-          throwsException,
+          throwsArgumentError,
         );
       });
 

--- a/packages/ndk/test/signers/nip46_event_signer_test.dart
+++ b/packages/ndk/test/signers/nip46_event_signer_test.dart
@@ -6,11 +6,7 @@ import 'package:test/test.dart';
 import '../mocks/mock_relay.dart';
 
 void main() {
-  EventSigner eventSignerFactory({
-    String? privateKey,
-    required String publicKey,
-  }) =>
-      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+  final eventSignerFactory = Bip340EventSignerFactory();
 
   group('Nip46EventSigner with MockRelay', () {
     late Nip46EventSigner signer;

--- a/packages/ndk/test/signers/nip46_event_signer_test.dart
+++ b/packages/ndk/test/signers/nip46_event_signer_test.dart
@@ -6,6 +6,12 @@ import 'package:test/test.dart';
 import '../mocks/mock_relay.dart';
 
 void main() {
+  EventSigner eventSignerFactory({
+    String? privateKey,
+    required String publicKey,
+  }) =>
+      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+
   group('Nip46EventSigner with MockRelay', () {
     late Nip46EventSigner signer;
     late BunkerConnection connection;
@@ -41,7 +47,8 @@ void main() {
       signer = Nip46EventSigner(
           connection: connection,
           requests: ndk.requests,
-          broadcast: ndk.broadcast);
+          broadcast: ndk.broadcast,
+          eventSignerFactory: eventSignerFactory);
     });
 
     tearDown(() async {
@@ -93,6 +100,7 @@ void main() {
       final bunkers = Bunkers(
         requests: ndk.requests,
         broadcast: ndk.broadcast,
+        eventSignerFactory: eventSignerFactory,
       );
 
       final bunkerConnection = await bunkers.connectWithBunkerUrl(
@@ -113,6 +121,7 @@ void main() {
         connection: bunkerConnection,
         requests: ndk.requests,
         broadcast: ndk.broadcast,
+        eventSignerFactory: eventSignerFactory,
       );
 
       final testEvent = Nip01Event(
@@ -140,9 +149,10 @@ void main() {
       final bunkers = Bunkers(
         requests: ndk.requests,
         broadcast: ndk.broadcast,
+        eventSignerFactory: eventSignerFactory,
       );
 
-      final accounts = Accounts();
+      final accounts = Accounts(eventSignerFactory);
 
       // Login with the bunker URL
       final connection = await accounts.loginWithBunkerUrl(
@@ -193,9 +203,10 @@ void main() {
       final bunkers = Bunkers(
         requests: ndk.requests,
         broadcast: ndk.broadcast,
+        eventSignerFactory: eventSignerFactory,
       );
 
-      final accounts = Accounts();
+      final accounts = Accounts(eventSignerFactory);
 
       // Login with the bunker connection
       await accounts.loginWithBunkerConnection(

--- a/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
+++ b/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
@@ -30,6 +30,7 @@ void main() {
     giftWrapService = GiftWrap(
       accounts: ndk.accounts,
       eventVerifier: MockEventVerifier(),
+      eventSignerFactory: ndk.config.eventSignerFactory,
     );
   });
 
@@ -102,6 +103,7 @@ void main() {
         recipientPublicKey: key2.publicKey,
         sealEvent: seal,
         additionalTags: additionalTags,
+        eventSignerFactory: ndk.config.eventSignerFactory,
       );
 
       // Verify additional tags were included

--- a/packages/ndk/test/usecases/zaps/zaps_test.dart
+++ b/packages/ndk/test/usecases/zaps/zaps_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:ndk/data_layer/data_sources/http_request.dart';
 import 'package:ndk/data_layer/repositories/lnurl_http_impl.dart';
 import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
+import 'package:ndk/domain_layer/repositories/event_signer.dart';
 import 'package:ndk/domain_layer/usecases/lnurl/lnurl.dart';
 import 'package:ndk/domain_layer/usecases/zaps/zap_request.dart';
 import 'package:ndk/domain_layer/usecases/zaps/zaps.dart';
@@ -19,6 +20,12 @@ import '../lnurl/lnurl_test.mocks.dart';
 // Mock classes
 @GenerateMocks([http.Client])
 void main() {
+  EventSigner eventSignerFactory({
+    String? privateKey,
+    required String publicKey,
+  }) =>
+      Bip340EventSigner(privateKey: privateKey, publicKey: publicKey);
+
   group('Zaps', () {
     KeyPair key = Bip340.generatePrivateKey();
 
@@ -64,7 +71,7 @@ void main() {
           amountSats: amount,
           eventId: 'eventId',
           comment: 'comment',
-          signer: Bip340EventSigner(
+          signer: eventSignerFactory(
               privateKey: key.privateKey, publicKey: key.publicKey),
           pubKey: 'pubKey',
           relays: ['relay1', 'relay2']);
@@ -99,7 +106,7 @@ void main() {
         amountSats: amount,
         eventId: eventId,
         comment: comment,
-        signer: Bip340EventSigner(
+        signer: eventSignerFactory(
             privateKey: key.privateKey, publicKey: key.publicKey),
         pubKey: pubKey,
         relays: relays,
@@ -126,7 +133,7 @@ void main() {
           amountSats: -1000,
           eventId: 'eventId',
           comment: 'comment',
-          signer: Bip340EventSigner(
+          signer: eventSignerFactory(
               privateKey: key.privateKey, publicKey: key.publicKey),
           pubKey: 'pubKey',
           relays: ['relay1', 'relay2'],
@@ -142,7 +149,7 @@ void main() {
         amountSats: 1000,
         eventId: 'eventId',
         comment: 'comment',
-        signer: Bip340EventSigner(
+        signer: eventSignerFactory(
             privateKey: key.privateKey, publicKey: key.publicKey),
         pubKey: 'pubKey',
         relays: [],

--- a/packages/ndk_flutter/lib/main/ndk_flutter.dart
+++ b/packages/ndk_flutter/lib/main/ndk_flutter.dart
@@ -197,6 +197,7 @@ class NdkFlutter {
           ),
           requests: ndk.requests,
           broadcast: ndk.broadcast,
+          eventSignerFactory: ndk.config.eventSignerFactory,
           cachedPublicKey: account.pubkey,
         );
         ndk.accounts.addAccount(
@@ -211,7 +212,7 @@ class NdkFlutter {
         ndk.accounts.addAccount(
           pubkey: account.pubkey,
           type: AccountType.publicKey,
-          signer: Bip340EventSigner(
+          signer: ndk.config.eventSignerFactory(
             privateKey: null,
             publicKey: account.pubkey,
           ),
@@ -224,7 +225,7 @@ class NdkFlutter {
         ndk.accounts.addAccount(
           pubkey: pubkey,
           type: AccountType.privateKey,
-          signer: Bip340EventSigner(
+          signer: ndk.config.eventSignerFactory(
             privateKey: account.signerSeed!,
             publicKey: pubkey,
           ),

--- a/packages/ndk_flutter/lib/main/ndk_flutter.dart
+++ b/packages/ndk_flutter/lib/main/ndk_flutter.dart
@@ -212,7 +212,7 @@ class NdkFlutter {
         ndk.accounts.addAccount(
           pubkey: account.pubkey,
           type: AccountType.publicKey,
-          signer: ndk.config.eventSignerFactory(
+          signer: ndk.config.eventSignerFactory.create(
             privateKey: null,
             publicKey: account.pubkey,
           ),
@@ -225,7 +225,7 @@ class NdkFlutter {
         ndk.accounts.addAccount(
           pubkey: pubkey,
           type: AccountType.privateKey,
-          signer: ndk.config.eventSignerFactory(
+          signer: ndk.config.eventSignerFactory.create(
             privateKey: account.signerSeed!,
             publicKey: pubkey,
           ),


### PR DESCRIPTION
Introduces a factory for event singers so they can be configured via ndk config.
(In preparation for a platform signer using https://github.com/relaystr/ndk/pull/602)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable EventSignerFactory added to configuration for pluggable signer creation, public-key derivation, and key-pair generation.

* **Refactor**
  * Core flows (accounts, connections, lists, file access, wrapping, NWC, init, and related UI) now use the injected factory for signer creation and public-key handling.
  * Temporary/ephemeral signer creation standardized across the app.

* **Tests**
  * Tests updated to use the factory; new tests validate key derivation, key-pair generation, and factory behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/604)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->