### PR TITLE
feat: cashu preflight checks

### DIFF
--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/cashu/cashu_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/cashu/cashu_wallet_provider.dart
@@ -53,6 +53,8 @@ class CashuWalletProvider implements WalletProvider {
       throw ArgumentError('Expected a CashuWallet');
     }
 
+    await _cashuUseCase.preflightChecks();
+
     // Ensure mint info is cached
     await _cashuUseCase.getMintInfoNetwork(mintUrl: wallet.mintUrl);
     return null; // No wallet update needed
@@ -106,7 +108,8 @@ class CashuWalletProvider implements WalletProvider {
   }
 
   @override
-  Future<PayInvoiceResponse> send(Wallet wallet, String invoice, {Duration? timeout}) async {
+  Future<PayInvoiceResponse> send(Wallet wallet, String invoice,
+      {Duration? timeout}) async {
     if (wallet is! CashuWallet) {
       throw ArgumentError('Expected a CashuWallet');
     }

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
@@ -100,10 +100,11 @@ class Cashu {
     return _cashuSeed;
   }
 
+  /// cheks to run for any cashu operation that modifies state \
   void _preflightChecks() {
     if (!getCashuSeed().isSeedPhraseSet) {
       final logMsg =
-          'Cashu seed phrase is not set. Please set it using Cashu.setCashuSeedPhrase() or in NdkConfig';
+          'Cashu seed phrase is not set. Please set it using .setCashuSeedPhrase() or in NdkConfig';
       Logger.log.f(() => logMsg);
 
       throw Exception(logMsg);

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
@@ -100,7 +100,7 @@ class Cashu {
     return _cashuSeed;
   }
 
-  /// cheks to run for any cashu operation that modifies state
+  /// checks to run for any cashu operation that modifies state
   void _preflightChecks() {
     if (!getCashuSeed().isSeedPhraseSet) {
       final logMsg =
@@ -450,6 +450,7 @@ class Cashu {
     required String mintUrl,
     bool deleteState = true,
   }) async {
+    _preflightChecks();
     // Remove from cache
     await _cacheManager.removeMintInfo(mintUrl: mintUrl);
 
@@ -1162,7 +1163,7 @@ class Cashu {
   /// todo: restore pending transaction from cache
   /// todo: recover funds
   /// todo: timeout
-  void checkSpendingState({
+  Future<void> checkSpendingState({
     required CashuWalletTransaction transaction,
   }) async {
     _preflightChecks();

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
@@ -100,7 +100,7 @@ class Cashu {
     return _cashuSeed;
   }
 
-  /// cheks to run for any cashu operation that modifies state \
+  /// cheks to run for any cashu operation that modifies state
   void _preflightChecks() {
     if (!getCashuSeed().isSeedPhraseSet) {
       final logMsg =

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
@@ -101,7 +101,7 @@ class Cashu {
   }
 
   /// checks to run for any cashu operation that modifies state
-  void _preflightChecks() {
+  Future<void> preflightChecks() async {
     if (!getCashuSeed().isSeedPhraseSet) {
       final logMsg =
           'Cashu seed phrase is not set. Please set it using .setCashuSeedPhrase() or in NdkConfig';
@@ -131,7 +131,7 @@ class Cashu {
     int batchSize = 100,
     int gapLimit = 2,
   }) async* {
-    _preflightChecks();
+    await preflightChecks();
     Logger.log.i(() => 'Starting restore from $mintUrl');
 
     // Get keysets for this mint and unit
@@ -419,7 +419,7 @@ class Cashu {
   Future<bool> addMintToKnownMints({
     required String mintUrl,
   }) async {
-    _preflightChecks();
+    await preflightChecks();
     final result = await _checkIfMintIsKnown(mintUrl);
     return !result;
   }
@@ -450,7 +450,7 @@ class Cashu {
     required String mintUrl,
     bool deleteState = true,
   }) async {
-    _preflightChecks();
+    await preflightChecks();
     // Remove from cache
     await _cacheManager.removeMintInfo(mintUrl: mintUrl);
 
@@ -492,7 +492,7 @@ class Cashu {
     required String method,
     String? memo,
   }) async {
-    _preflightChecks();
+    await preflightChecks();
     await _checkIfMintIsKnown(mintUrl);
     final keysets = await _cashuKeysets.getKeysetsFromMint(mintUrl);
 
@@ -543,7 +543,7 @@ class Cashu {
   Stream<CashuWalletTransaction> retrieveFunds({
     required CashuWalletTransaction draftTransaction,
   }) async* {
-    _preflightChecks();
+    await preflightChecks();
     if (draftTransaction.qoute == null) {
       throw Exception("Quote is not available in the transaction");
     }
@@ -706,7 +706,7 @@ class Cashu {
     required String unit,
     required String method,
   }) async {
-    _preflightChecks();
+    await preflightChecks();
 
     final meltQuote = await _cashuRepo.getMeltQuote(
       mintUrl: mintUrl,
@@ -735,7 +735,7 @@ class Cashu {
   Stream<CashuWalletTransaction> redeem({
     required CashuWalletTransaction draftRedeemTransaction,
   }) async* {
-    _preflightChecks();
+    await preflightChecks();
     if (draftRedeemTransaction.qouteMelt == null) {
       throw Exception("Melt Quote is not available in the transaction");
     }
@@ -984,7 +984,7 @@ class Cashu {
     required String unit,
     String? memo,
   }) async {
-    _preflightChecks();
+    await preflightChecks();
     if (amount <= 0) {
       throw Exception('Amount must be greater than zero');
     }
@@ -1166,7 +1166,7 @@ class Cashu {
   Future<void> checkSpendingState({
     required CashuWalletTransaction transaction,
   }) async {
-    _preflightChecks();
+    await preflightChecks();
     if (transaction.proofPubKeys == null || transaction.proofPubKeys!.isEmpty) {
       throw Exception('No proof public keys provided for checking state');
     }
@@ -1232,7 +1232,7 @@ class Cashu {
   /// [token] - the Cashu token string to receive \
   /// returns a stream of [CashuWalletTransaction] that emits the transaction state as it progresses.
   Stream<CashuWalletTransaction> receive(String token) async* {
-    _preflightChecks();
+    await preflightChecks();
 
     final rcvToken = CashuTokenEncoder.decodedToken(token);
     if (rcvToken == null) {

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
@@ -100,6 +100,16 @@ class Cashu {
     return _cashuSeed;
   }
 
+  void _preflightChecks() {
+    if (!getCashuSeed().isSeedPhraseSet) {
+      final logMsg =
+          'Cashu seed phrase is not set. Please set it using Cashu.setCashuSeedPhrase() or in NdkConfig';
+      Logger.log.f(() => logMsg);
+
+      throw Exception(logMsg);
+    }
+  }
+
   /// Restores proofs from a mint using the wallet's seed phrase.
   ///
   /// This implements NUT-09 (Restore) using NUT-13 (Deterministic Secrets).
@@ -120,6 +130,7 @@ class Cashu {
     int batchSize = 100,
     int gapLimit = 2,
   }) async* {
+    _preflightChecks();
     Logger.log.i(() => 'Starting restore from $mintUrl');
 
     // Get keysets for this mint and unit
@@ -407,6 +418,7 @@ class Cashu {
   Future<bool> addMintToKnownMints({
     required String mintUrl,
   }) async {
+    _preflightChecks();
     final result = await _checkIfMintIsKnown(mintUrl);
     return !result;
   }
@@ -478,6 +490,7 @@ class Cashu {
     required String method,
     String? memo,
   }) async {
+    _preflightChecks();
     await _checkIfMintIsKnown(mintUrl);
     final keysets = await _cashuKeysets.getKeysetsFromMint(mintUrl);
 
@@ -528,6 +541,7 @@ class Cashu {
   Stream<CashuWalletTransaction> retrieveFunds({
     required CashuWalletTransaction draftTransaction,
   }) async* {
+    _preflightChecks();
     if (draftTransaction.qoute == null) {
       throw Exception("Quote is not available in the transaction");
     }
@@ -690,6 +704,8 @@ class Cashu {
     required String unit,
     required String method,
   }) async {
+    _preflightChecks();
+
     final meltQuote = await _cashuRepo.getMeltQuote(
       mintUrl: mintUrl,
       request: request,
@@ -717,6 +733,7 @@ class Cashu {
   Stream<CashuWalletTransaction> redeem({
     required CashuWalletTransaction draftRedeemTransaction,
   }) async* {
+    _preflightChecks();
     if (draftRedeemTransaction.qouteMelt == null) {
       throw Exception("Melt Quote is not available in the transaction");
     }
@@ -965,6 +982,7 @@ class Cashu {
     required String unit,
     String? memo,
   }) async {
+    _preflightChecks();
     if (amount <= 0) {
       throw Exception('Amount must be greater than zero');
     }
@@ -1146,6 +1164,7 @@ class Cashu {
   void checkSpendingState({
     required CashuWalletTransaction transaction,
   }) async {
+    _preflightChecks();
     if (transaction.proofPubKeys == null || transaction.proofPubKeys!.isEmpty) {
       throw Exception('No proof public keys provided for checking state');
     }
@@ -1211,6 +1230,8 @@ class Cashu {
   /// [token] - the Cashu token string to receive \
   /// returns a stream of [CashuWalletTransaction] that emits the transaction state as it progresses.
   Stream<CashuWalletTransaction> receive(String token) async* {
+    _preflightChecks();
+
     final rcvToken = CashuTokenEncoder.decodedToken(token);
     if (rcvToken == null) {
       throw Exception('Invalid Cashu token format');

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu_seed.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu_seed.dart
@@ -75,8 +75,10 @@ class CashuSeed {
     return seed.sentence;
   }
 
+  bool get isSeedPhraseSet => _userSeedPhrase != null;
+
   void _seedCheck() {
-    if (_userSeedPhrase == null) {
+    if (!isSeedPhraseSet) {
       throw Exception('Seed phrase is not set');
     }
     if (_cachedSeed.isEmpty) {

--- a/packages/ndk/test/cashu/cashu_fund_test.dart
+++ b/packages/ndk/test/cashu/cashu_fund_test.dart
@@ -35,6 +35,23 @@ void main() {
         throwsA(isA<Exception>()),
       );
     });
+
+    test('fund - missing seed phrase throws exception', () async {
+      final cashu = CashuTestTools.mockHttpCashu(
+        customMockClient: MockCashuHttpClient(),
+      );
+
+      expect(
+        () async => await cashu.initiateFund(
+          mintUrl: devMintUrl,
+          amount: 52,
+          unit: 'sat',
+          method: 'bolt11',
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
     test('fund - no keyset throws exception', () async {
       final ndk = _ndk();
 


### PR DESCRIPTION
adds cashu preflight checks for operations mutating state.

Catches a bug where its possible to get the mint invoice but throws exception after payment because of missing seedphrase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to ensure seed phrase is properly configured before executing Cashu wallet operations (fund, redeem, spend, receive, restore, and related functions)
  * Improved error handling across all seed-dependent operations to prevent incomplete execution

* **Tests**
  * Added test coverage validating proper error handling when seed phrase is missing from fund operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #654