### PR TITLE
fix(ndk_flutter): migrate Android plugin to Built-in Kotlin

### DIFF
--- a/packages/ndk_flutter/android/build.gradle
+++ b/packages/ndk_flutter/android/build.gradle
@@ -21,7 +21,11 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// AGP 9+ bundles Kotlin (Flutter Built-in Kotlin); only apply KGP ourselves on older AGP.
+// Must stay on one line: Flutter's detection flags any line starting with `apply plugin: 'kotlin-android'`.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) { apply plugin: 'kotlin-android' }
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -33,10 +37,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {
@@ -64,6 +64,12 @@ android {
                 showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
Apply the Kotlin Gradle Plugin only on AGP < 9 so Flutter 3.44+ stops flagging ndk_flutter as applying KGP and future Flutter versions keep building. The conditional stays on one line so Flutter's source-level detection does not re-trigger the warning. Replace the deprecated kotlinOptions block with kotlin { compilerOptions }, which also works under AGP 9. Remains compatible with Flutter < 3.44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build compatibility with newer tooling versions.
  * Updated Kotlin compilation settings to use a consistent JVM 17 target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->