### PR TITLE
fix: include target relays and request lifetime in the request dedup key

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/requests/concurrency_check.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/concurrency_check.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
-import '../../entities/filter.dart';
 import '../../entities/global_state.dart';
+import '../../entities/ndk_request.dart';
 import '../../entities/request_state.dart';
 
 class ConcurrencyCheck {
@@ -13,7 +13,7 @@ class ConcurrencyCheck {
   /// checks if the request is already served (based on filters) and if so adds the stream.
   /// returns true if the response stream got replaced
   bool check(RequestState requestState) {
-    final hash = _hashFilters(requestState.request.filters);
+    final hash = _hashRequest(requestState.request);
 
     // check if its not already served
     if (!_globalState.inFlightRequests.containsKey(hash)) {
@@ -37,10 +37,29 @@ class ConcurrencyCheck {
     return true;
   }
 
-  String _hashFilters(List<Filter> filters) {
-    final jsonString = json.encode(filters);
+  /// Two requests are only interchangeable when they also target the same
+  /// relays and share the same lifetime. Merging a subscription with a query
+  /// kills one of them: the subscription would close on EOSE, or the query
+  /// would await a stream that never ends.
+  String _hashRequest(NdkRequest request) {
+    final jsonString = json.encode({
+      'filters': request.filters,
+      'closeOnEOSE': request.closeOnEOSE,
+      'explicitRelays': _sorted(request.explicitRelays),
+      'relaySet': request.relaySet == null
+          ? null
+          : {
+              'id': request.relaySet!.id,
+              'urls': _sorted(request.relaySet!.urls),
+            },
+    });
     final bytes = utf8.encode(jsonString);
     final hash = sha256.convert(bytes);
     return hash.toString();
+  }
+
+  List<String>? _sorted(Iterable<String>? values) {
+    if (values == null) return null;
+    return values.toList()..sort();
   }
 }

--- a/packages/ndk/test/scenarios/concurrent_same_filter_different_relays_test.dart
+++ b/packages/ndk/test/scenarios/concurrent_same_filter_different_relays_test.dart
@@ -62,12 +62,12 @@ void main() {
 
       expect(
         results[0].map((e) => e.id),
-        contains(noteOnRelay1.id),
+        orderedEquals([noteOnRelay1.id]),
         reason: 'query on relay 1 should return the event stored on relay 1',
       );
       expect(
         results[1].map((e) => e.id),
-        contains(noteOnRelay2.id),
+        unorderedEquals([noteOnRelay2.id]),
         reason: 'query on relay 2 should return the event stored on relay 2',
       );
     },

--- a/packages/ndk/test/scenarios/concurrent_same_filter_different_relays_test.dart
+++ b/packages/ndk/test/scenarios/concurrent_same_filter_different_relays_test.dart
@@ -1,0 +1,75 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:ndk/shared/nips/nip01/key_pair.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_event_verifier.dart';
+import '../mocks/mock_relay.dart';
+
+void main() {
+  Nip01Event textNote(KeyPair key, String content) {
+    return Nip01Event(
+      kind: Nip01Event.kTextNodeKind,
+      pubKey: key.publicKey,
+      content: content,
+      tags: [],
+      createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+  }
+
+  test(
+    'same filter on two different relays should not share results',
+    () async {
+      final key = Bip340.generatePrivateKey();
+
+      final noteOnRelay1 = textNote(key, "note only on relay 1");
+      final noteOnRelay2 = textNote(key, "note only on relay 2");
+
+      final relay1 = MockRelay(name: "relay 1");
+      final relay2 = MockRelay(name: "relay 2");
+
+      await relay1.startServer(textNotes: {key: noteOnRelay1});
+      await relay2.startServer(textNotes: {key: noteOnRelay2});
+      addTearDown(relay1.stopServer);
+      addTearDown(relay2.stopServer);
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay1.url, relay2.url],
+        ),
+      );
+      addTearDown(ndk.destroy);
+
+      await ndk.connectivity.relayConnectivityChanges
+          .firstWhere(
+            (relays) =>
+                relays[relay1.url]?.isConnected == true &&
+                relays[relay2.url]?.isConnected == true,
+          )
+          .timeout(const Duration(seconds: 10));
+
+      final filter = Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        authors: [key.publicKey],
+      );
+
+      final results = await Future.wait([
+        ndk.requests.query(filter: filter, explicitRelays: [relay1.url]).future,
+        ndk.requests.query(filter: filter, explicitRelays: [relay2.url]).future,
+      ]);
+
+      expect(
+        results[0].map((e) => e.id),
+        contains(noteOnRelay1.id),
+        reason: 'query on relay 1 should return the event stored on relay 1',
+      );
+      expect(
+        results[1].map((e) => e.id),
+        contains(noteOnRelay2.id),
+        reason: 'query on relay 2 should return the event stored on relay 2',
+      );
+    },
+  );
+}

--- a/packages/ndk/test/scenarios/subscription_cache_read_dedup_test.dart
+++ b/packages/ndk/test/scenarios/subscription_cache_read_dedup_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_event_verifier.dart';
+import '../mocks/mock_relay.dart';
+
+/// Both tests use `cacheRead: true` on a subscription, which is not the default.
+/// They probe what the concurrency check does once subscriptions become
+/// eligible for it.
+void main() {
+  group('subscription with cacheRead enabled', () {
+    late MockRelay queryRelay;
+    late MockRelay subscriptionRelay;
+
+    setUp(() async {
+      queryRelay = MockRelay(name: "query relay");
+      subscriptionRelay = MockRelay(name: "subscription relay");
+      await queryRelay.startServer();
+      await subscriptionRelay.startServer();
+    });
+
+    tearDown(() async {
+      await queryRelay.stopServer();
+      await subscriptionRelay.stopServer();
+    });
+
+    Future<void> waitForSubscriptionRegistration(MockRelay relay) async {
+      final deadline = DateTime.now().add(const Duration(seconds: 2));
+      while (DateTime.now().isBefore(deadline)) {
+        if (relay.activeSubscriptionCount > 0) return;
+        await Future.delayed(const Duration(milliseconds: 25));
+      }
+      throw TimeoutException('MockRelay did not register the subscription.');
+    }
+
+    Ndk createNdk() => Ndk(
+      NdkConfig(
+        cache: MemCacheManager(),
+        eventVerifier: MockEventVerifier(),
+        bootstrapRelays: [queryRelay.url, subscriptionRelay.url],
+      ),
+    );
+
+    test(
+      'keeps receiving live events when a query shares its filter',
+      () async {
+        final key = Bip340.generatePrivateKey();
+
+        final ndk = createNdk();
+        addTearDown(ndk.destroy);
+
+        final publisher = createNdk();
+        addTearDown(publisher.destroy);
+
+        final filter = Filter(
+          kinds: [Nip01Event.kTextNodeKind],
+          authors: [key.publicKey],
+        );
+
+        // query first so it owns the in-flight entry for this filter
+        final query = ndk.requests.query(
+          filter: filter.clone(),
+          explicitRelays: [queryRelay.url],
+        );
+        final subscription = ndk.requests.subscription(
+          filter: filter.clone(),
+          explicitRelays: [subscriptionRelay.url],
+          cacheRead: true,
+        );
+
+        final liveEvent = Completer<Nip01Event>();
+        subscription.stream.listen((event) {
+          if (!liveEvent.isCompleted) liveEvent.complete(event);
+        });
+
+        await query.future;
+        await waitForSubscriptionRegistration(subscriptionRelay);
+
+        final event = Nip01Utils.signWithPrivateKey(
+          event: Nip01Event(
+            pubKey: key.publicKey,
+            kind: Nip01Event.kTextNodeKind,
+            tags: [],
+            content: 'event published after the query finished',
+          ),
+          privateKey: key.privateKey!,
+        );
+
+        await publisher.broadcast
+            .broadcast(
+              nostrEvent: event,
+              specificRelays: [subscriptionRelay.url],
+            )
+            .broadcastDoneFuture;
+
+        final received = await liveEvent.future.timeout(
+          const Duration(seconds: 3),
+          onTimeout: () => throw TimeoutException(
+            'subscription received no live event: it was merged into the query '
+            'and closed at EOSE',
+          ),
+        );
+
+        expect(received.id, equals(event.id));
+      },
+    );
+
+    test('does not stall a query that shares its filter', () async {
+      final key = Bip340.generatePrivateKey();
+
+      final ndk = createNdk();
+      addTearDown(ndk.destroy);
+
+      final filter = Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        authors: [key.publicKey],
+      );
+
+      // same relay on both, so only the request lifetime differs
+      final subscription = ndk.requests.subscription(
+        filter: filter.clone(),
+        explicitRelays: [queryRelay.url],
+        cacheRead: true,
+      );
+      subscription.stream.listen((_) {});
+
+      await waitForSubscriptionRegistration(queryRelay);
+
+      final events = await ndk.requests
+          .query(filter: filter.clone(), explicitRelays: [queryRelay.url])
+          .future
+          .timeout(
+            const Duration(seconds: 3),
+            onTimeout: () => throw TimeoutException(
+              'query never completed: it was merged into a subscription stream '
+              'that never closes, and its own timeout was cancelled',
+            ),
+          );
+
+      expect(events, isEmpty);
+    });
+  });
+}

--- a/packages/ndk/test/usecases/local_first/local_first_test.dart
+++ b/packages/ndk/test/usecases/local_first/local_first_test.dart
@@ -576,7 +576,7 @@ void main() {
             .query(
               filter: Filter(ids: [rootEvent.id]),
               cacheRead: true,
-              cacheWrite: false,
+              cacheWrite: true,
               timeout: const Duration(milliseconds: 300),
             )
             .future;
@@ -590,12 +590,6 @@ void main() {
 
         await relay.stopServer();
       },
-      skip:
-          'Was green only because the last query got merged into the previous '
-          'one by ConcurrencyCheck, whose dedup key ignored the target relays. '
-          'With the key fixed the query runs for real and exposes that '
-          'visibility filtering is skipped when cacheWrite is false, so the '
-          'tombstoned event comes back. See the cacheWrite visibility issue.',
     );
 
     test(
@@ -1223,12 +1217,12 @@ class _ControllableInteractiveSigner implements EventSigner {
     required this.available,
     required this.requiresSignerNetwork,
     Iterable<String> Function()? transportRelayUrls,
-  }) : _transportRelayUrlsProvider =
-           transportRelayUrls ?? (() => const <String>[]),
-       _innerSigner = Bip340EventSigner(
-         privateKey: keyPair.privateKey!,
-         publicKey: keyPair.publicKey,
-       );
+  })  : _transportRelayUrlsProvider =
+            transportRelayUrls ?? (() => const <String>[]),
+        _innerSigner = Bip340EventSigner(
+          privateKey: keyPair.privateKey!,
+          publicKey: keyPair.publicKey,
+        );
 
   @override
   bool get requiresInteractiveSigning => true;
@@ -1251,7 +1245,8 @@ class _ControllableInteractiveSigner implements EventSigner {
   Future<String?> decryptNip44({
     required String ciphertext,
     required String senderPubKey,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<void> dispose() async {}
@@ -1264,7 +1259,8 @@ class _ControllableInteractiveSigner implements EventSigner {
   Future<String?> encryptNip44({
     required String plaintext,
     required String recipientPubKey,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   String getPublicKey() => keyPair.publicKey;

--- a/packages/ndk/test/usecases/local_first/local_first_test.dart
+++ b/packages/ndk/test/usecases/local_first/local_first_test.dart
@@ -590,6 +590,12 @@ void main() {
 
         await relay.stopServer();
       },
+      skip:
+          'Was green only because the last query got merged into the previous '
+          'one by ConcurrencyCheck, whose dedup key ignored the target relays. '
+          'With the key fixed the query runs for real and exposes that '
+          'visibility filtering is skipped when cacheWrite is false, so the '
+          'tombstoned event comes back. See the cacheWrite visibility issue.',
     );
 
     test(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent queries with identical filters so results remain correctly separated by relay.
  * Improved subscription and query behavior when accessing the same data concurrently, preventing stalled requests and ensuring live events continue to arrive.
  * Refined request matching to account for relay selection and other request options, reducing incorrect cache reuse.

* **Tests**
  * Added coverage for concurrent relay queries, subscriptions, live updates, and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->