### PR TITLE
fix(test): apply NIP-01 replacement in MockRelay

### DIFF
--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -163,9 +163,15 @@ class MockRelay {
               return;
             }
             if (newEvent.kind == ContactList.kKind) {
-              _contactLists[newEvent.pubKey] = newEvent;
+              final existing = _contactLists[newEvent.pubKey];
+              if (existing == null || _shouldReplace(existing, newEvent)) {
+                _contactLists[newEvent.pubKey] = newEvent;
+              }
             } else if (newEvent.kind == Metadata.kKind) {
-              _metadatas[newEvent.pubKey] = newEvent;
+              final existing = _metadatas[newEvent.pubKey];
+              if (existing == null || _shouldReplace(existing, newEvent)) {
+                _metadatas[newEvent.pubKey] = newEvent;
+              }
             } else if (newEvent.kind == Deletion.kKind) {
               final eventIdsToDelete = newEvent.getTags("e");
               for (final idToDelete in eventIdsToDelete) {
@@ -185,6 +191,35 @@ class MockRelay {
               // Also handle NIP-46 if targeting our mock signer
               if (newEvent.kind == kNip46Kind) {
                 _handleNip46Request(newEvent, webSocket);
+              }
+            } else if (_isReplaceableKind(newEvent.kind)) {
+              // NIP-01 replaceable: only one event per (pubkey, kind)
+              final existing = _storedEvents.where((e) =>
+                  e.pubKey == newEvent.pubKey && e.kind == newEvent.kind);
+              if (existing.isEmpty) {
+                _storedEvents.add(newEvent);
+              } else {
+                final current = existing.first;
+                if (_shouldReplace(current, newEvent)) {
+                  _storedEvents.remove(current);
+                  _storedEvents.add(newEvent);
+                }
+              }
+            } else if (_isAddressableKind(newEvent.kind)) {
+              // NIP-01 addressable: only one event per (pubkey, kind, d-tag)
+              final dTag = newEvent.getDtag() ?? '';
+              final existing = _storedEvents.where((e) =>
+                  e.pubKey == newEvent.pubKey &&
+                  e.kind == newEvent.kind &&
+                  (e.getDtag() ?? '') == dTag);
+              if (existing.isEmpty) {
+                _storedEvents.add(newEvent);
+              } else {
+                final current = existing.first;
+                if (_shouldReplace(current, newEvent)) {
+                  _storedEvents.remove(current);
+                  _storedEvents.add(newEvent);
+                }
               }
             } else {
               _storedEvents.add(newEvent);
@@ -470,6 +505,24 @@ class MockRelay {
   /// Check if a kind is ephemeral (20000-29999) per NIP-01
   bool _isEphemeralKind(int kind) {
     return kind >= 20000 && kind < 30000;
+  }
+
+  /// Check if a kind is replaceable (10000-19999) per NIP-01.
+  /// Kinds 0 and 3 are also replaceable but handled via dedicated maps.
+  bool _isReplaceableKind(int kind) {
+    return kind >= 10000 && kind < 20000;
+  }
+
+  /// Check if a kind is addressable (30000-39999) per NIP-01
+  bool _isAddressableKind(int kind) {
+    return kind >= 30000 && kind < 40000;
+  }
+
+  /// NIP-01 replacement rule: newer created_at wins; on tie, lower id wins.
+  bool _shouldReplace(Nip01Event existing, Nip01Event incoming) {
+    if (incoming.createdAt > existing.createdAt) return true;
+    if (incoming.createdAt < existing.createdAt) return false;
+    return incoming.id.compareTo(existing.id) < 0;
   }
 
   /// Broadcast an event to all clients with matching subscriptions

--- a/packages/ndk/test/mocks/mock_relay_replaceable_test.dart
+++ b/packages/ndk/test/mocks/mock_relay_replaceable_test.dart
@@ -1,0 +1,205 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import 'mock_event_verifier.dart';
+import 'mock_relay.dart';
+
+void main() {
+  group('MockRelay replacement semantics', () {
+    late MockRelay mockRelay;
+
+    setUp(() async {
+      mockRelay = MockRelay(
+        name: 'replaceable-test-relay',
+        explicitPort: 4060,
+      );
+      await mockRelay.startServer();
+    });
+
+    tearDown(() async {
+      await mockRelay.stopServer();
+    });
+
+    test(
+        'replaceable events (kind 10002) should be replaced by newer version from same author',
+        () async {
+      final keyPair = Bip340.generatePrivateKey();
+
+      final ndkWriter = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
+
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Older version
+      final oldEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 10002,
+        tags: [
+          ['r', 'wss://old.example.com'],
+        ],
+        content: '',
+        createdAt: now - 100,
+      );
+      final signedOld = Nip01Utils.signWithPrivateKey(
+        event: oldEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast.broadcast(
+        nostrEvent: signedOld,
+        specificRelays: [mockRelay.url],
+      ).broadcastDoneFuture;
+
+      // Newer version (same author, same kind)
+      final newEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 10002,
+        tags: [
+          ['r', 'wss://new.example.com'],
+        ],
+        content: '',
+        createdAt: now,
+      );
+      final signedNew = Nip01Utils.signWithPrivateKey(
+        event: newEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast.broadcast(
+        nostrEvent: signedNew,
+        specificRelays: [mockRelay.url],
+      ).broadcastDoneFuture;
+
+      // Query from a fresh client to bypass any local cache
+      final ndkReader = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
+
+      final received = <Nip01Event>[];
+      final response = ndkReader.requests.query(
+        filter: Filter(
+          kinds: [10002],
+          authors: [keyPair.publicKey],
+        ),
+      );
+      await for (final event in response.stream) {
+        received.add(event);
+      }
+
+      expect(
+        received.length,
+        equals(1),
+        reason:
+            'NIP-01 replaceable events should keep only the latest (pubkey, kind); '
+            'mock currently returns every version ever sent.',
+      );
+      expect(
+        received.first.getFirstTag('r'),
+        equals('wss://new.example.com'),
+        reason: 'The retained event should be the newer one.',
+      );
+
+      await ndkWriter.destroy();
+      await ndkReader.destroy();
+    });
+
+    test(
+        'addressable events (kind 30023) should be replaced by newer version with same d-tag',
+        () async {
+      final keyPair = Bip340.generatePrivateKey();
+
+      final ndkWriter = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
+
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      const dTag = 'my-article';
+
+      // Older version with d-tag
+      final oldEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 30023,
+        tags: [
+          ['d', dTag],
+        ],
+        content: 'first draft',
+        createdAt: now - 100,
+      );
+      final signedOld = Nip01Utils.signWithPrivateKey(
+        event: oldEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast.broadcast(
+        nostrEvent: signedOld,
+        specificRelays: [mockRelay.url],
+      ).broadcastDoneFuture;
+
+      // Newer version with same d-tag
+      final newEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 30023,
+        tags: [
+          ['d', dTag],
+        ],
+        content: 'final version',
+        createdAt: now,
+      );
+      final signedNew = Nip01Utils.signWithPrivateKey(
+        event: newEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast.broadcast(
+        nostrEvent: signedNew,
+        specificRelays: [mockRelay.url],
+      ).broadcastDoneFuture;
+
+      final ndkReader = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
+
+      final received = <Nip01Event>[];
+      final response = ndkReader.requests.query(
+        filter: Filter(
+          kinds: [30023],
+          authors: [keyPair.publicKey],
+          dTags: [dTag],
+        ),
+      );
+      await for (final event in response.stream) {
+        received.add(event);
+      }
+
+      expect(
+        received.length,
+        equals(1),
+        reason:
+            'NIP-01 addressable events should keep only the latest '
+            '(pubkey, kind, d-tag); mock currently returns every version sent.',
+      );
+      expect(
+        received.first.content,
+        equals('final version'),
+        reason: 'The retained event should be the newer one.',
+      );
+
+      await ndkWriter.destroy();
+      await ndkReader.destroy();
+    });
+  });
+}

--- a/packages/ndk/test/usecases/metadatas/metadatas_test.dart
+++ b/packages/ndk/test/usecases/metadatas/metadatas_test.dart
@@ -93,6 +93,11 @@ void main() async {
           await ndk.metadata.loadMetadata(key0.publicKey, forceRefresh: true);
       expect(result!.pubKey, metadata.pubKey);
 
+      // NIP-01 replacement uses created_at (1s resolution); on a tie the
+      // lower-id event wins. Wait so the second broadcast lands in a later
+      // second and replaces deterministically.
+      await Future.delayed(const Duration(seconds: 1));
+
       metadata.name = "my name";
       await ndk.metadata.broadcastMetadata(metadata);
       result =


### PR DESCRIPTION
MockRelay was keeping every version of replaceable (10000-19999) and addressable (30000-39999) events in _storedEvents, so queries returned duplicates instead of just the latest. Kinds 0 and 3 were also overwritten unconditionally, letting a stale event clobber a newer one.

Apply the NIP-01 replacement rule (newer created_at wins; lower id on tie) per (pubkey, kind) for replaceable events and per (pubkey, kind, d-tag) for addressable events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mock relay now correctly applies NIP-01 replacement rules for replaceable and addressable events, ensuring only the intended event is retained.

* **Tests**
  * Added tests validating replacement behavior for replaceable and addressable event kinds.
  * Made metadata broadcast timing deterministic to ensure predictable replacement outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/605)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->