### PR TITLE
Fix/nip59 giftwrap timestamp randomization

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
+++ b/packages/ndk/lib/domain_layer/usecases/gift_wrap/gift_wrap.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import '../../../data_layer/models/nip_01_event_model.dart';
 import '../../entities/gift_wrap_unwrap_result.dart';
@@ -10,6 +11,8 @@ import '../accounts/accounts.dart';
 class GiftWrap {
   static const int kSealEventKind = 13;
   static const int kGiftWrapEventkind = 1059;
+  static const int _createdAtRandomizationWindowSeconds = 172800;
+  static final Random _random = Random.secure();
 
   final Accounts accounts;
   final EventVerifier eventVerifier;
@@ -44,16 +47,20 @@ class GiftWrap {
     required String recipientPubkey,
     EventSigner? customSigner,
   }) async {
+    final sealCreatedAt = _randomCreatedAtBefore(rumor.createdAt);
+
     final sealedRumor = await sealRumor(
       rumor: rumor,
       recipientPubkey: recipientPubkey,
       customSigner: customSigner,
+      createdAt: sealCreatedAt,
     );
 
     final giftWrap = await wrapEvent(
       recipientPublicKey: recipientPubkey,
       sealEvent: sealedRumor,
       eventSignerFactory: eventSignerFactory,
+      randomizeCreatedAtBefore: rumor.createdAt,
     );
     return giftWrap;
   }
@@ -157,6 +164,7 @@ class GiftWrap {
     required Nip01Event rumor,
     required String recipientPubkey,
     EventSigner? customSigner,
+    int? createdAt,
   }) async {
     final signer = _getSigner(customSigner: customSigner);
 
@@ -174,6 +182,7 @@ class GiftWrap {
       kind: kSealEventKind,
       tags: [],
       content: encryptedContent,
+      createdAt: createdAt ?? _randomCreatedAtBefore(rumor.createdAt),
     );
 
     // Sign the seal event (required by NIP-59)
@@ -226,12 +235,16 @@ class GiftWrap {
   /// [recipientPublicKey] the reciever of the rumor \
   /// [sealEvent] not wrapped event \
   /// [eventSignerFactory] factory to create event signers \
+  /// [createdAt] exact created_at timestamp to use for the gift wrap \
+  /// [randomizeCreatedAtBefore] randomizes created_at in the 2 days before this timestamp \
   /// [returns] giftWrapEvent
   static Future<Nip01Event> wrapEvent({
     required String recipientPublicKey,
     required Nip01Event sealEvent,
     List<List<String>>? additionalTags,
     required LocalEventSignerFactory eventSignerFactory,
+    int? createdAt,
+    int? randomizeCreatedAtBefore,
   }) async {
     // Generate a random one-time-use keypair
     final ephemeralSigner = eventSignerFactory.createWithNewKeyPair();
@@ -254,14 +267,17 @@ class GiftWrap {
       tags.addAll(additionalTags);
     }
 
-    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final giftWrapCreatedAt = createdAt ??
+        (randomizeCreatedAtBefore != null
+            ? _randomCreatedAtBefore(randomizeCreatedAtBefore)
+            : sealEvent.createdAt);
 
     // Create the gift wrap event with ephemeral keys
     final giftWrapEvent = Nip01Event(
       kind: kGiftWrapEventkind,
       content: encryptedSeal,
       tags: tags,
-      createdAt: now,
+      createdAt: giftWrapCreatedAt,
       pubKey: ephemeralSigner.getPublicKey(),
     );
 
@@ -292,5 +308,11 @@ class GiftWrap {
     final Map<String, dynamic> sealJson = jsonDecode(decryptedEventJson);
     final event = Nip01EventModel.fromJson(sealJson);
     return event;
+  }
+
+  static int _randomCreatedAtBefore(int referenceCreatedAt) {
+    return referenceCreatedAt -
+        _random.nextInt(_createdAtRandomizationWindowSeconds) -
+        1;
   }
 }

--- a/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
+++ b/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
@@ -119,6 +119,46 @@ void main() {
     });
 
     test(
+        'NIP-17 DM gift wrap and seal timestamps should be randomized in the 2 days before the rumor createdAt',
+        () async {
+      const twoDaysInSeconds = 172800;
+
+      final rumor = Nip01Event(
+        pubKey: key1.publicKey,
+        content: 'Test NIP-17 direct message',
+        kind: 14,
+        tags: [
+          ['p', key2.publicKey],
+        ],
+      );
+      final baseCreatedAt = rumor.createdAt;
+
+      final giftWrap = await giftWrapService.toGiftWrap(
+        rumor: rumor,
+        recipientPubkey: key2.publicKey,
+      );
+
+      expect(giftWrap.createdAt,
+          greaterThanOrEqualTo(baseCreatedAt - twoDaysInSeconds));
+      expect(giftWrap.createdAt, lessThan(baseCreatedAt));
+
+      ndk.accounts
+          .loginPrivateKey(pubkey: key2.publicKey, privkey: key2.privateKey!);
+
+      final seal = await giftWrapService.unwrapEvent(wrappedEvent: giftWrap);
+
+      expect(seal.createdAt,
+          greaterThanOrEqualTo(baseCreatedAt - twoDaysInSeconds));
+      expect(seal.createdAt, lessThan(baseCreatedAt));
+      expect(seal.createdAt, isNot(equals(giftWrap.createdAt)));
+
+      final unwrappedRumor = await giftWrapService.fromGiftWrap(
+        giftWrap: giftWrap,
+      );
+      expect(unwrappedRumor.createdAt, equals(rumor.createdAt));
+    });
+
+    test(
         'Can use custom signer instead of logged-in account for wrap and unwrap',
         () async {
       // Create a custom signer with key3 (different from logged-in key1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gift-wrapping now randomizes timestamps within a 2-day window for enhanced privacy.

* **Tests**
  * Added test to verify timestamp randomization behavior in gift-wrap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->