### PR TITLE
feat(nip05)!: return Nip05ResolveResult from resolve()

### DIFF
--- a/packages/ndk/lib/data_layer/data_sources/http_request.dart
+++ b/packages/ndk/lib/data_layer/data_sources/http_request.dart
@@ -5,6 +5,22 @@ import 'package:rxdart/rxdart.dart';
 
 bool _isSuccessStatus(int statusCode) => statusCode >= 200 && statusCode < 300;
 
+/// Exception thrown when an HTTP request completes with a non-2xx status code.
+class HttpRequestException implements Exception {
+  final int statusCode;
+  final String body;
+  final String url;
+
+  const HttpRequestException({
+    required this.statusCode,
+    required this.body,
+    required this.url,
+  });
+
+  @override
+  String toString() => "error fetching STATUS: $statusCode, $body, Link: $url";
+}
+
 /// Upload progress information
 class UploadProgress {
   final int sentBytes;
@@ -39,8 +55,11 @@ class HttpRequestDS {
         headers: {"Accept": "application/json"});
 
     if (!_isSuccessStatus(response.statusCode)) {
-      return throw Exception(
-          "error fetching STATUS: ${response.statusCode}, ${response.body},Link: $url");
+      throw HttpRequestException(
+        statusCode: response.statusCode,
+        body: response.body,
+        url: url,
+      );
     }
     return jsonDecode(response.body);
   }

--- a/packages/ndk/lib/data_layer/repositories/nip_05_http_impl.dart
+++ b/packages/ndk/lib/data_layer/repositories/nip_05_http_impl.dart
@@ -53,7 +53,15 @@ class Nip05HttpRepositoryImpl implements Nip05Repository {
 
     String myUrl = "https://$url/.well-known/nostr.json?name=$username";
 
-    final json = await httpDS.jsonRequest(myUrl);
+    final Map<String, dynamic> json;
+    try {
+      json = await httpDS.jsonRequest(myUrl);
+    } on HttpRequestException catch (e) {
+      if (e.statusCode == 404) {
+        return null;
+      }
+      rethrow;
+    }
 
     Map names = json["names"];
     Map relays = json["relays"] ?? {};

--- a/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/nip46_event_signer.dart
@@ -16,9 +16,7 @@ class _PendingRequestEntry {
   _PendingRequestEntry(this.completer, this.request);
 }
 
-class Nip46EventSigner
-    with ConcurrencyLimiterMixin
-    implements EventSigner {
+class Nip46EventSigner with ConcurrencyLimiterMixin implements EventSigner {
   BunkerConnection connection;
   Requests requests;
   Broadcast broadcast;

--- a/packages/ndk/lib/domain_layer/entities/nip_05_resolve_result.dart
+++ b/packages/ndk/lib/domain_layer/entities/nip_05_resolve_result.dart
@@ -32,7 +32,7 @@ class Nip05NotFound extends Nip05ResolveResult {
 /// from a server returning a body we cannot parse.
 sealed class Nip05ResolveError extends Nip05ResolveResult {
   /// The underlying error that caused the resolution to fail.
-  Object get cause;
+  Exception get cause;
   const Nip05ResolveError();
 }
 
@@ -40,18 +40,27 @@ sealed class Nip05ResolveError extends Nip05ResolveResult {
 ///
 /// Covers DNS failures, timeouts, connection refused, and non-2xx HTTP
 /// responses. Often transient - safe to retry later.
-class Nip05ResolveNetworkError extends Nip05ResolveError {
+class Nip05ResolveNetworkError extends Nip05ResolveError implements Exception {
   @override
-  final Object cause;
+  final Exception cause;
   const Nip05ResolveNetworkError(this.cause);
+
+  @override
+  String toString() =>
+      'Nip05ResolveNetworkError: failed to fetch nostr.json: $cause';
 }
 
 /// The file was fetched but could not be interpreted as a valid nostr.json.
 ///
 /// Covers malformed JSON bodies and unexpected response schemas (e.g.
 /// missing `names` field, wrong types). The server is misconfigured.
-class Nip05ResolveInvalidResponse extends Nip05ResolveError {
+class Nip05ResolveInvalidResponse extends Nip05ResolveError
+    implements Exception {
   @override
-  final Object cause;
+  final Exception cause;
   const Nip05ResolveInvalidResponse(this.cause);
+
+  @override
+  String toString() =>
+      'Nip05ResolveInvalidResponse: invalid nostr.json response: $cause';
 }

--- a/packages/ndk/lib/domain_layer/entities/nip_05_resolve_result.dart
+++ b/packages/ndk/lib/domain_layer/entities/nip_05_resolve_result.dart
@@ -7,9 +7,9 @@ import 'nip_05.dart';
 /// - [Nip05NotFound] - the `.well-known/nostr.json` file was reachable but
 ///   does not contain the requested user (no entry under the username and no
 ///   fallback `_` entry).
-/// - [Nip05ResolveError] - we could not determine whether the user exists:
-///   network failure, non-2xx HTTP status, malformed body, or unexpected
-///   schema. Inspect [Nip05ResolveError.cause] for the underlying error.
+/// - [Nip05ResolveError] - we could not determine whether the user exists.
+///   Switch on its subtypes ([Nip05ResolveNetworkError],
+///   [Nip05ResolveInvalidResponse]) to react accordingly.
 sealed class Nip05ResolveResult {
   const Nip05ResolveResult();
 }
@@ -25,10 +25,33 @@ class Nip05NotFound extends Nip05ResolveResult {
   const Nip05NotFound();
 }
 
-/// We could not determine whether the user exists. Covers network failures
-/// (DNS, timeout, connection refused), non-2xx HTTP responses (e.g. 404 / 500),
-/// malformed JSON bodies, and unexpected response schemas.
-class Nip05ResolveError extends Nip05ResolveResult {
+/// We could not determine whether the user exists.
+///
+/// Sealed: switch on [Nip05ResolveNetworkError] vs
+/// [Nip05ResolveInvalidResponse] to tell a transient transport failure
+/// from a server returning a body we cannot parse.
+sealed class Nip05ResolveError extends Nip05ResolveResult {
+  /// The underlying error that caused the resolution to fail.
+  Object get cause;
+  const Nip05ResolveError();
+}
+
+/// We could not fetch the `.well-known/nostr.json` file.
+///
+/// Covers DNS failures, timeouts, connection refused, and non-2xx HTTP
+/// responses. Often transient - safe to retry later.
+class Nip05ResolveNetworkError extends Nip05ResolveError {
+  @override
   final Object cause;
-  const Nip05ResolveError(this.cause);
+  const Nip05ResolveNetworkError(this.cause);
+}
+
+/// The file was fetched but could not be interpreted as a valid nostr.json.
+///
+/// Covers malformed JSON bodies and unexpected response schemas (e.g.
+/// missing `names` field, wrong types). The server is misconfigured.
+class Nip05ResolveInvalidResponse extends Nip05ResolveError {
+  @override
+  final Object cause;
+  const Nip05ResolveInvalidResponse(this.cause);
 }

--- a/packages/ndk/lib/domain_layer/entities/nip_05_resolve_result.dart
+++ b/packages/ndk/lib/domain_layer/entities/nip_05_resolve_result.dart
@@ -1,0 +1,34 @@
+import 'nip_05.dart';
+
+/// Result of [Nip05Usecase.resolve].
+///
+/// Lets callers distinguish three outcomes:
+/// - [Nip05Found] - the identifier was resolved (from cache or network).
+/// - [Nip05NotFound] - the `.well-known/nostr.json` file was reachable but
+///   does not contain the requested user (no entry under the username and no
+///   fallback `_` entry).
+/// - [Nip05ResolveError] - we could not determine whether the user exists:
+///   network failure, non-2xx HTTP status, malformed body, or unexpected
+///   schema. Inspect [Nip05ResolveError.cause] for the underlying error.
+sealed class Nip05ResolveResult {
+  const Nip05ResolveResult();
+}
+
+/// The NIP-05 identifier was resolved.
+class Nip05Found extends Nip05ResolveResult {
+  final Nip05 data;
+  const Nip05Found(this.data);
+}
+
+/// The NIP-05 file was reached but does not contain the requested user.
+class Nip05NotFound extends Nip05ResolveResult {
+  const Nip05NotFound();
+}
+
+/// We could not determine whether the user exists. Covers network failures
+/// (DNS, timeout, connection refused), non-2xx HTTP responses (e.g. 404 / 500),
+/// malformed JSON bodies, and unexpected response schemas.
+class Nip05ResolveError extends Nip05ResolveResult {
+  final Object cause;
+  const Nip05ResolveError(this.cause);
+}

--- a/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
@@ -130,9 +130,13 @@ class Nip05Usecase {
     } on FormatException catch (e) {
       return Nip05ResolveInvalidResponse(e);
     } on TypeError catch (e) {
-      return Nip05ResolveInvalidResponse(e);
+      return Nip05ResolveInvalidResponse(
+        Exception(e.toString()),
+      );
     } catch (e) {
-      return Nip05ResolveNetworkError(e);
+      return Nip05ResolveNetworkError(
+        e is Exception ? e : Exception(e.toString()),
+      );
     }
   }
 }

--- a/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
@@ -127,8 +127,12 @@ class Nip05Usecase {
       }
       await _database.saveNip05(result);
       return Nip05Found(result);
+    } on FormatException catch (e) {
+      return Nip05ResolveInvalidResponse(e);
+    } on TypeError catch (e) {
+      return Nip05ResolveInvalidResponse(e);
     } catch (e) {
-      return Nip05ResolveError(e);
+      return Nip05ResolveNetworkError(e);
     }
   }
 }

--- a/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
@@ -1,5 +1,6 @@
 import '../../../config/nip_05_defaults.dart';
 import '../../entities/nip_05.dart';
+import '../../entities/nip_05_resolve_result.dart';
 import '../../repositories/cache_manager.dart';
 import '../../repositories/nip_05_repo.dart';
 
@@ -7,7 +8,7 @@ import '../../repositories/nip_05_repo.dart';
 class Nip05Usecase {
   // Static map to keep track of in-flight requests
   static final Map<String, Future<Nip05>> _inFlightRequests = {};
-  static final Map<String, Future<Nip05?>> _inFlightFetches = {};
+  static final Map<String, Future<Nip05ResolveResult>> _inFlightResolves = {};
 
   final CacheManager _database;
   final Nip05Repository _nip05Repository;
@@ -82,12 +83,12 @@ class Nip05Usecase {
     return result;
   }
 
-  /// resolves NIP-05 data without requiring a pubkey for validation
-  /// returns the [Nip05] object with pubkey and relays
+  /// Resolves NIP-05 data without requiring a pubkey for validation.
   ///
   /// [nip05] the nip05 identifier (e.g. "username@example.com")
-  /// returns the [Nip05] object or null if not found
-  Future<Nip05?> resolve(String nip05) async {
+  /// returns a [Nip05ResolveResult] — one of [Nip05Found], [Nip05NotFound],
+  /// or [Nip05ResolveError]. Throws if [nip05] is empty.
+  Future<Nip05ResolveResult> resolve(String nip05) async {
     if (nip05.isEmpty) {
       throw Exception("nip05 empty");
     }
@@ -98,35 +99,36 @@ class Nip05Usecase {
       int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       int lastCheck = databaseResult.networkFetchTime ?? 0;
       if (now - lastCheck < NIP_05_VALID_DURATION.inSeconds) {
-        return databaseResult;
+        return Nip05Found(databaseResult);
       }
     }
 
     // Check if there's an in-flight fetch for this nip05
-    if (_inFlightFetches.containsKey(nip05)) {
-      return await _inFlightFetches[nip05]!;
+    if (_inFlightResolves.containsKey(nip05)) {
+      return await _inFlightResolves[nip05]!;
     }
 
     // Create a new fetch and add it to the in-flight map
-    final fetch = _performFetch(nip05);
-    _inFlightFetches[nip05] = fetch;
+    final fetch = _performResolve(nip05);
+    _inFlightResolves[nip05] = fetch;
 
     try {
       return await fetch;
     } finally {
-      _inFlightFetches.remove(nip05);
+      _inFlightResolves.remove(nip05);
     }
   }
 
-  Future<Nip05?> _performFetch(String nip05) async {
+  Future<Nip05ResolveResult> _performResolve(String nip05) async {
     try {
       final result = await _nip05Repository.fetchNip05(nip05);
-      if (result != null) {
-        await _database.saveNip05(result);
+      if (result == null) {
+        return const Nip05NotFound();
       }
-      return result;
+      await _database.saveNip05(result);
+      return Nip05Found(result);
     } catch (e) {
-      return null;
+      return Nip05ResolveError(e);
     }
   }
 }

--- a/packages/ndk/lib/entities.dart
+++ b/packages/ndk/lib/entities.dart
@@ -14,6 +14,7 @@ export 'domain_layer/entities/global_state.dart';
 export 'domain_layer/entities/metadata.dart';
 export 'domain_layer/entities/nip_01_event.dart';
 export 'domain_layer/entities/nip_05.dart';
+export 'domain_layer/entities/nip_05_resolve_result.dart';
 export 'domain_layer/entities/nip_51_list.dart';
 export 'domain_layer/entities/nip_65.dart';
 export 'domain_layer/entities/pubkey_mapping.dart';

--- a/packages/ndk/test/usecases/nip05/nip05_network_test.dart
+++ b/packages/ndk/test/usecases/nip05/nip05_network_test.dart
@@ -6,6 +6,7 @@ import 'package:ndk/config/nip_05_defaults.dart';
 import 'package:ndk/data_layer/data_sources/http_request.dart';
 import 'package:ndk/data_layer/repositories/nip_05_http_impl.dart';
 import 'package:ndk/domain_layer/entities/nip_05.dart';
+import 'package:ndk/domain_layer/entities/nip_05_resolve_result.dart';
 import 'package:ndk/domain_layer/usecases/nip05/nip_05.dart';
 import 'package:ndk/ndk.dart';
 
@@ -296,7 +297,7 @@ void main() {
       expect(result.relays, equals(['relay1', 'relay2']));
     });
 
-    test('resolve() returns pubkey without validation', () async {
+    test('resolve() returns Nip05Found on success', () async {
       final client = MockClient(requestHandler);
 
       final cache = MemCacheManager();
@@ -308,13 +309,36 @@ void main() {
 
       final result = await nip05Usecase.resolve('username@example.com');
 
-      expect(result, isNotNull);
-      expect(result!.pubKey, equals('pubkey'));
-      expect(result.nip05, equals('username@example.com'));
-      expect(result.relays, equals(['relay1', 'relay2']));
+      expect(result, isA<Nip05Found>());
+      final found = result as Nip05Found;
+      expect(found.data.pubKey, equals('pubkey'));
+      expect(found.data.nip05, equals('username@example.com'));
+      expect(found.data.relays, equals(['relay1', 'relay2']));
     });
 
-    test('resolve() returns null on error', () async {
+    test('resolve() returns Nip05NotFound when user is absent from nostr.json',
+        () async {
+      // Server replies 200 with an empty `names` map: the file exists but
+      // the requested user is not in it.
+      Future<http.Response> notFoundHandler(http.Request request) async {
+        return http.Response('{"names": {}}', 200);
+      }
+
+      final client = MockClient(notFoundHandler);
+
+      final cache = MemCacheManager();
+      final nip05Repos = Nip05HttpRepositoryImpl(httpDS: HttpRequestDS(client));
+      Nip05Usecase nip05Usecase = Nip05Usecase(
+        database: cache,
+        nip05Repository: nip05Repos,
+      );
+
+      final result = await nip05Usecase.resolve('ghost@example.com');
+
+      expect(result, isA<Nip05NotFound>());
+    });
+
+    test('resolve() returns Nip05ResolveError on HTTP error', () async {
       final client = MockClient(requestHandlerErr);
 
       final cache = MemCacheManager();
@@ -326,7 +350,27 @@ void main() {
 
       final result = await nip05Usecase.resolve('username@example.com');
 
-      expect(result, isNull);
+      expect(result, isA<Nip05ResolveError>());
+      expect((result as Nip05ResolveError).cause, isNotNull);
+    });
+
+    test('resolve() returns Nip05ResolveError on malformed JSON', () async {
+      Future<http.Response> malformedHandler(http.Request request) async {
+        return http.Response('not json', 200);
+      }
+
+      final client = MockClient(malformedHandler);
+
+      final cache = MemCacheManager();
+      final nip05Repos = Nip05HttpRepositoryImpl(httpDS: HttpRequestDS(client));
+      Nip05Usecase nip05Usecase = Nip05Usecase(
+        database: cache,
+        nip05Repository: nip05Repos,
+      );
+
+      final result = await nip05Usecase.resolve('username@example.com');
+
+      expect(result, isA<Nip05ResolveError>());
     });
 
     test('resolve() throws if nip05 is empty', () async {
@@ -358,7 +402,7 @@ void main() {
 
       final results = await Future.wait([resolve1, resolve2, resolve3]);
 
-      expect(results[0]!.pubKey, equals('pubkey'));
+      expect(results[0], isA<Nip05Found>());
       expect(results[0].hashCode, equals(results[1].hashCode));
       expect(results[1].hashCode, equals(results[2].hashCode));
     });
@@ -389,15 +433,14 @@ void main() {
 
       // resolve() should refetch because cache is expired
       final result = await nip05Usecase.resolve('username@example.com');
-      expect(result, isNotNull);
-      expect(
-          result!.pubKey, equals('pubkey')); // From network, not 'old_pubkey'
+      expect(result, isA<Nip05Found>());
+      // From network, not 'old_pubkey'
+      expect((result as Nip05Found).data.pubKey, equals('pubkey'));
 
       // Second call should return cached result (now valid)
       final result2 = await nip05Usecase.resolve('username@example.com');
-      expect(result2, isNotNull);
-      expect(result2!.pubKey, equals('pubkey'));
-      expect(result.hashCode, equals(result2.hashCode)); // Same cached object
+      expect(result2, isA<Nip05Found>());
+      expect((result2 as Nip05Found).data.pubKey, equals('pubkey'));
     });
   });
 }

--- a/packages/ndk/test/usecases/nip05/nip05_network_test.dart
+++ b/packages/ndk/test/usecases/nip05/nip05_network_test.dart
@@ -338,6 +338,25 @@ void main() {
       expect(result, isA<Nip05NotFound>());
     });
 
+    test('resolve() returns Nip05NotFound on HTTP 404', () async {
+      Future<http.Response> notFoundHandler(http.Request request) async {
+        return http.Response('', 404);
+      }
+
+      final client = MockClient(notFoundHandler);
+
+      final cache = MemCacheManager();
+      final nip05Repos = Nip05HttpRepositoryImpl(httpDS: HttpRequestDS(client));
+      Nip05Usecase nip05Usecase = Nip05Usecase(
+        database: cache,
+        nip05Repository: nip05Repos,
+      );
+
+      final result = await nip05Usecase.resolve('ghost@example.com');
+
+      expect(result, isA<Nip05NotFound>());
+    });
+
     test('resolve() returns Nip05ResolveError on HTTP error', () async {
       final client = MockClient(requestHandlerErr);
 


### PR DESCRIPTION
resolve() now returns a sealed Nip05ResolveResult (Nip05Found, Nip05NotFound, Nip05ResolveError) instead of Nip05?, so callers can distinguish "user not in the nostr.json file" from "server unreachable or invalid response".

BREAKING CHANGE: resolve() return type changed from Future<Nip05?> to Future<Nip05ResolveResult>. Switch on the sealed result instead of null-checking the returned Nip05.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NIP-05 resolution now returns explicit, typed outcomes: success with resolved data, user-not-found, or detailed error carrying the underlying cause.
  * Introduced a dedicated HTTP error type for non-2xx responses, enabling clearer error details.

* **Breaking Changes**
  * The resolve API returns a structured result type instead of a nullable value; callers must handle the new result variants.

* **Tests**
  * Tests updated to assert the new typed resolve outcomes, cache behavior, and in-flight deduplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->