### PR TITLE
chore(release): manually bump version bases for prerelease cycle

### DIFF
--- a/packages/ndk_flutter/pubspec.yaml
+++ b/packages/ndk_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ndk_flutter
 description: "A Flutter UI package providing ready-to-use widgets."
-version: 0.8.2-dev.0+1
+version: 0.8.3
 repository: https://github.com/relaystr/ndk
 topics:
   - ndk

--- a/packages/objectbox/pubspec.yaml
+++ b/packages/objectbox/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ndk_objectbox
 description: Nostr Development Kit - the most performant lib for all your nostr usecases
-version: 0.2.11-dev.0+1
+version: 0.2.12
 homepage: https://github.com/relaystr/ndk
 
 environment:


### PR DESCRIPTION
Bump ndk_flutter to 0.8.3 and ndk_objectbox to 0.2.12 so that melos --prerelease increments the correct base version instead of re-creating 0.8.2-dev.X and 0.2.11-dev.X cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ndk_flutter package updated to version 0.8.3
  * ndk_objectbox package updated to version 0.2.12

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/626)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->