### PR TITLE
fix(ndk_flutter): prevent QR code overflow in nostr connect dialog

### DIFF
--- a/packages/ndk_flutter/lib/widgets/login/nostr_connect_dialog_view.dart
+++ b/packages/ndk_flutter/lib/widgets/login/nostr_connect_dialog_view.dart
@@ -13,22 +13,22 @@ class NostrConnectDialogView extends StatelessWidget {
     return Theme(
       data: ThemeData.light(),
       child: AlertDialog(
+        backgroundColor: Colors.white,
         title: Text(AppLocalizations.of(context)!.nostrConnectUrl),
-        content: Row(
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            Spacer(),
-            AspectRatio(
-              aspectRatio: 1,
-              child: PrettyQrView.data(
-                data: nostrConnectURL,
-                decoration: const PrettyQrDecoration(
-                  shape: PrettyQrShape.custom(PrettyQrDotsSymbol()),
+        content: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 300, maxHeight: 300),
+          child: AspectRatio(
+            aspectRatio: 1,
+            child: PrettyQrView.data(
+              data: nostrConnectURL,
+              decoration: const PrettyQrDecoration(
+                quietZone: PrettyQrQuietZone.standard,
+                shape: PrettyQrSmoothSymbol(
+                  roundFactor: 0,
                 ),
               ),
             ),
-            Spacer(),
-          ],
+          ),
         ),
         actions: [
           FilledButton(

--- a/packages/sample-app/lib/login_popup.dart
+++ b/packages/sample-app/lib/login_popup.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ndk/ndk.dart';
 import 'package:ndk_demo/l10n/app_localizations_context.dart';
 import 'package:ndk_flutter/ndk_flutter.dart';
 
@@ -26,12 +27,22 @@ Future<void> showNLoginPopup({
         ),
         content: SizedBox(
           width: 420,
-          child: NLogin(
-            ndkFlutter: ndkFlutter,
-            onLoggedIn: () {
-              Navigator.of(dialogContext).pop();
-              onLoggedIn();
-            },
+          child: SingleChildScrollView(
+            child: NLogin(
+              ndkFlutter: ndkFlutter,
+              nostrConnect: NostrConnect(
+                appName: 'NDK sample app',
+                relays: [
+                  "wss://relay.damus.io",
+                  "wss://relay.primal.net",
+                  "wss://relay.nmail.li",
+                ],
+              ),
+              onLoggedIn: () {
+                Navigator.of(dialogContext).pop();
+                onLoggedIn();
+              },
+            ),
           ),
         ),
       );

--- a/packages/sample-app/lib/widgets_demo_page.dart
+++ b/packages/sample-app/lib/widgets_demo_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ndk/ndk.dart';
 import 'package:ndk_demo/l10n/app_localizations_context.dart';
 import 'package:ndk_flutter/ndk_flutter.dart';
 
@@ -215,6 +216,14 @@ class _WidgetsDemoPageState extends State<WidgetsDemoPage> {
                           },
                           enableNip07Login: false,
                           enableAmberLogin: false,
+                          nostrConnect: NostrConnect(
+                            appName: 'NDK sample app',
+                            relays: [
+                              "wss://relay.damus.io",
+                              "wss://relay.primal.net",
+                              "wss://relay.nmail.li",
+                            ],
+                          ),
                         ),
                       ],
                     ],


### PR DESCRIPTION
Constrain the QR view with a ConstrainedBox (maxWidth/maxHeight 300) so it no longer overflows on narrow screens nor stretches the dialog on wide ones. Also switch to PrettyQrSmoothSymbol with a standard quiet zone and force a white background for best scannabillity.

Wire up NostrConnect (app name + default relays) in the sample app's login popup and widgets demo, and wrap the login popup content in a SingleChildScrollView to avoid overflow when the dialog content grows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned login dialog with cleaner QR code layout, white background, and improved QR rendering
  
* **Refactor**
  * Updated login configuration with relay network settings and app identification parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/relaystr/ndk/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->