### PR TITLE
Fix/external signer returned event

### DIFF
--- a/packages/ndk_flutter/lib/data_layer/repositories/signers/nip55_event_signer.dart
+++ b/packages/ndk_flutter/lib/data_layer/repositories/signers/nip55_event_signer.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:ndk/ndk.dart';
 import 'package:rxdart/rxdart.dart';
@@ -129,7 +130,16 @@ class Nip55EventSigner with ConcurrencyLimiterMixin implements EventSigner {
         eventJson: Nip01EventModel.fromEntity(event).toJsonString(),
         id: requestId,
       );
-      return event.copyWith(sig: _extractResult(map));
+      final signature = _extractResult(map);
+
+      // Prefer the event the signer actually signed, when it returns one.
+      final signedEventJson = map['event'] as String?;
+      if (signedEventJson == null || signedEventJson.isEmpty) {
+        return event.copyWith(sig: signature);
+      }
+      return Nip01EventModel.fromJson(
+        jsonDecode(signedEventJson) as Map<dynamic, dynamic>,
+      );
     }, event: event);
   }
 

--- a/packages/ndk_flutter/lib/signers/src/nip07_event_signer_web.dart
+++ b/packages/ndk_flutter/lib/signers/src/nip07_event_signer_web.dart
@@ -233,7 +233,16 @@ class Nip07EventSigner with ConcurrencyLimiterMixin implements EventSigner {
             .toJS;
 
       final signedEvent = await js.nostr!.signEvent(jsEvent).toDart;
-      return event.copyWith(id: signedEvent.id!, sig: signedEvent.sig!);
+
+      return event.copyWith(
+        id: signedEvent.id!,
+        sig: signedEvent.sig!,
+        pubKey: signedEvent.pubkey,
+        createdAt: signedEvent.created_at,
+        kind: signedEvent.kind,
+        content: signedEvent.content,
+        tags: signedEvent.tagsList,
+      );
     }, event: event);
   }
 

--- a/packages/ndk_flutter/test/nip07_event_signer_test.dart
+++ b/packages/ndk_flutter/test/nip07_event_signer_test.dart
@@ -41,9 +41,20 @@ void injectSetupCode() {
         _privkeyHex: privateKeyHex,
         _pubkey: publicKeyHex,
         _hang: false,
+        _stripClientTag: false,
 
         setHang: function(hang) {
           this._hang = hang;
+        },
+
+        setStripClientTag: function(strip) {
+          this._stripClientTag = strip;
+        },
+
+        setAccount: function(privkeyHex) {
+          this._privkeyHex = privkeyHex;
+          this._privkey = hexToBytes(privkeyHex);
+          this._pubkey = getPublicKey(this._privkey);
         },
 
         getPublicKey: function() {
@@ -54,10 +65,13 @@ void injectSetupCode() {
         },
 
         signEvent: async function(event) {
+          const tags = this._stripClientTag
+            ? event.tags.filter(function(tag) { return tag[0] !== 'client'; })
+            : event.tags;
           const eventToSign = {
             kind: event.kind,
             created_at: event.created_at,
-            tags: event.tags,
+            tags: tags,
             content: event.content,
             pubkey: event.pubkey,
           };
@@ -156,6 +170,58 @@ void main() {
       );
 
       final signedEvent = await nip07Signer.sign(event);
+      expect(await Bip340EventVerifier().verify(signedEvent), isTrue);
+    });
+
+    test(
+      'sign returns the event as signed when extension strips client tag',
+      () async {
+        await setupNostrExtension();
+        eval('window.nostr.setStripClientTag(true);');
+
+        final pubkey = await nip07Signer.getPublicKeyAsync();
+        final event = Nip01Event(
+          pubKey: pubkey,
+          kind: 1,
+          tags: [
+            ['client', 'ndk'],
+            ['t', 'nostr'],
+          ],
+          content: 'test content',
+          createdAt: 1234567890,
+        );
+
+        final signedEvent = await nip07Signer.sign(event);
+
+        expect(
+          signedEvent.tags,
+          equals([
+            ['t', 'nostr'],
+          ]),
+        );
+        expect(await Bip340EventVerifier().verify(signedEvent), isTrue);
+      },
+    );
+
+    test('sign returns the event as signed when the account changed', () async {
+      await setupNostrExtension();
+
+      final cachedPubKey = await nip07Signer.getPublicKeyAsync();
+      eval("window.nostr.setAccount('${bip340EventSigner.privateKey}');");
+
+      final event = Nip01Event(
+        pubKey: cachedPubKey,
+        kind: 1,
+        tags: [
+          ['t', 'nostr'],
+        ],
+        content: 'test content',
+        createdAt: 1234567890,
+      );
+
+      final signedEvent = await nip07Signer.sign(event);
+
+      expect(signedEvent.pubKey, equals(bip340EventSigner.publicKey));
       expect(await Bip340EventVerifier().verify(signedEvent), isTrue);
     });
 

--- a/packages/ndk_flutter/test/nip55_event_signer_test.dart
+++ b/packages/ndk_flutter/test/nip55_event_signer_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ndk/ndk.dart';
+import 'package:ndk_flutter/data_layer/data_sources/nip55_signer.dart';
+import 'package:ndk_flutter/data_layer/repositories/signers/nip55_event_signer.dart';
+
+class _FakeNip55Signer extends Nip55Signer {
+  _FakeNip55Signer(this.response);
+
+  final Map<dynamic, dynamic> response;
+
+  @override
+  Future<Map<dynamic, dynamic>> signEvent({
+    required String currentUser,
+    required String eventJson,
+    String? id,
+  }) async {
+    return response;
+  }
+}
+
+void main() {
+  const privateKey =
+      'e4bd52924bce6a9c58d2decc7fe91b376d6a6513fc615aabc9e071f2b436b127';
+  const publicKey =
+      '953f12b4f6966a289fde9adfc511e00a66cfa4cb9d69551dee51f3f387e8e277';
+  const stalePublicKey =
+      'e247d5da03bab4206b4d6ef5d9db0e175e0dbf51585fa16345dd53abdd2d9259';
+
+  group('Nip55EventSigner', () {
+    test(
+      'sign returns the event the external signer actually signed',
+      () async {
+        final externalSigner = Bip340EventSigner(
+          privateKey: privateKey,
+          publicKey: publicKey,
+        );
+        final actuallySigned = await externalSigner.sign(
+          Nip01Event(
+            pubKey: publicKey,
+            kind: 1,
+            tags: [
+              ['t', 'nostr'],
+            ],
+            content: 'test content',
+            createdAt: 1234567890,
+          ),
+        );
+
+        final signer = Nip55EventSigner(
+          publicKey: stalePublicKey,
+          nip55Signer: _FakeNip55Signer({
+            'signature': actuallySigned.sig,
+            'event': Nip01EventModel.fromEntity(actuallySigned).toJsonString(),
+          }),
+        );
+        addTearDown(signer.dispose);
+
+        final signedEvent = await signer.sign(
+          Nip01Event(
+            pubKey: stalePublicKey,
+            kind: 1,
+            tags: [
+              ['t', 'nostr'],
+            ],
+            content: 'test content',
+            createdAt: 1234567890,
+          ),
+        );
+
+        expect(signedEvent.pubKey, equals(publicKey));
+        expect(signedEvent.id, equals(actuallySigned.id));
+        expect(await Bip340EventVerifier().verify(signedEvent), isTrue);
+      },
+    );
+
+    test(
+      'sign keeps the local event when the signer returns no event',
+      () async {
+        const signature = 'ab12';
+
+        final signer = Nip55EventSigner(
+          publicKey: publicKey,
+          nip55Signer: _FakeNip55Signer({'signature': signature}),
+        );
+        addTearDown(signer.dispose);
+
+        final event = Nip01Event(
+          pubKey: publicKey,
+          kind: 1,
+          tags: [],
+          content: 'test content',
+          createdAt: 1234567890,
+        );
+
+        final signedEvent = await signer.sign(event);
+
+        expect(signedEvent.id, equals(event.id));
+        expect(signedEvent.sig, equals(signature));
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event signing through browser and external signers by preserving all signer-provided event details, including public keys, timestamps, content, tags, IDs, and signatures.
  - Added support for signed event data returned by external signing services, with a safe fallback when no complete event is provided.
  - Improved account switching and optional client-tag removal during browser-based signing.
- **Tests**
  - Expanded coverage for external signing, signature validation, account changes, and client-tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->