### PR TITLE
fix: support WebEventSigner in saveAccountsState on web

### DIFF
--- a/packages/ndk_flutter/lib/main/ndk_flutter.dart
+++ b/packages/ndk_flutter/lib/main/ndk_flutter.dart
@@ -129,9 +129,6 @@ class NdkFlutter {
       }
 
       if (account.type == AccountType.privateKey) {
-        // Both Bip340EventSigner and WebEventSigner have a public privateKey field,
-        // but there is no common interface exposing it. Use dynamic to handle
-        // both local signer implementations regardless of platform.
         final privateKey = (account.signer as dynamic).privateKey as String?;
         if (privateKey == null) continue;
         accounts.accounts.add(

--- a/packages/ndk_flutter/lib/main/ndk_flutter.dart
+++ b/packages/ndk_flutter/lib/main/ndk_flutter.dart
@@ -129,13 +129,16 @@ class NdkFlutter {
       }
 
       if (account.type == AccountType.privateKey) {
-        final signer = account.signer as Bip340EventSigner;
-        if (signer.privateKey == null) continue;
+        // Both Bip340EventSigner and WebEventSigner have a public privateKey field,
+        // but there is no common interface exposing it. Use dynamic to handle
+        // both local signer implementations regardless of platform.
+        final privateKey = (account.signer as dynamic).privateKey as String?;
+        if (privateKey == null) continue;
         accounts.accounts.add(
           NostrAccount(
             kind: AccountKinds.privkey,
             pubkey: account.pubkey,
-            signerSeed: signer.privateKey!,
+            signerSeed: privateKey,
           ),
         );
         continue;


### PR DESCRIPTION
Replace explicit Bip340EventSigner cast with dynamic access to privateKey, allowing both Bip340EventSigner and WebEventSigner to work regardless of platform or factory configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced private key account handling to support multiple signer implementations.
  * Improved error handling when retrieving private key data during account persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/623)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->