### PR TITLE
Fix/giftwrap broadcast auth

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -911,14 +911,15 @@ class RelayManager<T> {
       return;
     }
 
-    // Get account to authenticate (use the event's author)
-    Account? account;
+    // Prefer authenticating as the event author. Gift wraps and other
+    // ephemeral-author events may not have a matching account, so fall back to
+    // the currently logged-in account when needed.
+    Account? account = _accounts?.accounts[eventToResend.pubKey];
     final loggedAccount = _accounts?.getLoggedAccount();
-    if (loggedAccount != null && loggedAccount.pubkey == eventToResend.pubKey) {
+    if ((account == null || !account.signer.canSign()) &&
+        loggedAccount != null &&
+        loggedAccount.pubkey != account?.pubkey) {
       account = loggedAccount;
-    } else {
-      // Try to find an account that matches the event author
-      account = _accounts?.accounts[eventToResend.pubKey];
     }
 
     if (account == null || !account.signer.canSign()) {

--- a/packages/ndk/test/usecases/nip42_auth_test.dart
+++ b/packages/ndk/test/usecases/nip42_auth_test.dart
@@ -89,6 +89,55 @@ void main() {
     await relay.stopServer();
   });
 
+  test('gift wrap broadcast on auth-required relay should authenticate as sender',
+      timeout: const Timeout(Duration(seconds: 5)), () async {
+    final senderKey = Bip340.generatePrivateKey();
+    final recipientKey = Bip340.generatePrivateKey();
+    final relay = MockRelay(
+      name: "gift wrap auth relay",
+      explicitPort: 5107,
+      requireAuthForEvents: true,
+    );
+
+    await relay.startServer();
+
+    final ndk = Ndk(NdkConfig(
+      eventVerifier: MockEventVerifier(),
+      cache: MemCacheManager(),
+      bootstrapRelays: [relay.url],
+      defaultBroadcastTimeout: const Duration(milliseconds: 300),
+    ));
+
+    addTearDown(() async {
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    ndk.accounts.loginPrivateKey(
+      pubkey: senderKey.publicKey,
+      privkey: senderKey.privateKey!,
+    );
+
+    final rumor = await ndk.giftWrap.createRumor(
+      content: "gift wrap auth-required broadcast",
+      kind: Nip01Event.kTextNodeKind,
+      tags: [
+        ["p", recipientKey.publicKey]
+      ],
+    );
+    final giftWrap = await ndk.giftWrap.toGiftWrap(
+      rumor: rumor,
+      recipientPubkey: recipientKey.publicKey,
+    );
+
+    final result = await ndk.broadcast.broadcast(
+      nostrEvent: giftWrap,
+      specificRelays: [relay.url],
+    ).broadcastDoneFuture;
+
+    expect(result.any((r) => r.broadcastSuccessful), isTrue);
+  });
+
   test(
       'request should complete when relay requires auth but sends no challenge',
       timeout: const Timeout(Duration(seconds: 5)), () async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account selection logic when broadcasting to relays requiring authentication. The system now better determines which account to use for authorization signing during broadcasts.

* **Tests**
  * Added test coverage verifying gift-wrap events authenticate and broadcast successfully to relays with authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->