### PR TITLE
fix: add missing timeout to wallets.send

### DIFF
--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/cashu/cashu_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/cashu/cashu_wallet_provider.dart
@@ -106,7 +106,7 @@ class CashuWalletProvider implements WalletProvider {
   }
 
   @override
-  Future<PayInvoiceResponse> send(Wallet wallet, String invoice) async {
+  Future<PayInvoiceResponse> send(Wallet wallet, String invoice, {Duration? timeout}) async {
     if (wallet is! CashuWallet) {
       throw ArgumentError('Expected a CashuWallet');
     }

--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/lnurl/lnurl_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/lnurl/lnurl_wallet_provider.dart
@@ -107,7 +107,7 @@ class LnurlWalletProvider implements WalletProvider {
   }
 
   @override
-  Future<PayInvoiceResponse> send(Wallet wallet, String invoice) async {
+  Future<PayInvoiceResponse> send(Wallet wallet, String invoice, {Duration? timeout}) async {
     // LNURL wallet is receive-only, cannot pay invoices
     throw UnsupportedError(
         'LNURL wallet is receive-only and cannot pay invoices');

--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet.dart
@@ -14,6 +14,11 @@ class NwcWallet extends Wallet {
   final String nwcUrl;
   final Set<String> cachedPermissions;
   NwcConnection? connection;
+
+  /// Remaining NWC budget in sats, cached after the last `get_budget` call.
+  /// null = wallet doesn't support get_budget, or not yet fetched.
+  int? cachedRemainingBudgetSats;
+
   BehaviorSubject<List<WalletBalance>>? balanceSubject;
   BehaviorSubject<List<WalletTransaction>>? transactionsSubject;
   BehaviorSubject<List<WalletTransaction>>? pendingTransactionsSubject;
@@ -73,6 +78,7 @@ class NwcWallet extends Wallet {
       metadata: metadata,
     );
     wallet.connection = connection;
+    wallet.cachedRemainingBudgetSats = cachedRemainingBudgetSats;
     wallet.balanceSubject = balanceSubject;
     wallet.transactionsSubject = transactionsSubject;
     wallet.pendingTransactionsSubject = pendingTransactionsSubject;

--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:rxdart/rxdart.dart';
 
+import '../../../../usecases/nwc/consts/nwc_method.dart';
 import '../../../../usecases/nwc/nwc.dart';
 import '../../../../usecases/nwc/nwc_connection.dart';
 import '../../../../usecases/nwc/responses/pay_invoice_response.dart';
@@ -20,6 +21,10 @@ class NwcWalletProvider implements WalletProvider {
 
   /// Track in-flight connection attempts to prevent concurrent connections for the same wallet
   final Map<String, Completer<void>> _connectionInProgress = {};
+
+  /// Subscriptions to NWC notification streams, one per wallet.
+  /// Cancelled in [removeWallet].
+  final Map<String, StreamSubscription<dynamic>> _notificationSubscriptions = {};
 
   NwcWalletProvider(this._nwcUseCase);
 
@@ -50,6 +55,9 @@ class NwcWalletProvider implements WalletProvider {
   @override
   Future<void> removeWallet(Wallet wallet) async {
     final nwcWallet = wallet as NwcWallet;
+    // Cancel notification listener before disconnecting.
+    await _notificationSubscriptions[nwcWallet.id]?.cancel();
+    _notificationSubscriptions.remove(nwcWallet.id);
     if (nwcWallet.connection != null) {
       await _nwcUseCase.disconnect(nwcWallet.connection!);
       await nwcWallet.balanceSubject?.close();
@@ -189,6 +197,28 @@ class NwcWalletProvider implements WalletProvider {
     }
   }
 
+  /// Fetches and caches the remaining NWC budget for [wallet].
+  /// No-op if the connection is gone or the wallet lacks get_budget permission.
+  Future<void> _refreshBudget(NwcWallet wallet) async {
+    final connection = wallet.connection;
+    if (connection == null) return;
+    final perms = connection.permissions.isNotEmpty
+        ? connection.permissions
+        : wallet.cachedPermissions;
+    if (!perms.contains(NwcMethod.GET_BUDGET.name)) return;
+    try {
+      final budget = await _nwcUseCase
+          .getBudget(connection)
+          .timeout(const Duration(seconds: 10));
+      // totalBudget == 0 means no spending limit configured → null (unlimited).
+      wallet.cachedRemainingBudgetSats = budget.totalBudget > 0
+          ? budget.totalBudgetSats - budget.userBudgetSats
+          : null;
+    } catch (_) {
+      // Leave existing cached value on error.
+    }
+  }
+
   Future<void> _refreshBalance(NwcWallet wallet) async {
     wallet.balanceSubject ??= BehaviorSubject<List<WalletBalance>>();
     final connection = _connectionOrThrow(wallet);
@@ -291,6 +321,16 @@ class NwcWalletProvider implements WalletProvider {
       wallet.nwcUrl,
       doGetInfoMethod: true,
     );
+
+    // Auto-refresh balance whenever the wallet reports a payment notification
+    // (payment_sent, payment_received, hold_invoice_accepted).
+    // This keeps ndk.wallets.getBalance() accurate without polling.
+    _notificationSubscriptions[wallet.id]?.cancel();
+    _notificationSubscriptions[wallet.id] =
+        wallet.connection!.notificationStream.stream.listen((_) {
+      _refreshBalance(wallet).catchError((_) {});
+      _refreshBudget(wallet).catchError((_) {});
+    });
   }
 
   bool _setEquals(Set<String> a, Set<String> b) {

--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet_provider.dart
@@ -331,6 +331,10 @@ class NwcWalletProvider implements WalletProvider {
       _refreshBalance(wallet).catchError((_) {});
       _refreshBudget(wallet).catchError((_) {});
     });
+
+    // Pre-cache budget immediately on connect so callers can read
+    // cachedRemainingBudgetSats without issuing a separate live query.
+    _refreshBudget(wallet).catchError((_) {});
   }
 
   bool _setEquals(Set<String> a, Set<String> b) {

--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/nwc/nwc_wallet_provider.dart
@@ -135,7 +135,7 @@ class NwcWalletProvider implements WalletProvider {
   }
 
   @override
-  Future<PayInvoiceResponse> send(Wallet wallet, String invoice) async {
+  Future<PayInvoiceResponse> send(Wallet wallet, String invoice, {Duration? timeout}) async {
     final nwcWallet = wallet as NwcWallet;
 
     await initialize(wallet);
@@ -144,6 +144,7 @@ class NwcWalletProvider implements WalletProvider {
     final response = await _nwcUseCase.payInvoice(
       connection,
       invoice: invoice,
+      timeout: timeout
     );
     await _refreshAll(nwcWallet);
     return response;

--- a/packages/ndk/lib/domain_layer/entities/wallet/wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/wallet_provider.dart
@@ -40,7 +40,7 @@ abstract class WalletProvider {
 
   /// Pays a Lightning invoice using this wallet
   /// Returns payment result with preimage and fees
-  Future<PayInvoiceResponse> send(Wallet wallet, String invoice);
+  Future<PayInvoiceResponse> send(Wallet wallet, String invoice, {Duration? timeout});
 
   /// Receive by creating a Lightning Invoice
   Future<String> receive(Wallet wallet, int amountSats);

--- a/packages/ndk/lib/domain_layer/usecases/wallets/wallets.dart
+++ b/packages/ndk/lib/domain_layer/usecases/wallets/wallets.dart
@@ -531,7 +531,7 @@ class Wallets {
 
   /// Send payment
   Future<PayInvoiceResponse> send(
-      {String? walletId, required String invoice}) async {
+      {String? walletId, required String invoice, Duration? timeout}) async {
     await _initializationFuture;
     walletId ??= _repository.getDefaultWalletIdForSending();
     if (walletId == null) {
@@ -542,7 +542,7 @@ class Wallets {
     if (provider == null) {
       throw ArgumentError('No provider for wallet type: ${wallet.type}');
     }
-    return provider.send(wallet, invoice);
+    return provider.send(wallet, invoice, timeout: timeout);
   }
 
   /// Create a Lightning invoice to receive funds

--- a/packages/ndk_flutter/lib/widgets/wallets/n_add_wallet_dialogs.dart
+++ b/packages/ndk_flutter/lib/widgets/wallets/n_add_wallet_dialogs.dart
@@ -430,8 +430,8 @@ Future<CashuWallet?> showAddCashuWalletDialog(
 
                 await ndkFlutter.ndk.wallets.addWallet(cashuWallet);
 
-                if (context.mounted) {
-                  Navigator.of(context).pop(cashuWallet);
+                if (dialogContext.mounted) {
+                  Navigator.of(dialogContext).pop(cashuWallet);
                 }
                 scaffoldMessenger.showSnackBar(
                   SnackBar(


### PR DESCRIPTION
- [ ] cashu ln invoice expiration 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional timeout for Lightning invoice payments across wallets (callers can control payment timeout).

* **Improvements**
  * NWC wallets cache remaining budget and auto-refresh balance and budget when payment notifications arrive.
  * Payment timeout is accepted and propagated through wallet send flows.

* **Bug Fixes**
  * Notification subscriptions are cleaned up when a wallet is removed.
  * Dialog navigation now uses the correct context check before closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->