### PR TITLE
Fix/mock relay tag filtering

### DIFF
--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -449,6 +449,10 @@ class MockRelay {
         }
       }
 
+      eventsForThisFilter = eventsForThisFilter
+          .where((event) => _matchesTagFilters(event, filter))
+          .toList();
+
       // Apply limit per filter - sort by created_at desc and take limit
       if (filter.limit != null && eventsForThisFilter.length > filter.limit!) {
         eventsForThisFilter.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -593,29 +597,22 @@ class MockRelay {
       return false;
     }
 
-    // Check #p tag filter
-    if (filter.pTags != null) {
-      List<String> eventPTags = event.tags
-          .where((tag) => tag.isNotEmpty && tag[0] == 'p')
-          .map((tag) => tag[1])
-          .toList();
-      if (!filter.pTags!.any((pTag) => eventPTags.contains(pTag))) {
-        return false;
-      }
-    }
+    return _matchesTagFilters(event, filter);
+  }
 
-    // Check #e tag filter
-    if (filter.eTags != null) {
-      List<String> eventETags = event.tags
-          .where((tag) => tag.isNotEmpty && tag[0] == 'e')
-          .map((tag) => tag[1])
-          .toList();
-      if (!filter.eTags!.any((eTag) => eventETags.contains(eTag))) {
-        return false;
-      }
-    }
+  bool _matchesTagFilters(Nip01Event event, Filter filter) {
+    if (filter.tags == null) return true;
 
-    return true;
+    return filter.tags!.entries.every((filterTag) {
+      final tagName = filterTag.key.startsWith('#')
+          ? filterTag.key.substring(1)
+          : filterTag.key;
+
+      return event.tags.any((eventTag) =>
+          eventTag.length > 1 &&
+          eventTag[0] == tagName &&
+          filterTag.value.contains(eventTag[1]));
+    });
   }
 
   Future<void> stopServer() async {

--- a/packages/ndk/test/mocks/mock_relay_tag_filter_test.dart
+++ b/packages/ndk/test/mocks/mock_relay_tag_filter_test.dart
@@ -1,0 +1,85 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import 'mock_event_verifier.dart';
+import 'mock_relay.dart';
+
+void main() {
+  test('REQ with #r=a only returns events tagged r=a', () async {
+    final relay = MockRelay(
+      name: 'tag-filter-test-relay',
+      explicitPort: 4080,
+    );
+    await relay.startServer();
+    addTearDown(relay.stopServer);
+
+    final keyPair = Bip340.generatePrivateKey();
+    final writer = Ndk(
+      NdkConfig(
+        cache: MemCacheManager(),
+        eventVerifier: MockEventVerifier(),
+        bootstrapRelays: [relay.url],
+      ),
+    );
+    addTearDown(writer.destroy);
+
+    final matchingEvent = Nip01Utils.signWithPrivateKey(
+      event: Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: [
+          ['r', 'a'],
+        ],
+        content: 'matching event',
+      ),
+      privateKey: keyPair.privateKey!,
+    );
+    final nonMatchingEvent = Nip01Utils.signWithPrivateKey(
+      event: Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: [
+          ['r', 'b'],
+        ],
+        content: 'non-matching event',
+      ),
+      privateKey: keyPair.privateKey!,
+    );
+
+    await writer.broadcast.broadcast(
+      nostrEvent: matchingEvent,
+      specificRelays: [relay.url],
+    ).broadcastDoneFuture;
+    await writer.broadcast.broadcast(
+      nostrEvent: nonMatchingEvent,
+      specificRelays: [relay.url],
+    ).broadcastDoneFuture;
+
+    final reader = Ndk(
+      NdkConfig(
+        cache: MemCacheManager(),
+        eventVerifier: MockEventVerifier(),
+        bootstrapRelays: [relay.url],
+      ),
+    );
+    addTearDown(reader.destroy);
+
+    final query = reader.requests.query(
+      filter: Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        tags: {
+          '#r': ['a'],
+        },
+      ),
+    );
+
+    final receivedEvents = await query.future;
+
+    expect(
+      receivedEvents.map((event) => event.id),
+      equals([matchingEvent.id]),
+      reason: 'The relay must not return an event whose r tag is not "a".',
+    );
+  });
+}

--- a/packages/ndk/test/mocks/mock_relay_tag_filter_test.dart
+++ b/packages/ndk/test/mocks/mock_relay_tag_filter_test.dart
@@ -1,5 +1,6 @@
 import 'package:ndk/ndk.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:test/test.dart';
 
 import 'mock_event_verifier.dart';
@@ -7,65 +8,18 @@ import 'mock_relay.dart';
 
 void main() {
   test('REQ with #r=a only returns events tagged r=a', () async {
-    final relay = MockRelay(
-      name: 'tag-filter-test-relay',
-      explicitPort: 4080,
-    );
-    await relay.startServer();
-    addTearDown(relay.stopServer);
-
     final keyPair = Bip340.generatePrivateKey();
-    final writer = Ndk(
-      NdkConfig(
-        cache: MemCacheManager(),
-        eventVerifier: MockEventVerifier(),
-        bootstrapRelays: [relay.url],
-      ),
-    );
-    addTearDown(writer.destroy);
+    final matchingEvent = _signedNote(keyPair, [
+      ['r', 'a'],
+    ]);
+    final nonMatchingEvent = _signedNote(keyPair, [
+      ['r', 'b'],
+    ]);
 
-    final matchingEvent = Nip01Utils.signWithPrivateKey(
-      event: Nip01Event(
-        pubKey: keyPair.publicKey,
-        kind: Nip01Event.kTextNodeKind,
-        tags: [
-          ['r', 'a'],
-        ],
-        content: 'matching event',
-      ),
-      privateKey: keyPair.privateKey!,
-    );
-    final nonMatchingEvent = Nip01Utils.signWithPrivateKey(
-      event: Nip01Event(
-        pubKey: keyPair.publicKey,
-        kind: Nip01Event.kTextNodeKind,
-        tags: [
-          ['r', 'b'],
-        ],
-        content: 'non-matching event',
-      ),
-      privateKey: keyPair.privateKey!,
-    );
-
-    await writer.broadcast.broadcast(
-      nostrEvent: matchingEvent,
-      specificRelays: [relay.url],
-    ).broadcastDoneFuture;
-    await writer.broadcast.broadcast(
-      nostrEvent: nonMatchingEvent,
-      specificRelays: [relay.url],
-    ).broadcastDoneFuture;
-
-    final reader = Ndk(
-      NdkConfig(
-        cache: MemCacheManager(),
-        eventVerifier: MockEventVerifier(),
-        bootstrapRelays: [relay.url],
-      ),
-    );
-    addTearDown(reader.destroy);
-
-    final query = reader.requests.query(
+    final received = await _queryRelay(
+      port: 4080,
+      relayName: 'tag-filter-test-relay',
+      events: [matchingEvent, nonMatchingEvent],
       filter: Filter(
         kinds: [Nip01Event.kTextNodeKind],
         tags: {
@@ -74,12 +28,183 @@ void main() {
       ),
     );
 
-    final receivedEvents = await query.future;
-
     expect(
-      receivedEvents.map((event) => event.id),
+      received.map((event) => event.id),
       equals([matchingEvent.id]),
       reason: 'The relay must not return an event whose r tag is not "a".',
     );
   });
+
+  test('REQ with #p still filters previously-supported pubkey tags', () async {
+    final keyPair = Bip340.generatePrivateKey();
+    final taggedPubkey = Bip340.generatePrivateKey().publicKey;
+    final otherPubkey = Bip340.generatePrivateKey().publicKey;
+
+    final matchingEvent = _signedNote(keyPair, [
+      ['p', taggedPubkey],
+    ]);
+    final nonMatchingEvent = _signedNote(keyPair, [
+      ['p', otherPubkey],
+    ]);
+
+    final received = await _queryRelay(
+      port: 4081,
+      relayName: 'p-tag-filter-test-relay',
+      events: [matchingEvent, nonMatchingEvent],
+      filter: Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        pTags: [taggedPubkey],
+      ),
+    );
+
+    expect(
+      received.map((event) => event.id),
+      equals([matchingEvent.id]),
+      reason: 'The #p tag must keep filtering through the generic tag path.',
+    );
+  });
+
+  test('REQ with #e still filters previously-supported event tags', () async {
+    final keyPair = Bip340.generatePrivateKey();
+    final taggedEventId = 'a' * 64;
+    final otherEventId = 'b' * 64;
+
+    final matchingEvent = _signedNote(keyPair, [
+      ['e', taggedEventId],
+    ]);
+    final nonMatchingEvent = _signedNote(keyPair, [
+      ['e', otherEventId],
+    ]);
+
+    final received = await _queryRelay(
+      port: 4082,
+      relayName: 'e-tag-filter-test-relay',
+      events: [matchingEvent, nonMatchingEvent],
+      filter: Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        eTags: [taggedEventId],
+      ),
+    );
+
+    expect(
+      received.map((event) => event.id),
+      equals([matchingEvent.id]),
+      reason: 'The #e tag must keep filtering through the generic tag path.',
+    );
+  });
+
+  test('REQ with multiple tags requires all of them to match (AND)', () async {
+    final keyPair = Bip340.generatePrivateKey();
+    final taggedPubkey = Bip340.generatePrivateKey().publicKey;
+
+    final bothEvent = _signedNote(keyPair, [
+      ['r', 'a'],
+      ['p', taggedPubkey],
+    ]);
+    final onlyREvent = _signedNote(keyPair, [
+      ['r', 'a'],
+    ]);
+    final onlyPEvent = _signedNote(keyPair, [
+      ['p', taggedPubkey],
+    ]);
+
+    final received = await _queryRelay(
+      port: 4083,
+      relayName: 'multi-tag-filter-test-relay',
+      events: [bothEvent, onlyREvent, onlyPEvent],
+      filter: Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        tags: {
+          '#r': ['a'],
+          '#p': [taggedPubkey],
+        },
+      ),
+    );
+
+    expect(
+      received.map((event) => event.id),
+      equals([bothEvent.id]),
+      reason: 'An event must match every requested tag, not just one of them.',
+    );
+  });
+
+  test('REQ safely skips malformed single-element tags', () async {
+    final keyPair = Bip340.generatePrivateKey();
+    final malformedEvent = _signedNote(keyPair, [
+      ['r'],
+    ]);
+    final validEvent = _signedNote(keyPair, [
+      ['r', 'a'],
+    ]);
+
+    final received = await _queryRelay(
+      port: 4084,
+      relayName: 'malformed-tag-filter-test-relay',
+      events: [malformedEvent, validEvent],
+      filter: Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        tags: {
+          '#r': ['a'],
+        },
+      ),
+    );
+
+    expect(
+      received.map((event) => event.id),
+      equals([validEvent.id]),
+      reason: 'A value-less tag like ["r"] must be skipped without crashing.',
+    );
+  });
+}
+
+Nip01Event _signedNote(KeyPair keyPair, List<List<String>> tags) {
+  return Nip01Utils.signWithPrivateKey(
+    event: Nip01Event(
+      pubKey: keyPair.publicKey,
+      kind: Nip01Event.kTextNodeKind,
+      tags: tags,
+      content: 'test event',
+    ),
+    privateKey: keyPair.privateKey!,
+  );
+}
+
+/// Broadcasts [events] to a fresh [MockRelay] and returns the events a reader
+/// receives back for [filter].
+Future<List<Nip01Event>> _queryRelay({
+  required int port,
+  required String relayName,
+  required List<Nip01Event> events,
+  required Filter filter,
+}) async {
+  final relay = MockRelay(name: relayName, explicitPort: port);
+  await relay.startServer();
+  addTearDown(relay.stopServer);
+
+  final writer = Ndk(
+    NdkConfig(
+      cache: MemCacheManager(),
+      eventVerifier: MockEventVerifier(),
+      bootstrapRelays: [relay.url],
+    ),
+  );
+  addTearDown(writer.destroy);
+
+  for (final event in events) {
+    await writer.broadcast.broadcast(
+      nostrEvent: event,
+      specificRelays: [relay.url],
+    ).broadcastDoneFuture;
+  }
+
+  final reader = Ndk(
+    NdkConfig(
+      cache: MemCacheManager(),
+      eventVerifier: MockEventVerifier(),
+      bootstrapRelays: [relay.url],
+    ),
+  );
+  addTearDown(reader.destroy);
+
+  return reader.requests.query(filter: filter).future;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag-based event filtering in relay query responses, so results now respect multiple tag constraints more consistently.
  * Fixed handling of tag filters so malformed tag entries are safely ignored instead of causing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->