### PR TITLE
feat: add getDmRelays for NIP-17 DM relay list (kind 10050)

### DIFF
--- a/packages/ndk/lib/domain_layer/entities/nip_51_list.dart
+++ b/packages/ndk/lib/domain_layer/entities/nip_51_list.dart
@@ -16,6 +16,7 @@ class Nip51List {
   static const int kSearchRelays = 10007;
   static const int kInterests = 10015;
   static const int kEmojis = 10030;
+  static const int kDmRelays = 10050;
 
   static const int kFollowSet = 30000;
   static const int kRelaySet = 30002;
@@ -50,6 +51,7 @@ class Nip51List {
     kSearchRelays,
     kInterests,
     kEmojis,
+    kDmRelays,
     kFollowSet,
     kRelaySet,
     kBookmarksSet,

--- a/packages/ndk/lib/domain_layer/usecases/user_relay_lists/user_relay_lists.dart
+++ b/packages/ndk/lib/domain_layer/usecases/user_relay_lists/user_relay_lists.dart
@@ -4,6 +4,8 @@ import '../../../shared/logger/logger.dart';
 import '../../../shared/nips/nip01/helpers.dart';
 import '../../entities/contact_list.dart';
 import '../../entities/filter.dart';
+import '../../entities/nip_01_event.dart';
+import '../../entities/nip_51_list.dart';
 import '../../entities/nip_65.dart';
 import '../../entities/read_write_marker.dart';
 import '../../entities/user_relay_list.dart';
@@ -159,6 +161,56 @@ class UserRelayLists {
       userRelayList = await _cacheManager.loadUserRelayList(pubKey);
     }
     return userRelayList;
+  }
+
+  /// Fetches the DM relay list (NIP-17, kind 10050) for a given user.
+  ///
+  /// Returns the list of relay URLs where the user has indicated they want
+  /// to receive direct messages.
+  ///
+  /// - Returns `null` if the user has not published a kind 10050 event.
+  ///
+  /// [pubKey] the public key of the user whose DM relays to fetch \
+  /// [forceRefresh] if true, bypass cache and query relays directly
+  Future<List<String>?> getDmRelays(
+    String pubKey, {
+    bool forceRefresh = false,
+  }) async {
+    if (!forceRefresh) {
+      final cached = await _cacheManager.loadEvents(
+        pubKeys: [pubKey],
+        kinds: [Nip51List.kDmRelays],
+      );
+      if (cached.isNotEmpty) {
+        cached.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        return _extractDmRelayUrls(cached.first);
+      }
+    }
+
+    final events = await _requests.query(
+      name: "dm-relays",
+      filters: [
+        Filter(
+          authors: [pubKey],
+          kinds: [Nip51List.kDmRelays],
+          limit: 1,
+        ),
+      ],
+    ).future;
+
+    if (events.isEmpty) return null;
+
+    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final latest = events.first;
+    await _cacheManager.saveEvent(latest);
+    return _extractDmRelayUrls(latest);
+  }
+
+  List<String> _extractDmRelayUrls(Nip01Event event) {
+    return event.tags
+        .where((tag) => tag.length >= 2 && tag[0] == Nip51List.kRelay)
+        .map((tag) => tag[1])
+        .toList();
   }
 
   /// *************************************************************************************************

--- a/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
+++ b/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
@@ -88,6 +88,30 @@ void main() async {
       // cache
       expect(rcv, equals(cache0));
     });
+    test('getDmRelays - returns null when no kind 10050 found', () async {
+      final dmRelays =
+          await ndk.userRelayLists.getDmRelays(key1.publicKey);
+      expect(dmRelays, isNull);
+    });
+
+    test('getDmRelays - reads from cache', () async {
+      final event = Nip01Event(
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        pubKey: key0.publicKey,
+        kind: Nip51List.kDmRelays,
+        content: "",
+        tags: [
+          ['relay', 'wss://dm1.example'],
+          ['relay', 'wss://dm2.example'],
+        ],
+      );
+      await ndk.config.cache.saveEvent(event);
+
+      final dmRelays =
+          await ndk.userRelayLists.getDmRelays(key0.publicKey);
+      expect(dmRelays, ['wss://dm1.example', 'wss://dm2.example']);
+    });
+
     test('broadcastAdd/RemoveNip65Relay', () async {
       ndk.accounts
           .loginPrivateKey(pubkey: key3.publicKey, privkey: key3.privateKey!);


### PR DESCRIPTION
Exposes ndk.userRelayLists.getDmRelays(pubKey) which returns the user's DM relays from a kind 10050 event, or null if none is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DM relay list retrieval and management functionality
  * Users can now discover and configure their DM relay settings
  * System supports querying and retrieving user DM relay configurations

* **Tests**
  * Added test coverage for DM relay operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/608)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->