### PR TITLE
Feat/one identity per connection

### DIFF
--- a/doc/concepts/nip42-auth.md
+++ b/doc/concepts/nip42-auth.md
@@ -1,35 +1,3 @@
 # NIP-42 Authentication
 
 NDK handles NIP-42 relay authentication automatically. When a relay requires authentication, NDK will sign and send AUTH events, then retry the original request.
-
-## Auth Strategies
-
-NDK supports two authentication strategies:
-
-### Lazy Auth (default)
-
-```dart
-final ndk = Ndk(NdkConfig(
-  eventVerifier: Bip340EventVerifier(),
-  cache: MemCacheManager(),
-  // eagerAuth: false (default)
-));
-```
-
-- AUTH is sent **only after** the relay responds with `auth-required`
-- More privacy-respecting: doesn't reveal identity until necessary
-- Flow: `REQ` → `CLOSED auth-required` → `AUTH` → `OK` → `REQ` (retry)
-
-### Eager Auth
-
-```dart
-final ndk = Ndk(NdkConfig(
-  eventVerifier: Bip340EventVerifier(),
-  cache: MemCacheManager(),
-  eagerAuth: true,
-));
-```
-
-- AUTH is sent **immediately** when the relay sends a challenge
-- Faster for relays that always require auth
-- Flow: `AUTH challenge` → `AUTH` → `OK` → `REQ`

--- a/packages/ndk/lib/config/request_defaults.dart
+++ b/packages/ndk/lib/config/request_defaults.dart
@@ -27,4 +27,9 @@ class RequestDefaults {
 
   /// default timeout for AUTH callbacks (how long to wait for AUTH OK)
   static const Duration DEFAULT_AUTH_CALLBACK_TIMEOUT = Duration(seconds: 30);
+
+  /// how long to wait for a NIP-42 challenge once something asked us to
+  /// authenticate; a relay that wants auth sends it with or right after the
+  /// refusal, so waiting longer only stalls the request
+  static const Duration DEFAULT_AUTH_CHALLENGE_TIMEOUT = Duration(seconds: 3);
 }

--- a/packages/ndk/lib/domain_layer/entities/global_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/global_state.dart
@@ -1,5 +1,6 @@
 import 'broadcast_state.dart';
 import 'nip77_state.dart';
+import 'relay_connection_key.dart';
 import 'relay_connectivity.dart';
 import 'request_state.dart';
 
@@ -17,9 +18,9 @@ class GlobalState {
   final Map<String, BroadcastState> inFlightBroadcasts = {};
 
   /// touched relays by ndk - connected, connecting, disconnected
-  /// key: relay url/identifier
+  /// key: relay url and identity bound to the connection
   /// value: relay connectivity
-  Map<String, RelayConnectivity> relays = {};
+  Map<RelayConnectionKey, RelayConnectivity> relays = {};
 
   /// clean urls of relays that are blocked
   Set<String> blockedRelays = {};

--- a/packages/ndk/lib/domain_layer/entities/relay_connection_key.dart
+++ b/packages/ndk/lib/domain_layer/entities/relay_connection_key.dart
@@ -1,0 +1,58 @@
+import '../../shared/helpers/relay_helper.dart';
+
+final _hexPubkeyRegex = RegExp(r'^[0-9a-fA-F]{64}$');
+
+/// Identifies a single relay connection.
+///
+/// A connection carries at most one authenticated identity, chosen when the
+/// connection is opened and immutable for its whole lifetime. Several
+/// connections may therefore exist towards the same relay.
+class RelayConnectionKey {
+  /// relay url, normalized
+  final String url;
+
+  /// lowercase hex pubkey authenticated on this connection, null when anonymous
+  final String? pubkey;
+
+  /// stands for the absent pubkey in [canonical]; not a valid pubkey, so it
+  /// cannot collide with one
+  static const String anonymousMarker = 'anon';
+
+  const RelayConnectionKey._(this.url, this.pubkey);
+
+  /// key of a connection that never authenticates
+  factory RelayConnectionKey.anonymous(String url) =>
+      RelayConnectionKey._(_normalizeUrl(url), null);
+
+  /// key of a connection authenticated as [pubkey]
+  factory RelayConnectionKey.authenticated(String url, String pubkey) {
+    if (!_hexPubkeyRegex.hasMatch(pubkey)) {
+      throw ArgumentError.value(pubkey, 'pubkey', 'expected 64 hex characters');
+    }
+    return RelayConnectionKey._(_normalizeUrl(url), pubkey.toLowerCase());
+  }
+
+  /// whether any identity is bound to this connection
+  bool get isAnonymous => pubkey == null;
+
+  /// stable representation, for persisted keys and logs
+  String get canonical => '$url|${pubkey ?? anonymousMarker}';
+
+  /// an unparsable url is kept as given: it simply never matches a connection,
+  /// which is what an unparsable url did before it became part of the key
+  static String _normalizeUrl(String url) => cleanRelayUrl(url) ?? url.trim();
+
+  @override
+  String toString() => canonical;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RelayConnectionKey &&
+          runtimeType == other.runtimeType &&
+          url == other.url &&
+          pubkey == other.pubkey;
+
+  @override
+  int get hashCode => Object.hash(url, pubkey);
+}

--- a/packages/ndk/lib/domain_layer/entities/relay_connectivity.dart
+++ b/packages/ndk/lib/domain_layer/entities/relay_connectivity.dart
@@ -3,11 +3,15 @@ import 'dart:async';
 import '../../shared/logger/logger.dart';
 import '../repositories/nostr_transport.dart';
 import 'relay.dart';
+import 'relay_connection_key.dart';
 import 'relay_info.dart';
 import 'relay_stats.dart';
 
 /// Represents the connectivity of a relay.
 class RelayConnectivity<T> {
+  /// identifies this connection: the relay and the identity bound to it
+  final RelayConnectionKey key;
+
   /// relay data including connection state
   final Relay relay;
 
@@ -61,7 +65,7 @@ class RelayConnectivity<T> {
   final T? specificEngineData;
 
   /// relay url/identifier
-  String get url => relay.url;
+  String get url => key.url;
 
   /// current connection state if connection is open
   bool get isConnected => relayTransport != null && relayTransport!.isOpen();
@@ -69,6 +73,7 @@ class RelayConnectivity<T> {
   /// Creates a new relay connectivity.
   /// relayTransport == null => relay is not connected and is not in connecting state
   RelayConnectivity({
+    required this.key,
     required this.relay,
     this.relayInfo,
     this.relayTransport,

--- a/packages/ndk/lib/domain_layer/entities/relay_connectivity.dart
+++ b/packages/ndk/lib/domain_layer/entities/relay_connectivity.dart
@@ -48,7 +48,7 @@ class RelayConnectivity<T> {
     _streamSubscription = null;
     relayTransport = null;
     // the socket carried them, they die with it
-    stats.activeRequests = 0;
+    stats.openRequestIds.clear();
 
     if (streamSubscription != null) {
       await streamSubscription.cancel();

--- a/packages/ndk/lib/domain_layer/entities/relay_connectivity.dart
+++ b/packages/ndk/lib/domain_layer/entities/relay_connectivity.dart
@@ -47,6 +47,8 @@ class RelayConnectivity<T> {
 
     _streamSubscription = null;
     relayTransport = null;
+    // the socket carried them, they die with it
+    stats.activeRequests = 0;
 
     if (streamSubscription != null) {
       await streamSubscription.cancel();

--- a/packages/ndk/lib/domain_layer/entities/relay_set.dart
+++ b/packages/ndk/lib/domain_layer/entities/relay_set.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 
 import 'pubkey_mapping.dart';
 import 'read_write.dart';
+import 'relay_connection_key.dart';
 import 'request_state.dart';
 import 'filter.dart';
 
@@ -44,9 +45,10 @@ class RelaySet {
   void splitIntoRequests(Filter filter, RequestState groupRequest) {
     for (var entry in relaysMap.entries) {
       String url = entry.key;
+      final connectionKey = RelayConnectionKey.anonymous(url);
       List<PubkeyMapping> pubKeyMappings = entry.value;
       if (pubKeyMappings.isEmpty) {
-        groupRequest.addRequest(url, [filter]);
+        groupRequest.addRequest(connectionKey, [filter]);
       } else if (filter.authors != null &&
           filter.authors!.isNotEmpty &&
           direction == RelayDirection.outbox) {
@@ -62,7 +64,7 @@ class RelaySet {
         }
         if (pubKeysForRelay.isNotEmpty) {
           groupRequest.addRequest(
-            url,
+            connectionKey,
             sliceFilterAuthors(filter.cloneWithAuthors(pubKeysForRelay)),
           );
         }
@@ -81,12 +83,12 @@ class RelaySet {
         }
         if (pubKeysForRelay.isNotEmpty) {
           groupRequest.addRequest(
-            url,
+            connectionKey,
             sliceFilterAuthors(filter.cloneWithPTags(pubKeysForRelay)),
           );
         }
       } else if (filter.eTags != null && direction == RelayDirection.inbox) {
-        groupRequest.addRequest(url, [filter]);
+        groupRequest.addRequest(connectionKey, [filter]);
       } else {
         /// TODO: Define what to do in this edge case
       }

--- a/packages/ndk/lib/domain_layer/entities/relay_stats.dart
+++ b/packages/ndk/lib/domain_layer/entities/relay_stats.dart
@@ -10,8 +10,13 @@ class RelayStats {
   /// number of connection errors
   int connectionErrors = 0;
 
+  /// ids of the requests open on the connection, so that a request replayed on
+  /// a socket that came back is not counted twice and a CLOSE that lands late
+  /// does not count below what is open
+  final Set<String> openRequestIds = {};
+
   /// number of active requests on this relay
-  int activeRequests = 0;
+  int get activeRequests => openRequestIds.length;
 
   /// gets incremented on every touch => search if it has a pubkey assigned
   int touched = 1;

--- a/packages/ndk/lib/domain_layer/entities/request_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/request_state.dart
@@ -18,6 +18,11 @@ class RelayRequestState {
 
   bool receivedEOSE = false;
   bool receivedClosed = false;
+
+  /// set while this connection authenticates to satisfy the request: the relay
+  /// closed it, but it is on its way back and must not count as finished
+  bool retryingAuth = false;
+
   List<Filter> filters;
 
   /// default const
@@ -127,7 +132,9 @@ class RequestState {
 
   /// checks if all requests finished (received EOSE or CLOSED)
   bool get didAllRequestsFinish => requests.values.every(
-    (element) => element.receivedEOSE || element.receivedClosed,
+    (element) =>
+        (element.receivedEOSE || element.receivedClosed) &&
+        !element.retryingAuth,
   );
 
   /// Adds single relay request to the state

--- a/packages/ndk/lib/domain_layer/entities/request_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/request_state.dart
@@ -125,10 +125,6 @@ class RequestState {
     _remainingTimeout = null;
   }
 
-  /// checks if all requests received EOSE
-  bool get didAllRequestsReceivedEOSE =>
-      !requests.values.any((element) => !element.receivedEOSE);
-
   /// checks if all requests finished (received EOSE or CLOSED)
   bool get didAllRequestsFinish => requests.values.every(
     (element) => element.receivedEOSE || element.receivedClosed,

--- a/packages/ndk/lib/domain_layer/entities/request_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/request_state.dart
@@ -6,16 +6,22 @@ import '../../config/rx_defaults.dart';
 import 'filter.dart';
 import 'ndk_request.dart';
 import 'nip_01_event.dart';
+import 'relay_connection_key.dart';
 
 /// Single relay request state
 class RelayRequestState {
-  String url;
+  /// connection this request was sent on
+  final RelayConnectionKey key;
+
+  /// url of the relay this request was sent to
+  String get url => key.url;
+
   bool receivedEOSE = false;
   bool receivedClosed = false;
   List<Filter> filters;
 
   /// default const
-  RelayRequestState(this.url, this.filters);
+  RelayRequestState(this.key, this.filters);
 }
 
 /// State per request for multiple relays
@@ -47,8 +53,8 @@ class RequestState {
   bool get isSubscription => !request.closeOnEOSE;
 
   ///! our requests tracking obj
-  // key is relay url, value is RelayRequestState
-  Map<String, RelayRequestState> requests = {};
+  // key is the connection the request was sent on, value is RelayRequestState
+  Map<RelayConnectionKey, RelayRequestState> requests = {};
 
   /// the original request
   NdkRequest request;
@@ -129,9 +135,9 @@ class RequestState {
   );
 
   /// Adds single relay request to the state
-  void addRequest(String url, List<Filter> filters) {
-    if (!requests.containsKey(url)) {
-      requests[url] = RelayRequestState(url, filters);
+  void addRequest(RelayConnectionKey key, List<Filter> filters) {
+    if (!requests.containsKey(key)) {
+      requests[key] = RelayRequestState(key, filters);
     }
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/connectivity/connectivity.dart
+++ b/packages/ndk/lib/domain_layer/usecases/connectivity/connectivity.dart
@@ -8,10 +8,9 @@ class Connectivy {
 
   Connectivy(this._relayManager);
 
-  /// streams connectivity status of all relays \
-  /// key: relay url/identifier
-  /// value: relay connectivity
-  Stream<Map<String, RelayConnectivity>> get relayConnectivityChanges =>
+  /// streams connectivity status of every connection \
+  /// a relay can hold several, so group by [RelayConnectivity.url] if needed
+  Stream<List<RelayConnectivity>> get relayConnectivityChanges =>
       _relayManager.relayConnectivityChanges;
 
   /// forces all relays to reconnect \

--- a/packages/ndk/lib/domain_layer/usecases/connectivity/connectivity.dart
+++ b/packages/ndk/lib/domain_layer/usecases/connectivity/connectivity.dart
@@ -23,8 +23,8 @@ class Connectivy {
     for (final rConnectivity in relayConnectivities) {
       if (!rConnectivity.isConnected) {
         await _relayManager
-            .reconnectRelay(
-              rConnectivity.url,
+            .reconnectConnection(
+              rConnectivity.key,
               connectionSource: rConnectivity.relay.connectionSource,
               force: true,
             )

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
@@ -88,7 +88,7 @@ class JitEngine with Logger implements NetworkEngine {
           requestState: requestState,
           cacheManager: cache,
           filter: filter,
-          connectedRelays: relayManagerLight.connectedRelays
+          connectedRelays: relayManagerLight.connectedAnonymousRelays
               .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
               .toList(),
           bootstrapRelays: bootstrapRelays,
@@ -108,7 +108,7 @@ class JitEngine with Logger implements NetworkEngine {
           requestState: requestState,
           cacheManager: cache,
           filter: filter,
-          connectedRelays: relayManagerLight.connectedRelays
+          connectedRelays: relayManagerLight.connectedAnonymousRelays
               .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
               .toList(),
           bootstrapRelays: bootstrapRelays,
@@ -136,7 +136,7 @@ class JitEngine with Logger implements NetworkEngine {
         relayManager: relayManagerLight,
         requestState: requestState,
         filter: filter,
-        connectedRelays: relayManagerLight.connectedRelays
+        connectedRelays: relayManagerLight.connectedAnonymousRelays
             .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
             .toList(),
         bootstrapRelays: bootstrapRelays,
@@ -190,7 +190,7 @@ class JitEngine with Logger implements NetworkEngine {
           relayManager: relayManagerLight,
           cacheManager: cache,
           eventToPublish: workingNostrEvent,
-          connectedRelays: relayManagerLight.connectedRelays
+          connectedRelays: relayManagerLight.connectedAnonymousRelays
               .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
               .toList(),
         );
@@ -201,7 +201,7 @@ class JitEngine with Logger implements NetworkEngine {
       // default publish to own outbox
       await RelayJitBroadcastOutboxStrategy.broadcast(
         eventToPublish: workingNostrEvent,
-        connectedRelays: relayManagerLight.connectedRelays
+        connectedRelays: relayManagerLight.connectedAnonymousRelays
             .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
             .toList(),
         cacheManager: cache,
@@ -214,7 +214,7 @@ class JitEngine with Logger implements NetworkEngine {
           workingNostrEvent.kind != ContactList.kKind) {
         await RelayJitBroadcastOtherReadStrategy.broadcast(
           eventToPublish: workingNostrEvent,
-          connectedRelays: relayManagerLight.connectedRelays
+          connectedRelays: relayManagerLight.connectedAnonymousRelays
               .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
               .toList(),
           cacheManager: cache,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
@@ -147,9 +147,9 @@ class JitEngine with Logger implements NetworkEngine {
     // Late auth for subscriptions with authenticateAs
     if (ndkRequest.authenticateAs != null &&
         ndkRequest.authenticateAs!.isNotEmpty) {
-      for (final relayUrl in requestState.requests.keys) {
+      for (final connectionKey in requestState.requests.keys) {
         relayManagerLight.authenticateIfNeeded(
-          relayUrl,
+          connectionKey.url,
           ndkRequest.authenticateAs!,
         );
       }

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_other_read.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_other_read.dart
@@ -100,7 +100,7 @@ class RelayJitBroadcastOtherReadStrategy {
         }
 
         try {
-          final relay = relayManager.connectedRelays.firstWhere(
+          final relay = relayManager.connectedAnonymousRelays.firstWhere(
             (element) => element.url == relayUrl,
           );
           sendToRelay(relay: relay);

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_own.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_own.dart
@@ -94,7 +94,7 @@ class RelayJitBroadcastOutboxStrategy {
         }
 
         try {
-          final relay = relayManager.connectedRelays.firstWhere(
+          final relay = relayManager.connectedAnonymousRelays.firstWhere(
             (element) => element.url == relayUrl,
           );
           sendToRelay(relay: relay);

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_specific.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_specific.dart
@@ -92,7 +92,7 @@ class RelayJitBroadcastSpecificRelaysStrategy {
           return;
         }
         try {
-          final relay = relayManager.connectedRelays.firstWhere(
+          final relay = relayManager.connectedAnonymousRelays.firstWhere(
             (element) => element.url == relayUrl,
           );
           sendToRelay(relay: relay);

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_blast_all_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_blast_all_strategy.dart
@@ -32,7 +32,7 @@ class RelayJitBlastAllStrategy {
       /// register request
       relayManager.registerRelayRequest(
         reqId: requestState.id,
-        relayUrl: connectedRelay.url,
+        connectionKey: connectedRelay.key,
         filters: [filter],
       );
       relayManager.send(connectedRelay, clientMsg);

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
@@ -9,6 +9,7 @@ import 'package:ndk/domain_layer/usecases/jit_engine/relay_jit_request_strategie
 
 import '../../../entities/global_state.dart';
 import '../../../entities/jit_engine_relay_connectivity_data.dart';
+import '../../../entities/relay_connection_key.dart';
 import '../../../entities/relay_connectivity.dart';
 import '../../../entities/request_state.dart';
 import '../../../entities/connection_source.dart';
@@ -201,7 +202,9 @@ class RelayJitPubkeyStrategy with Logger {
             .then((success) {
               if (success.first) {
                 final myRelayConnectivity =
-                    globalState.relays[relayCandidate.relayUrl]
+                    globalState.relays[RelayConnectionKey.anonymous(
+                          relayCandidate.relayUrl,
+                        )]
                         as RelayConnectivity<JitEngineRelayConnectivityData>;
                 // add assigned pubkeys
                 myRelayConnectivity.specificEngineData!
@@ -252,7 +255,9 @@ class RelayJitPubkeyStrategy with Logger {
 
       if (alreadyConnected) {
         final myRelayConnectivity =
-            globalState.relays[relayCandidate.relayUrl]
+            globalState.relays[RelayConnectionKey.anonymous(
+                  relayCandidate.relayUrl,
+                )]
                 as RelayConnectivity<JitEngineRelayConnectivityData>;
 
         myRelayConnectivity.specificEngineData!.addPubkeysToAssignedPubkeys(

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
@@ -338,7 +338,7 @@ void _sendRequestToSocket(
   // link the request id to the relay
   relayManager.registerRelayRequest(
     reqId: requestState.id,
-    relayUrl: connectedRelay.url,
+    connectionKey: connectedRelay.key,
     filters: filters,
   );
 

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_specific_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_specific_strategy.dart
@@ -34,7 +34,7 @@ class RelayJitRequestSpecificStrategy {
     await Future.wait(connectFutures);
 
     // filter connected relays && specific relays
-    final specificConnectedRelays = relayManager.connectedRelays
+    final specificConnectedRelays = relayManager.connectedAnonymousRelays
         .where((relay) => specificRelays.contains(relay.url))
         .toList();
 

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_specific_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_specific_strategy.dart
@@ -48,7 +48,7 @@ class RelayJitRequestSpecificStrategy {
       /// register request
       relayManager.registerRelayRequest(
         reqId: requestState.id,
-        relayUrl: connectedRelay.url,
+        connectionKey: connectedRelay.key,
         filters: [filter],
       );
       relayManager.send(connectedRelay, clientMsg);

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -499,18 +499,16 @@ class RelayManager<T> {
           // by connection, not by relay: replaying a bound request on the
           // anonymous socket gets it refused, and replaying an anonymous one on
           // a bound socket makes it attributable. An entry the relay already
-          // refused stays refused, replaying it only retriggers the re-route.
+          // refused stays refused, replaying it only retriggers the re-route,
+          // unless it was refused for an authentication that never landed.
           .where(
-            (req) => req.key == relayConnectivity.key && !req.receivedClosed,
+            (req) =>
+                req.key == relayConnectivity.key &&
+                (!req.receivedClosed || req.retryingAuth),
           )
           .forEach((req) {
             if (!state.request.closeOnEOSE) {
-              List<dynamic> list = ["REQ", state.id];
-              list.addAll(req.filters.map((filter) => filter.toMap()));
-
-              if (_sendRaw(relayConnectivity, transport, jsonEncode(list))) {
-                relayConnectivity.stats.activeRequests++;
-              }
+              _sendRequest(relayConnectivity, state.id, req);
             }
           });
     });
@@ -1223,6 +1221,7 @@ class RelayManager<T> {
     RelayRequestState request,
   ) {
     request.receivedClosed = false;
+    request.retryingAuth = false;
     send(
       relayConnectivity,
       ClientMsg(ClientMsgType.kReq, id: reqId, filters: request.filters),
@@ -1287,12 +1286,17 @@ class RelayManager<T> {
 
       Logger.log.d(() => "Authenticating $key to satisfy REQ $reqId");
       state.pauseTimeout();
+      request.retryingAuth = true;
+      final generation = _generationOf(key);
       authenticateConnection(key).then((authenticated) {
         if (!_isStillInFlight(reqId, state)) {
           return;
         }
         state.resumeTimeout();
         if (!authenticated) {
+          // an authentication that died with its socket is not a refusal: stay
+          // on the retry so the replacement replays the request
+          request.retryingAuth = _generationOf(key) != generation;
           _checkNetworkClose(state, relayConnectivity);
           return;
         }
@@ -1473,17 +1477,17 @@ class RelayManager<T> {
     }
 
     /// check if relays for this request are still connected
-    /// if not ignore it and wait for the ones still alive to finish
-    final connectionsForThisRequest = state.requests.keys.toList();
-    final myNotConnectedRelays = globalState.relays.keys
-        .where((key) => connectionsForThisRequest.contains(key))
+    /// if not ignore it and wait for the ones still alive to finish. A
+    /// connection that was dropped entirely counts as gone too, otherwise a
+    /// request left on it would wait for a socket nobody will reopen.
+    final myNotConnectedRelays = state.requests.keys
         .where((key) => !isConnectionOpen(key))
         .toList();
 
     final bool didAllRelaysFinish = state.requests.values.every(
       (element) =>
-          element.receivedEOSE ||
-          element.receivedClosed ||
+          ((element.receivedEOSE || element.receivedClosed) &&
+              !element.retryingAuth) ||
           myNotConnectedRelays.contains(element.key),
     );
 

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1143,6 +1143,12 @@ class RelayManager<T> {
     return;
   }
 
+  /// Whether [state] is still the request tracked under [reqId]. A request
+  /// closed while an authentication or a connection was pending must not be
+  /// sent afterwards: nothing tracks it anymore, so nothing would ever CLOSE it.
+  bool _isStillInFlight(String reqId, RequestState state) =>
+      identical(globalState.inFlightRequests[reqId], state);
+
   /// Handles CLOSED auth-required.
   ///
   /// A connection is bound to at most one identity, and that binding never
@@ -1182,6 +1188,9 @@ class RelayManager<T> {
       Logger.log.d(() => "Authenticating $key to satisfy REQ $reqId");
       state.pauseTimeout();
       authenticateConnection(key).then((authenticated) {
+        if (!_isStillInFlight(reqId, state)) {
+          return;
+        }
         state.resumeTimeout();
         if (!authenticated) {
           request.receivedClosed = true;
@@ -1221,6 +1230,9 @@ class RelayManager<T> {
       account,
       connectionSource: relayConnectivity.relay.connectionSource,
     ).then((bound) {
+      if (!_isStillInFlight(reqId, state)) {
+        return;
+      }
       state.resumeTimeout();
       final retry = state.requests[target];
       if (retry == null) {

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1377,10 +1377,13 @@ class RelayManager<T> {
     }
   }
 
-  /// sends a close message to a relay
-  void sendCloseToRelay(String url, String id) {
-    RelayConnectivity? connectivity =
-        globalState.relays[RelayConnectionKey.anonymous(url)];
+  /// sends a close message on the anonymous connection to a relay
+  void sendCloseToRelay(String url, String id) =>
+      sendCloseToConnection(RelayConnectionKey.anonymous(url), id);
+
+  /// sends a close message on the connection the subscription was sent on
+  void sendCloseToConnection(RelayConnectionKey key, String id) {
+    RelayConnectivity? connectivity = globalState.relays[key];
     if (connectivity != null) {
       _sendCloseToRelay(connectivity, id);
     }

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -677,56 +677,64 @@ class RelayManager<T> {
   }
 
   void _startListeningToSocket(RelayConnectivity relayConnectivity) {
+    final transport = relayConnectivity.relayTransport;
     relayConnectivity.listen(
       (message) {
         _handleIncomingMessage(message, relayConnectivity);
       },
-      onError: (error) async {
+      onError: (error) {
         Logger.log.e(() => "onError ${relayConnectivity.url} on listen $error");
         relayConnectivity.stats.connectionErrors++;
-        try {
-          await relayConnectivity.close();
-        } catch (e) {
-          Logger.log.w(
-            () => "Error closing relay ${relayConnectivity.url}: $e",
-          );
-        }
-        updateRelayConnectivity();
+        _handleTransportGone(relayConnectivity, transport);
       },
-      onDone: () async {
+      onDone: () {
         Logger.log.t(
           () =>
               "onDone ${relayConnectivity.url} on listen (close: ${relayConnectivity.relayTransport?.closeCode()} ${relayConnectivity.relayTransport?.closeReason()})",
         );
-
-        try {
-          await relayConnectivity.close();
-        } catch (e) {
-          Logger.log.w(
-            () => "Error closing relay ${relayConnectivity.url}: $e",
-          );
-        }
-        // the socket is gone, so is the AUTH the relay accepted on it
-        _forgetAuthState(relayConnectivity.key);
-        updateRelayConnectivity();
-        // Reconnect on close. close() above nulls relayTransport, so the only
-        // condition is that the relay is still tracked: deliberate closes cancel
-        // the stream subscription first and never reach this handler.
-        if (allowReconnectRelays &&
-            globalState.relays[relayConnectivity.key] != null) {
-          Logger.log.i(() => "closed ${relayConnectivity.url}. Reconnecting");
-          reconnectConnection(
-            relayConnectivity.key,
-            connectionSource: relayConnectivity.relay.connectionSource,
-          ).then((connected) {
-            updateRelayConnectivity();
-            if (connected) {
-              reSubscribeInFlightSubscriptions(relayConnectivity);
-            }
-          });
-        }
+        _handleTransportGone(relayConnectivity, transport);
       },
     );
+  }
+
+  /// Cleans up after [transport] died and brings the connection back. Both ways
+  /// a socket can end land here: an error cancels the stream subscription, so
+  /// the done event that would otherwise follow never arrives.
+  ///
+  /// Runs once per transport, so a late event from a socket that was already
+  /// replaced leaves the current one alone.
+  Future<void> _handleTransportGone(
+    RelayConnectivity relayConnectivity,
+    NostrTransport? transport,
+  ) async {
+    if (!identical(relayConnectivity.relayTransport, transport)) {
+      return;
+    }
+
+    try {
+      await relayConnectivity.close();
+    } catch (e) {
+      Logger.log.w(() => "Error closing relay ${relayConnectivity.url}: $e");
+    }
+    // the socket is gone, so is the AUTH the relay accepted on it
+    _forgetAuthState(relayConnectivity.key);
+    updateRelayConnectivity();
+    // Reconnect on close. close() above nulls relayTransport, so the only
+    // condition is that the relay is still tracked: deliberate closes cancel
+    // the stream subscription first and never reach this handler.
+    if (allowReconnectRelays &&
+        globalState.relays[relayConnectivity.key] != null) {
+      Logger.log.i(() => "closed ${relayConnectivity.url}. Reconnecting");
+      reconnectConnection(
+        relayConnectivity.key,
+        connectionSource: relayConnectivity.relay.connectionSource,
+      ).then((connected) {
+        updateRelayConnectivity();
+        if (connected) {
+          reSubscribeInFlightSubscriptions(relayConnectivity);
+        }
+      });
+    }
   }
 
   // Track processing order per relay so EVENT/EOSE/AUTH/CLOSED ordering stays

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -19,6 +19,7 @@ import '../entities/global_state.dart';
 import '../entities/nip_01_event.dart';
 import '../entities/nostr_message_raw.dart';
 import '../entities/relay.dart';
+import '../entities/relay_connection_key.dart';
 import '../entities/relay_connectivity.dart';
 import '../entities/relay_info.dart';
 import '../entities/request_state.dart';
@@ -102,7 +103,10 @@ class RelayManager<T> {
   }
 
   void updateRelayConnectivity() {
-    _relayUpdatesStreamController.add(globalState.relays);
+    _relayUpdatesStreamController.add({
+      for (final connectivity in globalState.relays.values)
+        connectivity.url: connectivity,
+    });
   }
 
   /// This will initialize the manager with bootstrap relays.
@@ -144,12 +148,14 @@ class RelayManager<T> {
 
   /// checks if a relay is connected, avoid using this
   bool isRelayConnected(String url) {
-    return globalState.relays[url]?.relayTransport?.isOpen() ?? false;
+    return globalState.relays[RelayConnectionKey.anonymous(url)]?.relayTransport
+            ?.isOpen() ??
+        false;
   }
 
   /// checks if a relay is connecting
   bool isRelayConnecting(String url) {
-    final relay = globalState.relays[url]?.relay;
+    final relay = globalState.relays[RelayConnectionKey.anonymous(url)]?.relay;
     return relay != null && relay.connecting;
   }
 
@@ -220,17 +226,19 @@ class RelayManager<T> {
       updateRelayConnectivity();
       return Tuple(false, "relay is still connecting");
     }
-    RelayConnectivity? relayConnectivity = globalState.relays[url];
+    final connectionKey = RelayConnectionKey.anonymous(url);
+    RelayConnectivity? relayConnectivity = globalState.relays[connectionKey];
     final connectCompleter = Completer<bool>();
     _connectReadyCompleters[url] = connectCompleter;
 
     try {
       if (relayConnectivity == null) {
         relayConnectivity = RelayConnectivity<T>(
+          key: connectionKey,
           relay: Relay(url: url, connectionSource: connectionSource),
           specificEngineData: engineAdditionalDataFactory?.call(),
         );
-        globalState.relays[url] = relayConnectivity;
+        globalState.relays[connectionKey] = relayConnectivity;
       }
 
       relayConnectivity.relay.tryingToConnect();
@@ -319,7 +327,8 @@ class RelayManager<T> {
       return connected;
     }
 
-    RelayConnectivity? relayConnectivity = globalState.relays[url];
+    RelayConnectivity? relayConnectivity =
+        globalState.relays[RelayConnectionKey.anonymous(url)];
     if (relayConnectivity != null && relayConnectivity.relayTransport != null) {
       try {
         final opened = await _waitForTransportOpen(
@@ -354,7 +363,7 @@ class RelayManager<T> {
         // could not connect
         return false;
       }
-      relayConnectivity = globalState.relays[url];
+      relayConnectivity = globalState.relays[RelayConnectionKey.anonymous(url)];
       if (relayConnectivity == null ||
           relayConnectivity.relayTransport == null ||
           !relayConnectivity.relayTransport!.isOpen()) {
@@ -368,7 +377,7 @@ class RelayManager<T> {
   /// Closes and clears only transport-scoped state for a relay, while keeping
   /// the relay entry and relay-scoped metadata in memory.
   Future<void> resetTransport(String url) async {
-    final connectivity = globalState.relays[url];
+    final connectivity = globalState.relays[RelayConnectionKey.anonymous(url)];
     if (connectivity != null) {
       Logger.log.d(() => "Resetting transport for $url...");
       connectivity.relay.failedToConnect();
@@ -598,7 +607,7 @@ class RelayManager<T> {
         // condition is that the relay is still tracked: deliberate closes cancel
         // the stream subscription first and never reach this handler.
         if (allowReconnectRelays &&
-            globalState.relays[relayConnectivity.url] != null) {
+            globalState.relays[relayConnectivity.key] != null) {
           Logger.log.i(() => "closed ${relayConnectivity.url}. Reconnecting");
           reconnectRelay(
             relayConnectivity.url,
@@ -911,7 +920,8 @@ class RelayManager<T> {
       return;
     }
 
-    final relayConnectivity = globalState.relays[relayUrl];
+    final relayConnectivity =
+        globalState.relays[RelayConnectionKey.anonymous(relayUrl)];
     if (relayConnectivity == null) {
       Logger.log.w(() => "Relay $relayUrl not found for late auth");
       return;
@@ -1263,6 +1273,7 @@ class RelayManager<T> {
     /// if not ignore it and wait for the ones still alive to finish
     final listOfRelaysForThisRequest = state.requests.keys.toList();
     final myNotConnectedRelays = globalState.relays.keys
+        .map((key) => key.url)
         .where((url) => listOfRelaysForThisRequest.contains(url))
         .where((url) => !isRelayConnected(url))
         .toList();
@@ -1282,7 +1293,8 @@ class RelayManager<T> {
 
   /// sends a close message to a relay
   void sendCloseToRelay(String url, String id) {
-    RelayConnectivity? connectivity = globalState.relays[url];
+    RelayConnectivity? connectivity =
+        globalState.relays[RelayConnectionKey.anonymous(url)];
     if (connectivity != null) {
       _sendCloseToRelay(connectivity, id);
     }
@@ -1324,10 +1336,11 @@ class RelayManager<T> {
 
   /// Closes this url transport and removes
   Future<void> closeTransport(String url) async {
-    RelayConnectivity? connectivity = globalState.relays[url];
+    final connectionKey = RelayConnectionKey.anonymous(url);
+    RelayConnectivity? connectivity = globalState.relays[connectionKey];
     if (connectivity != null && connectivity.relayTransport != null) {
       Logger.log.d(() => "Disconnecting $url...");
-      globalState.relays.remove(url);
+      globalState.relays.remove(connectionKey);
       _lastChallengePerRelay.remove(url);
       return connectivity.close();
     }
@@ -1335,9 +1348,11 @@ class RelayManager<T> {
 
   /// Closes all transports
   Future<void> closeAllTransports() async {
-    Iterable<String> keys = globalState.relays.keys.toList();
+    Iterable<String> urls = globalState.relays.keys
+        .map((key) => key.url)
+        .toList();
     try {
-      await Future.wait(keys.map((url) => closeTransport(url)));
+      await Future.wait(urls.map((url) => closeTransport(url)));
     } catch (e) {
       Logger.log.e(() => e);
     }
@@ -1346,7 +1361,7 @@ class RelayManager<T> {
   /// fetches relay info
   /// todo: refactor to use http injector and decouple data from fetching
   Future<RelayInfo?> getRelayInfo(String url) async {
-    if (globalState.relays[url] != null) {
+    if (globalState.relays[RelayConnectionKey.anonymous(url)] != null) {
       return await RelayInfo.get(url);
     }
     return null;
@@ -1354,7 +1369,8 @@ class RelayManager<T> {
 
   /// does relay support given nip
   bool doesRelaySupportNip(String url, int nip) {
-    RelayConnectivity? connectivity = globalState.relays[cleanRelayUrl(url)];
+    RelayConnectivity? connectivity =
+        globalState.relays[RelayConnectionKey.anonymous(url)];
     return connectivity != null &&
         connectivity.relayInfo != null &&
         connectivity.relayInfo!.supportsNip(nip);
@@ -1362,7 +1378,7 @@ class RelayManager<T> {
 
   /// return [RelayConnectivity] by url
   RelayConnectivity? getRelayConnectivity(String url) {
-    return globalState.relays[url];
+    return globalState.relays[RelayConnectionKey.anonymous(url)];
   }
 }
 

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -43,8 +43,9 @@ class RelayManager<T> {
   /// signer for nip-42 AUTH challenges from relays
   final Accounts? _accounts;
 
-  /// stores the last AUTH challenge per relay for late authentication
-  final Map<String, String> _lastChallengePerRelay = {};
+  /// stores the last AUTH challenge per connection for late authentication;
+  /// each socket gets its own challenge, so this cannot be keyed by relay
+  final Map<RelayConnectionKey, String> _lastChallengePerConnection = {};
 
   /// stores pending AUTH callbacks: authEventId -> callback to execute on AUTH OK
   final Map<String, void Function()> _pendingAuthCallbacks = {};
@@ -54,7 +55,7 @@ class RelayManager<T> {
 
   /// Tracks relay connect attempts that are still finishing setup so callers
   /// can wait for "socket open + listener attached", not just raw socket open.
-  final Map<String, Completer<bool>> _connectReadyCompleters = {};
+  final Map<RelayConnectionKey, Completer<bool>> _connectReadyCompleters = {};
 
   /// timeout for AUTH callbacks (how long to wait for AUTH OK)
   final Duration authCallbackTimeout;
@@ -143,19 +144,24 @@ class RelayManager<T> {
   /// Returns a list of fully connected relays, excluding connecting ones.
   /// DO NOT USE THIS FOR CHECKING A SINGLE RELAY, use [isRelayConnected] INSTEAD
   List<RelayConnectivity> get connectedRelays => globalState.relays.values
-      .where((relay) => isRelayConnected(relay.url))
+      .where((connectivity) => connectivity.isConnected)
       .toList();
 
   /// checks if a relay is connected, avoid using this
-  bool isRelayConnected(String url) {
-    return globalState.relays[RelayConnectionKey.anonymous(url)]?.relayTransport
-            ?.isOpen() ??
-        false;
-  }
+  bool isRelayConnected(String url) =>
+      isConnectionOpen(RelayConnectionKey.anonymous(url));
 
   /// checks if a relay is connecting
-  bool isRelayConnecting(String url) {
-    final relay = globalState.relays[RelayConnectionKey.anonymous(url)]?.relay;
+  bool isRelayConnecting(String url) =>
+      isConnectionConnecting(RelayConnectionKey.anonymous(url));
+
+  /// checks if the connection identified by [key] is open
+  bool isConnectionOpen(RelayConnectionKey key) =>
+      globalState.relays[key]?.relayTransport?.isOpen() ?? false;
+
+  /// checks if the connection identified by [key] is connecting
+  bool isConnectionConnecting(RelayConnectionKey key) {
+    final relay = globalState.relays[key]?.relay;
     return relay != null && relay.connecting;
   }
 
@@ -192,6 +198,7 @@ class RelayManager<T> {
   Future<Tuple<bool, String>> connectRelay({
     required String dirtyUrl,
     required ConnectionSource connectionSource,
+    String? authPubkey,
     int connectTimeout = DEFAULT_WEB_SOCKET_CONNECT_TIMEOUT,
   }) async {
     String? url = cleanRelayUrl(dirtyUrl);
@@ -204,15 +211,19 @@ class RelayManager<T> {
       return Tuple(false, "relay is blocked");
     }
 
-    if (isRelayConnected(url)) {
-      Logger.log.t(() => "relay already connected: $url");
+    final connectionKey = authPubkey == null
+        ? RelayConnectionKey.anonymous(url)
+        : RelayConnectionKey.authenticated(url, authPubkey);
+
+    if (isConnectionOpen(connectionKey)) {
+      Logger.log.t(() => "relay already connected: $connectionKey");
       updateRelayConnectivity();
       return Tuple(true, "");
     }
 
-    if (isRelayConnecting(url)) {
-      Logger.log.t(() => "relay is already connecting: $url");
-      final inFlightConnect = _connectReadyCompleters[url];
+    if (isConnectionConnecting(connectionKey)) {
+      Logger.log.t(() => "relay is already connecting: $connectionKey");
+      final inFlightConnect = _connectReadyCompleters[connectionKey];
       if (inFlightConnect != null) {
         final connected = await inFlightConnect.future;
         updateRelayConnectivity();
@@ -226,10 +237,9 @@ class RelayManager<T> {
       updateRelayConnectivity();
       return Tuple(false, "relay is still connecting");
     }
-    final connectionKey = RelayConnectionKey.anonymous(url);
     RelayConnectivity? relayConnectivity = globalState.relays[connectionKey];
     final connectCompleter = Completer<bool>();
-    _connectReadyCompleters[url] = connectCompleter;
+    _connectReadyCompleters[connectionKey] = connectCompleter;
 
     try {
       if (relayConnectivity == null) {
@@ -249,8 +259,11 @@ class RelayManager<T> {
         if (!connectCompleter.isCompleted) {
           connectCompleter.complete(false);
         }
-        if (identical(_connectReadyCompleters[url], connectCompleter)) {
-          _connectReadyCompleters.remove(url);
+        if (identical(
+          _connectReadyCompleters[connectionKey],
+          connectCompleter,
+        )) {
+          _connectReadyCompleters.remove(connectionKey);
         }
         updateRelayConnectivity();
         return Tuple(false, "bad relay");
@@ -293,8 +306,8 @@ class RelayManager<T> {
       if (!connectCompleter.isCompleted) {
         connectCompleter.complete(true);
       }
-      if (identical(_connectReadyCompleters[url], connectCompleter)) {
-        _connectReadyCompleters.remove(url);
+      if (identical(_connectReadyCompleters[connectionKey], connectCompleter)) {
+        _connectReadyCompleters.remove(connectionKey);
       }
       updateRelayConnectivity();
       return Tuple(true, "");
@@ -307,8 +320,8 @@ class RelayManager<T> {
     if (!connectCompleter.isCompleted) {
       connectCompleter.complete(false);
     }
-    if (identical(_connectReadyCompleters[url], connectCompleter)) {
-      _connectReadyCompleters.remove(url);
+    if (identical(_connectReadyCompleters[connectionKey], connectCompleter)) {
+      _connectReadyCompleters.remove(connectionKey);
     }
     updateRelayConnectivity();
     return Tuple(false, "could not connect to $url");
@@ -320,7 +333,8 @@ class RelayManager<T> {
     required ConnectionSource connectionSource,
     bool force = false,
   }) async {
-    final inFlightConnect = _connectReadyCompleters[url];
+    final inFlightConnect =
+        _connectReadyCompleters[RelayConnectionKey.anonymous(url)];
     if (inFlightConnect != null) {
       final connected = await inFlightConnect.future;
       updateRelayConnectivity();
@@ -381,7 +395,7 @@ class RelayManager<T> {
     if (connectivity != null) {
       Logger.log.d(() => "Resetting transport for $url...");
       connectivity.relay.failedToConnect();
-      _lastChallengePerRelay.remove(url);
+      _lastChallengePerConnection.remove(connectivity.key);
       await connectivity.close();
       updateRelayConnectivity();
     }
@@ -791,7 +805,7 @@ class RelayManager<T> {
       );
 
       // Store challenge for late authentication (multiple accounts on same connection)
-      _lastChallengePerRelay[relayConnectivity.url] = challenge;
+      _lastChallengePerConnection[relayConnectivity.key] = challenge;
 
       // If not eager auth, don't authenticate now - wait for auth-required
       if (!eagerAuth) {
@@ -912,7 +926,8 @@ class RelayManager<T> {
   /// Authenticates accounts on a relay if we have a stored challenge.
   /// Call this when creating a new subscription with authenticateAs.
   void authenticateIfNeeded(String relayUrl, List<Account> accounts) {
-    final challenge = _lastChallengePerRelay[relayUrl];
+    final challenge =
+        _lastChallengePerConnection[RelayConnectionKey.anonymous(relayUrl)];
     if (challenge == null) {
       Logger.log.t(
         () => "No stored challenge for $relayUrl, skipping late auth",
@@ -1054,7 +1069,7 @@ class RelayManager<T> {
       return;
     }
 
-    final challenge = _lastChallengePerRelay[relayConnectivity.url];
+    final challenge = _lastChallengePerConnection[relayConnectivity.key];
     if (challenge == null) {
       Logger.log.w(
         () =>
@@ -1163,7 +1178,7 @@ class RelayManager<T> {
     String eventId,
     RelayConnectivity relayConnectivity,
   ) {
-    final challenge = _lastChallengePerRelay[relayConnectivity.url];
+    final challenge = _lastChallengePerConnection[relayConnectivity.key];
     if (challenge == null) {
       Logger.log.w(
         () =>
@@ -1341,7 +1356,7 @@ class RelayManager<T> {
     if (connectivity != null && connectivity.relayTransport != null) {
       Logger.log.d(() => "Disconnecting $url...");
       globalState.relays.remove(connectionKey);
-      _lastChallengePerRelay.remove(url);
+      _lastChallengePerConnection.remove(connectionKey);
       return connectivity.close();
     }
   }

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -313,6 +313,8 @@ class RelayManager<T> {
           // open, so this is the only notice we get that the socket the relay
           // authenticated died
           _forgetAuthState(connectionKey);
+          // the requests died with that socket too; onReconnect replays them
+          relayConnectivity.stats.openRequestIds.clear();
           updateRelayConnectivity();
         },
       );
@@ -584,17 +586,21 @@ class RelayManager<T> {
       );
     }
     if (_sendRaw(relayConnectivity, transport, encodedMsg)) {
-      _countRequest(relayConnectivity, msg.type);
+      _countRequest(relayConnectivity, msg);
     }
   }
 
-  /// Keeps the open request count of a connection on the connection that
-  /// carries them: a REQ re-routed to another one is not accounted here.
-  void _countRequest(RelayConnectivity relayConnectivity, String type) {
-    if (type == ClientMsgType.kReq) {
-      relayConnectivity.stats.activeRequests++;
-    } else if (type == ClientMsgType.kClose) {
-      relayConnectivity.stats.activeRequests--;
+  /// Keeps the open requests of a connection on the connection that carries
+  /// them: a REQ re-routed to another one is not accounted here.
+  void _countRequest(RelayConnectivity relayConnectivity, ClientMsg msg) {
+    final id = msg.id;
+    if (id == null) {
+      return;
+    }
+    if (msg.type == ClientMsgType.kReq) {
+      relayConnectivity.stats.openRequestIds.add(id);
+    } else if (msg.type == ClientMsgType.kClose) {
+      relayConnectivity.stats.openRequestIds.remove(id);
     }
   }
 
@@ -1241,7 +1247,7 @@ class RelayManager<T> {
       );
       RelayRequestState? request = state.requests[relayConnectivity.key];
       if (request != null) {
-        _endRequestOnRelay(relayConnectivity, request);
+        _endRequestOnRelay(relayConnectivity, id, request);
       }
 
       _checkNetworkClose(state);
@@ -1268,12 +1274,11 @@ class RelayManager<T> {
   /// on that connection, and there is no CLOSE left for us to send.
   void _endRequestOnRelay(
     RelayConnectivity relayConnectivity,
+    String reqId,
     RelayRequestState request,
   ) {
-    if (!request.receivedClosed) {
-      request.receivedClosed = true;
-      relayConnectivity.stats.activeRequests--;
-    }
+    request.receivedClosed = true;
+    relayConnectivity.stats.openRequestIds.remove(reqId);
   }
 
   /// Whether [state] is still the request tracked under [reqId]. A request
@@ -1309,7 +1314,7 @@ class RelayManager<T> {
     }
 
     // whatever we do next, the relay just closed this one on this connection
-    _endRequestOnRelay(relayConnectivity, request);
+    _endRequestOnRelay(relayConnectivity, reqId, request);
 
     if (!key.isAnonymous) {
       if (_authenticatedConnections.contains(key)) {

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -47,12 +47,14 @@ class RelayManager<T> {
   /// each socket gets its own challenge, so this cannot be keyed by relay
   final Map<RelayConnectionKey, String> _lastChallengePerConnection = {};
 
-  /// stores pending AUTH callbacks: authEventId -> callback run on the relay's
-  /// OK, with whether the relay accepted the AUTH event
-  final Map<String, void Function(bool accepted)> _pendingAuthCallbacks = {};
+  /// AUTH events waiting for their OK, keyed by AUTH event id. The connection
+  /// is part of the entry so a dying transport can fail its own.
+  final Map<String, _PendingAuth> _pendingAuths = {};
 
-  /// stores timers for pending AUTH callbacks to clean them up on timeout
-  final Map<String, Timer> _pendingAuthTimers = {};
+  /// transport generation per connection, bumped whenever a socket dies or is
+  /// replaced. Authentication carries the generation it started on, so nothing
+  /// it produces can land on the socket that took its place.
+  final Map<RelayConnectionKey, int> _transportGenerations = {};
 
   /// waiters for the AUTH challenge of a connection that is being authenticated
   final Map<RelayConnectionKey, Completer<String>> _challengeWaiters = {};
@@ -293,13 +295,15 @@ class RelayManager<T> {
 
       Logger.log.i(() => "connecting to relay $dirtyUrl");
 
+      // a fresh socket for a key we may already know: nothing the previous one
+      // authenticated carries over
+      _forgetAuthState(connectionKey);
       relayConnectivity.relayTransport = nostrTransportFactory(
         url,
         onReconnect: () {
           // the relay accepted our AUTH on the socket that just died, not on
           // this one; the binding survives, the authentication does not
-          _authenticatedConnections.remove(connectionKey);
-          _lastChallengePerConnection.remove(connectionKey);
+          _forgetAuthState(connectionKey);
           reSubscribeInFlightSubscriptions(relayConnectivity!);
           updateRelayConnectivity();
         },
@@ -451,8 +455,7 @@ class RelayManager<T> {
     if (connectivity != null) {
       Logger.log.d(() => "Resetting transport for $key...");
       connectivity.relay.failedToConnect();
-      _authenticatedConnections.remove(key);
-      _lastChallengePerConnection.remove(key);
+      _forgetAuthState(key);
       await connectivity.close();
       updateRelayConnectivity();
     }
@@ -685,8 +688,7 @@ class RelayManager<T> {
           );
         }
         // the socket is gone, so is the AUTH the relay accepted on it
-        _authenticatedConnections.remove(relayConnectivity.key);
-        _lastChallengePerConnection.remove(relayConnectivity.key);
+        _forgetAuthState(relayConnectivity.key);
         updateRelayConnectivity();
         // Reconnect on close. close() above nulls relayTransport, so the only
         // condition is that the relay is still tracked: deliberate closes cancel
@@ -768,17 +770,14 @@ class RelayManager<T> {
       final bool success = eventJson[2] == true;
       final String? msg = eventJson.length > 3 ? eventJson[3] : null;
 
-      // Check if this is an AUTH OK response
-      if (_pendingAuthCallbacks.containsKey(eventId)) {
-        _pendingAuthTimers[eventId]?.cancel();
-        _pendingAuthTimers.remove(eventId);
+      // an AUTH is only answered by the connection it was sent on
+      if (_pendingAuths[eventId]?.key == relayConnectivity.key) {
         if (success) {
           Logger.log.d(() => "AUTH OK for $eventId, executing callback");
         } else {
           Logger.log.e(() => "AUTH failed for $eventId: $msg");
         }
-        final callback = _pendingAuthCallbacks.remove(eventId);
-        callback?.call(success);
+        _resolvePendingAuth(eventId, success);
         return Future.value();
       }
 
@@ -959,10 +958,64 @@ class RelayManager<T> {
     try {
       return await waiter.future.timeout(authChallengeTimeout);
     } catch (_) {
-      _challengeWaiters.remove(key);
+      if (identical(_challengeWaiters[key], waiter)) {
+        _challengeWaiters.remove(key);
+      }
       Logger.log.w(() => "No AUTH challenge from $key");
       return null;
     }
+  }
+
+  int _generationOf(RelayConnectionKey key) => _transportGenerations[key] ?? 0;
+
+  /// Drops everything authentication built on [key]'s current transport and
+  /// moves the connection to its next generation. Call this whenever the socket
+  /// dies or gets replaced: what is still in flight then resolves to false
+  /// instead of landing on the socket that took its place.
+  void _forgetAuthState(RelayConnectionKey key) {
+    _transportGenerations[key] = _generationOf(key) + 1;
+    _authenticatedConnections.remove(key);
+    _lastChallengePerConnection.remove(key);
+    _authenticating.remove(key);
+
+    final waiter = _challengeWaiters.remove(key);
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.completeError(StateError("transport of $key is gone"));
+    }
+
+    final pending = _pendingAuths.entries
+        .where((entry) => entry.value.key == key)
+        .map((entry) => entry.key)
+        .toList();
+    for (final authEventId in pending) {
+      _resolvePendingAuth(authEventId, false);
+    }
+  }
+
+  /// Registers an AUTH event waiting for its OK. [onResult] runs once, with
+  /// what the relay answered or with false if the OK never comes.
+  void _registerPendingAuth({
+    required String authEventId,
+    required RelayConnectionKey key,
+    required void Function(bool accepted) onResult,
+  }) {
+    _pendingAuths[authEventId] = _PendingAuth(
+      key: key,
+      onResult: onResult,
+      timer: Timer(authCallbackTimeout, () {
+        Logger.log.w(() => "AUTH callback timeout for $authEventId on $key");
+        _resolvePendingAuth(authEventId, false);
+      }),
+    );
+  }
+
+  void _resolvePendingAuth(String authEventId, bool accepted) {
+    final pending = _pendingAuths.remove(authEventId);
+    if (pending == null) {
+      return;
+    }
+    pending.timer.cancel();
+    pending.onResult(accepted);
   }
 
   /// Answers the challenge for [key] and completes once the relay accepted the
@@ -978,12 +1031,18 @@ class RelayManager<T> {
     if (inFlight != null) {
       return inFlight;
     }
-    final attempt = _sendAuth(key);
+    final attempt = _sendAuth(key, _generationOf(key));
     _authenticating[key] = attempt;
-    return attempt.whenComplete(() => _authenticating.remove(key));
+    return attempt.whenComplete(() {
+      if (identical(_authenticating[key], attempt)) {
+        _authenticating.remove(key);
+      }
+    });
   }
 
-  Future<bool> _sendAuth(RelayConnectionKey key) async {
+  Future<bool> _sendAuth(RelayConnectionKey key, int generation) async {
+    bool transportGone() => _generationOf(key) != generation;
+
     final connectivity = globalState.relays[key];
     final account = _accounts?.accounts[key.pubkey];
     if (connectivity == null || account == null) {
@@ -997,7 +1056,7 @@ class RelayManager<T> {
     // the relay may send its challenge before or with the refusal, so waiting
     // is safe here: something already asked us to authenticate
     final challenge = await _awaitChallenge(key);
-    if (challenge == null) {
+    if (challenge == null || transportGone()) {
       return false;
     }
 
@@ -1010,26 +1069,25 @@ class RelayManager<T> {
         ],
       ),
     );
+    if (transportGone()) {
+      return false;
+    }
 
     final accepted = Completer<bool>();
-    _pendingAuthCallbacks[signedAuth.id] = (ok) {
-      if (!accepted.isCompleted) {
-        accepted.complete(ok);
-      }
-    };
-    _pendingAuthTimers[signedAuth.id] = Timer(authCallbackTimeout, () {
-      Logger.log.w(() => "AUTH callback timeout for ${signedAuth.id} on $key");
-      _pendingAuthCallbacks.remove(signedAuth.id);
-      _pendingAuthTimers.remove(signedAuth.id);
-      if (!accepted.isCompleted) {
-        accepted.complete(false);
-      }
-    });
+    _registerPendingAuth(
+      authEventId: signedAuth.id,
+      key: key,
+      onResult: (ok) {
+        if (!accepted.isCompleted) {
+          accepted.complete(ok);
+        }
+      },
+    );
 
     send(connectivity, ClientMsg(ClientMsgType.kAuth, event: signedAuth));
     Logger.log.d(() => "AUTH sent on $key");
 
-    if (!await accepted.future) {
+    if (!await accepted.future || transportGone()) {
       return false;
     }
     _authenticatedConnections.add(key);
@@ -1338,32 +1396,29 @@ class RelayManager<T> {
     );
 
     // Sign and send AUTH, then re-send EVENT on OK
+    final generation = _generationOf(relayConnectivity.key);
     account.signer.sign(auth).then((signedAuth) {
-      // Store callback to re-send EVENT after AUTH OK
-      _pendingAuthCallbacks[signedAuth.id] = (accepted) {
-        if (!accepted) {
-          return;
-        }
-        Logger.log.d(
-          () =>
-              "AUTH OK received, re-sending EVENT $eventId to ${relayConnectivity.url}",
-        );
-        // Re-send the EVENT
-        send(
-          relayConnectivity,
-          ClientMsg(ClientMsgType.kEvent, event: eventToResend),
-        );
-      };
+      if (_generationOf(relayConnectivity.key) != generation) {
+        return;
+      }
 
-      // Start timeout timer to clean up orphaned callbacks
-      _pendingAuthTimers[signedAuth.id] = Timer(authCallbackTimeout, () {
-        Logger.log.w(
-          () =>
-              "AUTH callback timeout for ${signedAuth.id} on ${relayConnectivity.url}",
-        );
-        _pendingAuthCallbacks.remove(signedAuth.id);
-        _pendingAuthTimers.remove(signedAuth.id);
-      });
+      _registerPendingAuth(
+        authEventId: signedAuth.id,
+        key: relayConnectivity.key,
+        onResult: (accepted) {
+          if (!accepted) {
+            return;
+          }
+          Logger.log.d(
+            () =>
+                "AUTH OK received, re-sending EVENT $eventId to ${relayConnectivity.url}",
+          );
+          send(
+            relayConnectivity,
+            ClientMsg(ClientMsgType.kEvent, event: eventToResend),
+          );
+        },
+      );
 
       send(
         relayConnectivity,
@@ -1468,8 +1523,7 @@ class RelayManager<T> {
       return;
     }
     Logger.log.d(() => "Disconnecting $key...");
-    _authenticatedConnections.remove(key);
-    _lastChallengePerConnection.remove(key);
+    _forgetAuthState(key);
     return connectivity.close();
   }
 
@@ -1509,4 +1563,17 @@ class RelayManager<T> {
 
 dynamic decodeJson(String jsonString) {
   return json.decode(jsonString);
+}
+
+/// An AUTH event sent to a connection, waiting for the relay's OK
+class _PendingAuth {
+  _PendingAuth({
+    required this.key,
+    required this.onResult,
+    required this.timer,
+  });
+
+  final RelayConnectionKey key;
+  final void Function(bool accepted) onResult;
+  final Timer timer;
 }

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -488,6 +488,8 @@ class RelayManager<T> {
     );
   }
 
+  /// Puts back on [relayConnectivity] what the socket it replaces still owed us:
+  /// its subscriptions, and the queries that never got their EOSE.
   void reSubscribeInFlightSubscriptions(RelayConnectivity relayConnectivity) {
     final transport = relayConnectivity.relayTransport;
     if (transport == null || !transport.isOpen()) {
@@ -495,6 +497,11 @@ class RelayManager<T> {
     }
 
     globalState.inFlightRequests.forEach((key, state) {
+      // the concurrency check files a request under its filter hash as well,
+      // and one request must not go back up once per alias
+      if (key != state.id) {
+        return;
+      }
       state.requests.values
           // by connection, not by relay: replaying a bound request on the
           // anonymous socket gets it refused, and replaying an anonymous one on
@@ -504,13 +511,12 @@ class RelayManager<T> {
           .where(
             (req) =>
                 req.key == relayConnectivity.key &&
-                (!req.receivedClosed || req.retryingAuth),
+                (!req.receivedClosed || req.retryingAuth) &&
+                // a query is over once this connection answered EOSE, while a
+                // subscription outlives its EOSE and has to go back up
+                (state.isSubscription || !req.receivedEOSE),
           )
-          .forEach((req) {
-            if (!state.request.closeOnEOSE) {
-              _sendRequest(relayConnectivity, state.id, req);
-            }
-          });
+          .forEach((req) => _sendRequest(relayConnectivity, state.id, req));
     });
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -480,7 +480,13 @@ class RelayManager<T> {
 
     globalState.inFlightRequests.forEach((key, state) {
       state.requests.values
-          .where((req) => req.url == relayConnectivity.url)
+          // by connection, not by relay: replaying a bound request on the
+          // anonymous socket gets it refused, and replaying an anonymous one on
+          // a bound socket makes it attributable. An entry the relay already
+          // refused stays refused, replaying it only retriggers the re-route.
+          .where(
+            (req) => req.key == relayConnectivity.key && !req.receivedClosed,
+          )
           .forEach((req) {
             if (!state.request.closeOnEOSE) {
               List<dynamic> list = ["REQ", state.id];
@@ -675,8 +681,8 @@ class RelayManager<T> {
         if (allowReconnectRelays &&
             globalState.relays[relayConnectivity.key] != null) {
           Logger.log.i(() => "closed ${relayConnectivity.url}. Reconnecting");
-          reconnectRelay(
-            relayConnectivity.url,
+          reconnectConnection(
+            relayConnectivity.key,
             connectionSource: relayConnectivity.relay.connectionSource,
           ).then((connected) {
             updateRelayConnectivity();

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1459,16 +1459,18 @@ class RelayManager<T> {
     await Future.wait(_connectionKeysForRelay(url).map(closeConnection));
   }
 
-  /// Closes one connection and forgets it
+  /// Closes one connection and forgets it. An entry that lost its transport, to
+  /// a reset or to a failed connection attempt, is forgotten just the same:
+  /// leaving it behind keeps its auth state alive and makes it reconnect.
   Future<void> closeConnection(RelayConnectionKey key) async {
-    RelayConnectivity? connectivity = globalState.relays[key];
-    if (connectivity != null && connectivity.relayTransport != null) {
-      Logger.log.d(() => "Disconnecting $key...");
-      globalState.relays.remove(key);
-      _authenticatedConnections.remove(key);
-      _lastChallengePerConnection.remove(key);
-      return connectivity.close();
+    final connectivity = globalState.relays.remove(key);
+    if (connectivity == null) {
+      return;
     }
+    Logger.log.d(() => "Disconnecting $key...");
+    _authenticatedConnections.remove(key);
+    _lastChallengePerConnection.remove(key);
+    return connectivity.close();
   }
 
   /// Closes all transports

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -309,6 +309,10 @@ class RelayManager<T> {
         },
         onDisconnect: (code, error, reason) {
           relayConnectivity!.stats.connectionErrors++;
+          // the transport reconnects under us and keeps its message stream
+          // open, so this is the only notice we get that the socket the relay
+          // authenticated died
+          _forgetAuthState(connectionKey);
           updateRelayConnectivity();
         },
       );

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -508,14 +508,16 @@ class RelayManager<T> {
               List<dynamic> list = ["REQ", state.id];
               list.addAll(req.filters.map((filter) => filter.toMap()));
 
-              relayConnectivity.stats.activeRequests++;
-              _sendRaw(relayConnectivity, transport, jsonEncode(list));
+              if (_sendRaw(relayConnectivity, transport, jsonEncode(list))) {
+                relayConnectivity.stats.activeRequests++;
+              }
             }
           });
     });
   }
 
-  void _sendRaw(
+  /// Writes [data] and tells whether it reached the transport
+  bool _sendRaw(
     RelayConnectivity relayConnectivity,
     NostrTransport transport,
     dynamic data,
@@ -526,10 +528,11 @@ class RelayManager<T> {
         () =>
             "skip send to ${relayConnectivity.url}: transport changed or closed",
       );
-      return;
+      return false;
     }
     transport.send(data);
     Logger.log.d(() => "send message to ${relayConnectivity.url}: $data");
+    return true;
   }
 
   /// Sends a [ClientMsg] and surfaces transport churn/closed-socket failures to
@@ -571,7 +574,19 @@ class RelayManager<T> {
         "transport closed before send: ${relayConnectivity.url}",
       );
     }
-    _sendRaw(relayConnectivity, transport, encodedMsg);
+    if (_sendRaw(relayConnectivity, transport, encodedMsg)) {
+      _countRequest(relayConnectivity, msg.type);
+    }
+  }
+
+  /// Keeps the open request count of a connection on the connection that
+  /// carries them: a REQ re-routed to another one is not accounted here.
+  void _countRequest(RelayConnectivity relayConnectivity, String type) {
+    if (type == ClientMsgType.kReq) {
+      relayConnectivity.stats.activeRequests++;
+    } else if (type == ClientMsgType.kClose) {
+      relayConnectivity.stats.activeRequests--;
+    }
   }
 
   /// sends a [ClientMsg] to relay transport sink, throw an error if relay not connected
@@ -1192,13 +1207,38 @@ class RelayManager<T> {
       );
       RelayRequestState? request = state.requests[relayConnectivity.key];
       if (request != null) {
-        request.receivedClosed = true;
+        _endRequestOnRelay(relayConnectivity, request);
       }
 
       _checkNetworkClose(state, relayConnectivity);
       _logActiveRequests();
     }
     return;
+  }
+
+  /// Sends [request] on [relayConnectivity] and tracks it as open there
+  void _sendRequest(
+    RelayConnectivity relayConnectivity,
+    String reqId,
+    RelayRequestState request,
+  ) {
+    request.receivedClosed = false;
+    send(
+      relayConnectivity,
+      ClientMsg(ClientMsgType.kReq, id: reqId, filters: request.filters),
+    );
+  }
+
+  /// Marks what the relay itself ended with a CLOSED. It stops counting as open
+  /// on that connection, and there is no CLOSE left for us to send.
+  void _endRequestOnRelay(
+    RelayConnectivity relayConnectivity,
+    RelayRequestState request,
+  ) {
+    if (!request.receivedClosed) {
+      request.receivedClosed = true;
+      relayConnectivity.stats.activeRequests--;
+    }
   }
 
   /// Whether [state] is still the request tracked under [reqId]. A request
@@ -1233,12 +1273,14 @@ class RelayManager<T> {
       return;
     }
 
+    // whatever we do next, the relay just closed this one on this connection
+    _endRequestOnRelay(relayConnectivity, request);
+
     if (!key.isAnonymous) {
       if (_authenticatedConnections.contains(key)) {
         // the relay refused us while we were authenticated as the only identity
         // this connection may ever assume, so there is nothing left to try
         Logger.log.w(() => "REQ $reqId refused on authenticated $key");
-        request.receivedClosed = true;
         _checkNetworkClose(state, relayConnectivity);
         return;
       }
@@ -1251,14 +1293,10 @@ class RelayManager<T> {
         }
         state.resumeTimeout();
         if (!authenticated) {
-          request.receivedClosed = true;
           _checkNetworkClose(state, relayConnectivity);
           return;
         }
-        send(
-          relayConnectivity,
-          ClientMsg(ClientMsgType.kReq, id: reqId, filters: request.filters),
-        );
+        _sendRequest(relayConnectivity, reqId, request);
       });
       return;
     }
@@ -1266,17 +1304,12 @@ class RelayManager<T> {
     final account = _accountForRequest(state);
     if (account == null) {
       Logger.log.w(() => "Cannot satisfy auth-required for REQ $reqId on $key");
-      request.receivedClosed = true;
       _checkNetworkClose(state, relayConnectivity);
       return;
     }
 
     final target = RelayConnectionKey.authenticated(key.url, account.pubkey);
-
-    // register the retry before closing the refused entry, otherwise the
-    // request could complete while the bound connection is opening
     state.addRequest(target, request.filters);
-    request.receivedClosed = true;
 
     Logger.log.d(
       () => "AUTH required for REQ $reqId on $key, retrying on $target",
@@ -1304,10 +1337,7 @@ class RelayManager<T> {
       // sent without waiting for the AUTH: a relay that only challenges on
       // demand needs this request as the trigger, and the refusal that may
       // follow lands on the branch above
-      send(
-        bound,
-        ClientMsg(ClientMsgType.kReq, id: reqId, filters: retry.filters),
-      );
+      _sendRequest(bound, reqId, retry);
     });
   }
 
@@ -1478,7 +1508,6 @@ class RelayManager<T> {
   void _sendCloseToRelay(RelayConnectivity relayConnectivity, String id) {
     try {
       send(relayConnectivity, ClientMsg(ClientMsgType.kClose, id: id));
-      relayConnectivity.stats.activeRequests--;
     } catch (e) {
       Logger.log.e(() => e);
     }

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -47,11 +47,21 @@ class RelayManager<T> {
   /// each socket gets its own challenge, so this cannot be keyed by relay
   final Map<RelayConnectionKey, String> _lastChallengePerConnection = {};
 
-  /// stores pending AUTH callbacks: authEventId -> callback to execute on AUTH OK
-  final Map<String, void Function()> _pendingAuthCallbacks = {};
+  /// stores pending AUTH callbacks: authEventId -> callback run on the relay's
+  /// OK, with whether the relay accepted the AUTH event
+  final Map<String, void Function(bool accepted)> _pendingAuthCallbacks = {};
 
   /// stores timers for pending AUTH callbacks to clean them up on timeout
   final Map<String, Timer> _pendingAuthTimers = {};
+
+  /// waiters for the AUTH challenge of a connection that is being authenticated
+  final Map<RelayConnectionKey, Completer<String>> _challengeWaiters = {};
+
+  /// in flight authentications, so concurrent callers share a single AUTH
+  final Map<RelayConnectionKey, Future<bool>> _authenticating = {};
+
+  /// connections whose AUTH event the relay accepted
+  final Set<RelayConnectionKey> _authenticatedConnections = {};
 
   /// Tracks relay connect attempts that are still finishing setup so callers
   /// can wait for "socket open + listener attached", not just raw socket open.
@@ -59,6 +69,9 @@ class RelayManager<T> {
 
   /// timeout for AUTH callbacks (how long to wait for AUTH OK)
   final Duration authCallbackTimeout;
+
+  /// how long to wait for a NIP-42 challenge once authentication was asked for
+  final Duration authChallengeTimeout;
 
   /// Handler for NIP-77 NEG-MSG messages
   void Function(String subscriptionId, String relayUrl, String payload)?
@@ -98,6 +111,7 @@ class RelayManager<T> {
     allowReconnect = true,
     this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
+    this.authChallengeTimeout = RequestDefaults.DEFAULT_AUTH_CHALLENGE_TIMEOUT,
   }) : _accounts = accounts {
     allowReconnectRelays = allowReconnect;
     _connectSeedRelays(urls: bootstrapRelays ?? DEFAULT_BOOTSTRAP_RELAYS);
@@ -274,6 +288,10 @@ class RelayManager<T> {
       relayConnectivity.relayTransport = nostrTransportFactory(
         url,
         onReconnect: () {
+          // the relay accepted our AUTH on the socket that just died, not on
+          // this one; the binding survives, the authentication does not
+          _authenticatedConnections.remove(connectionKey);
+          _lastChallengePerConnection.remove(connectionKey);
           reSubscribeInFlightSubscriptions(relayConnectivity!);
           updateRelayConnectivity();
         },
@@ -327,22 +345,32 @@ class RelayManager<T> {
     return Tuple(false, "could not connect to $url");
   }
 
-  /// Reconnects to a relay, if the relay is not connected or the connection is closed.
+  /// Reconnects the anonymous connection to a relay, if it is closed.
   Future<bool> reconnectRelay(
     String url, {
     required ConnectionSource connectionSource,
     bool force = false,
+  }) => reconnectConnection(
+    RelayConnectionKey.anonymous(url),
+    connectionSource: connectionSource,
+    force: force,
+  );
+
+  /// Reconnects the connection identified by [key], if it is closed. An
+  /// authenticated connection comes back authenticated or not at all.
+  Future<bool> reconnectConnection(
+    RelayConnectionKey key, {
+    required ConnectionSource connectionSource,
+    bool force = false,
   }) async {
-    final inFlightConnect =
-        _connectReadyCompleters[RelayConnectionKey.anonymous(url)];
+    final inFlightConnect = _connectReadyCompleters[key];
     if (inFlightConnect != null) {
       final connected = await inFlightConnect.future;
       updateRelayConnectivity();
       return connected;
     }
 
-    RelayConnectivity? relayConnectivity =
-        globalState.relays[RelayConnectionKey.anonymous(url)];
+    RelayConnectivity? relayConnectivity = globalState.relays[key];
     if (relayConnectivity != null && relayConnectivity.relayTransport != null) {
       try {
         final opened = await _waitForTransportOpen(
@@ -354,7 +382,7 @@ class RelayManager<T> {
           return true;
         }
       } catch (error) {
-        Logger.log.e(() => "error connecting to relay $url: $error");
+        Logger.log.e(() => "error connecting to $key: $error");
       }
     }
     if (relayConnectivity == null ||
@@ -370,14 +398,28 @@ class RelayManager<T> {
         return false;
       }
 
+      if (!key.isAnonymous) {
+        final account = _accounts?.accounts[key.pubkey];
+        if (account == null) {
+          Logger.log.w(() => "No account left to reconnect $key");
+          return false;
+        }
+        return await openConnectionAs(
+              key.url,
+              account,
+              connectionSource: connectionSource,
+            ) !=
+            null;
+      }
+
       if (!(await connectRelay(
-        dirtyUrl: url,
+        dirtyUrl: key.url,
         connectionSource: connectionSource,
       )).first) {
         // could not connect
         return false;
       }
-      relayConnectivity = globalState.relays[RelayConnectionKey.anonymous(url)];
+      relayConnectivity = globalState.relays[key];
       if (relayConnectivity == null ||
           relayConnectivity.relayTransport == null ||
           !relayConnectivity.relayTransport!.isOpen()) {
@@ -388,17 +430,30 @@ class RelayManager<T> {
     return true;
   }
 
-  /// Closes and clears only transport-scoped state for a relay, while keeping
-  /// the relay entry and relay-scoped metadata in memory.
+  /// Closes and clears only transport-scoped state of every connection to
+  /// [url], while keeping the entries and relay-scoped metadata in memory.
   Future<void> resetTransport(String url) async {
-    final connectivity = globalState.relays[RelayConnectionKey.anonymous(url)];
+    await Future.wait(_connectionKeysForRelay(url).map(resetConnection));
+  }
+
+  /// Closes and clears only transport-scoped state of one connection, while
+  /// keeping its entry and relay-scoped metadata in memory.
+  Future<void> resetConnection(RelayConnectionKey key) async {
+    final connectivity = globalState.relays[key];
     if (connectivity != null) {
-      Logger.log.d(() => "Resetting transport for $url...");
+      Logger.log.d(() => "Resetting transport for $key...");
       connectivity.relay.failedToConnect();
-      _lastChallengePerConnection.remove(connectivity.key);
+      _authenticatedConnections.remove(key);
+      _lastChallengePerConnection.remove(key);
       await connectivity.close();
       updateRelayConnectivity();
     }
+  }
+
+  /// every connection currently held towards [url]
+  List<RelayConnectionKey> _connectionKeysForRelay(String url) {
+    final relayUrl = RelayConnectionKey.anonymous(url).url;
+    return globalState.relays.keys.where((key) => key.url == relayUrl).toList();
   }
 
   /// Reconnects all given relays
@@ -615,6 +670,9 @@ class RelayManager<T> {
             () => "Error closing relay ${relayConnectivity.url}: $e",
           );
         }
+        // the socket is gone, so is the AUTH the relay accepted on it
+        _authenticatedConnections.remove(relayConnectivity.key);
+        _lastChallengePerConnection.remove(relayConnectivity.key);
         updateRelayConnectivity();
         // Reconnect on close. close() above nulls relayTransport, so the only
         // condition is that the relay is still tracked: deliberate closes cancel
@@ -702,12 +760,11 @@ class RelayManager<T> {
         _pendingAuthTimers.remove(eventId);
         if (success) {
           Logger.log.d(() => "AUTH OK for $eventId, executing callback");
-          final callback = _pendingAuthCallbacks.remove(eventId);
-          callback?.call();
         } else {
           Logger.log.e(() => "AUTH failed for $eventId: $msg");
-          _pendingAuthCallbacks.remove(eventId);
         }
+        final callback = _pendingAuthCallbacks.remove(eventId);
+        callback?.call(success);
         return Future.value();
       }
 
@@ -797,51 +854,24 @@ class RelayManager<T> {
     if (nostrMsg.type == NostrMessageRawType.auth) {
       final eventJson = nostrMsg.otherData;
       // nip 42 used to send authentication challenges
-      // NIP-42 allows multiple AUTH events for different pubkeys on the same connection
       final challenge = eventJson[1];
       Logger.log.d(
-        () => "AUTH challenge from ${relayConnectivity.url}: $challenge",
+        () => "AUTH challenge from ${relayConnectivity.key}: $challenge",
       );
 
-      // Store challenge for late authentication (multiple accounts on same connection)
       _lastChallengePerConnection[relayConnectivity.key] = challenge;
 
-      // If not eager auth, don't authenticate now - wait for auth-required
-      if (!eagerAuth) {
-        return Future.value();
+      final waiter = _challengeWaiters.remove(relayConnectivity.key);
+      if (waiter != null && !waiter.isCompleted) {
+        waiter.complete(challenge);
       }
 
-      if (_accounts == null) {
-        Logger.log.w(
-          () => "Received an AUTH challenge but no accounts configured",
-        );
-        return Future.value();
+      // an anonymous connection never answers a challenge: signing here would
+      // bind it to an identity nobody asked for, and every request already on
+      // it would become attributable. A bound one answers as soon as it can.
+      if (!relayConnectivity.key.isAnonymous) {
+        unawaited(authenticateConnection(relayConnectivity.key));
       }
-
-      // Collect accounts from active requests on this relay
-      final accountsToAuth = <Account>{};
-      for (final state in globalState.inFlightRequests.values) {
-        final hasRequestOnThisRelay = state.requests.containsKey(
-          relayConnectivity.key,
-        );
-        if (hasRequestOnThisRelay && state.request.authenticateAs != null) {
-          accountsToAuth.addAll(state.request.authenticateAs!);
-        }
-      }
-
-      // Fallback to logged account if no authenticateAs specified
-      if (accountsToAuth.isEmpty && _accounts.getLoggedAccount() != null) {
-        accountsToAuth.add(_accounts.getLoggedAccount()!);
-      }
-
-      if (accountsToAuth.isEmpty) {
-        Logger.log.w(
-          () => "Received an AUTH challenge but no accounts to authenticate",
-        );
-        return Future.value();
-      }
-
-      _authenticateAccounts(relayConnectivity, challenge, accountsToAuth);
       return Future.value();
     }
     if (nostrMsg.type == NostrMessageRawType.negMsg) {
@@ -871,80 +901,133 @@ class RelayManager<T> {
     // }
   }
 
-  /// Sends AUTH events for the given accounts using the stored challenge
-  void _authenticateAccounts(
-    RelayConnectivity relayConnectivity,
-    String challenge,
-    Set<Account> accounts,
-  ) {
-    // Pause timeout for all requests on this relay during AUTH signing
-    final requestsOnRelay = globalState.inFlightRequests.values
-        .where((state) => state.requests.containsKey(relayConnectivity.key))
-        .toList();
-    for (final state in requestsOnRelay) {
-      state.pauseTimeout();
+  /// Opens the connection towards [url] bound to [account]. The binding says
+  /// which identity this socket may ever assume, not that it is already
+  /// authenticated: relays are free to send their challenge whenever they want,
+  /// and some only send it once a request needs it.
+  Future<RelayConnectivity?> openConnectionAs(
+    String url,
+    Account account, {
+    ConnectionSource connectionSource = ConnectionSource.explicit,
+  }) async {
+    if (!account.signer.canSign()) {
+      Logger.log.w(() => "Cannot bind a connection to ${account.pubkey}");
+      return null;
+    }
+    final key = RelayConnectionKey.authenticated(url, account.pubkey);
+
+    if (isConnectionOpen(key)) {
+      return globalState.relays[key];
     }
 
-    int authCount = 0;
-    for (final account in accounts) {
-      if (account.signer.canSign()) {
-        final auth = AuthEvent(
-          pubKey: account.pubkey,
-          tags: [
-            ["relay", relayConnectivity.url],
-            ["challenge", challenge],
-          ],
-        );
-        account.signer.sign(auth).then((signedAuth) {
-          // Resume timeout for requests after signing completes
-          for (final state in requestsOnRelay) {
-            state.resumeTimeout();
-          }
-          send(
-            relayConnectivity,
-            ClientMsg(ClientMsgType.kAuth, event: signedAuth),
-          );
-          Logger.log.d(
-            () =>
-                "AUTH sent for ${account.pubkey.substring(0, 8)} to ${relayConnectivity.url}",
-          );
-        });
-        authCount++;
-      }
+    final connected = await connectRelay(
+      dirtyUrl: url,
+      connectionSource: connectionSource,
+      authPubkey: account.pubkey,
+    );
+    final connectivity = globalState.relays[key];
+    if (!connected.first || connectivity == null) {
+      Logger.log.w(() => "Could not open $key: ${connected.second}");
+      return null;
     }
+    return connectivity;
+  }
 
-    if (authCount == 0) {
-      // No signing will happen, resume timeouts immediately
-      for (final state in requestsOnRelay) {
-        state.resumeTimeout();
-      }
-      Logger.log.w(() => "Received an AUTH challenge but no account can sign");
+  /// Waits for the AUTH challenge of [key]. Only call this once something has
+  /// asked for authentication, otherwise a relay that only challenges on demand
+  /// would never answer. Returns null if it never arrives.
+  Future<String?> _awaitChallenge(RelayConnectionKey key) async {
+    final stored = _lastChallengePerConnection[key];
+    if (stored != null) {
+      return stored;
+    }
+    final waiter = _challengeWaiters.putIfAbsent(key, Completer<String>.new);
+    try {
+      return await waiter.future.timeout(authChallengeTimeout);
+    } catch (_) {
+      _challengeWaiters.remove(key);
+      Logger.log.w(() => "No AUTH challenge from $key");
+      return null;
     }
   }
 
-  /// Authenticates accounts on a relay if we have a stored challenge.
-  /// Call this when creating a new subscription with authenticateAs.
-  void authenticateIfNeeded(String relayUrl, List<Account> accounts) {
-    final challenge =
-        _lastChallengePerConnection[RelayConnectionKey.anonymous(relayUrl)];
+  /// Answers the challenge for [key] and completes once the relay accepted the
+  /// AUTH event. Concurrent callers share a single AUTH.
+  Future<bool> authenticateConnection(RelayConnectionKey key) {
+    if (key.isAnonymous) {
+      return Future.value(false);
+    }
+    if (_authenticatedConnections.contains(key)) {
+      return Future.value(true);
+    }
+    final inFlight = _authenticating[key];
+    if (inFlight != null) {
+      return inFlight;
+    }
+    final attempt = _sendAuth(key);
+    _authenticating[key] = attempt;
+    return attempt.whenComplete(() => _authenticating.remove(key));
+  }
+
+  Future<bool> _sendAuth(RelayConnectionKey key) async {
+    final connectivity = globalState.relays[key];
+    final account = _accounts?.accounts[key.pubkey];
+    if (connectivity == null || account == null) {
+      return false;
+    }
+    if (!account.signer.canSign()) {
+      Logger.log.w(() => "Cannot authenticate $key, signer cannot sign");
+      return false;
+    }
+
+    // the relay may send its challenge before or with the refusal, so waiting
+    // is safe here: something already asked us to authenticate
+    final challenge = await _awaitChallenge(key);
     if (challenge == null) {
-      Logger.log.t(
-        () => "No stored challenge for $relayUrl, skipping late auth",
-      );
-      return;
+      return false;
     }
 
-    final relayConnectivity =
-        globalState.relays[RelayConnectionKey.anonymous(relayUrl)];
-    if (relayConnectivity == null) {
-      Logger.log.w(() => "Relay $relayUrl not found for late auth");
-      return;
-    }
-
-    Logger.log.d(
-      () => "Late AUTH for ${accounts.length} accounts on $relayUrl",
+    final signedAuth = await account.signer.sign(
+      AuthEvent(
+        pubKey: account.pubkey,
+        tags: [
+          ["relay", key.url],
+          ["challenge", challenge],
+        ],
+      ),
     );
-    _authenticateAccounts(relayConnectivity, challenge, accounts.toSet());
+
+    final accepted = Completer<bool>();
+    _pendingAuthCallbacks[signedAuth.id] = (ok) {
+      if (!accepted.isCompleted) {
+        accepted.complete(ok);
+      }
+    };
+    _pendingAuthTimers[signedAuth.id] = Timer(authCallbackTimeout, () {
+      Logger.log.w(() => "AUTH callback timeout for ${signedAuth.id} on $key");
+      _pendingAuthCallbacks.remove(signedAuth.id);
+      _pendingAuthTimers.remove(signedAuth.id);
+      if (!accepted.isCompleted) {
+        accepted.complete(false);
+      }
+    });
+
+    send(connectivity, ClientMsg(ClientMsgType.kAuth, event: signedAuth));
+    Logger.log.d(() => "AUTH sent on $key");
+
+    if (!await accepted.future) {
+      return false;
+    }
+    _authenticatedConnections.add(key);
+    return true;
+  }
+
+  /// Opens the bound connections a subscription will need, so the re-route on
+  /// auth-required does not have to open a socket first.
+  void authenticateIfNeeded(String relayUrl, List<Account> accounts) {
+    for (final account in accounts.where((a) => a.signer.canSign())) {
+      unawaited(openConnectionAs(relayUrl, account));
+    }
   }
 
   void _handleIncomingEvent(
@@ -1046,7 +1129,11 @@ class RelayManager<T> {
     return;
   }
 
-  /// Handles CLOSED auth-required by authenticating and re-sending the REQ
+  /// Handles CLOSED auth-required.
+  ///
+  /// A connection is bound to at most one identity, and that binding never
+  /// changes. An anonymous connection therefore hands the request over to a
+  /// bound one, while a bound connection answers the challenge itself.
   void _handleClosedAuthRequired(
     String reqId,
     RelayConnectivity relayConnectivity,
@@ -1059,120 +1146,108 @@ class RelayManager<T> {
       return;
     }
 
-    final request = state.requests[relayConnectivity.key];
+    final key = relayConnectivity.key;
+    final request = state.requests[key];
     if (request == null) {
       Logger.log.w(
-        () =>
-            "Received CLOSED auth-required but no request state for ${relayConnectivity.url}",
+        () => "Received CLOSED auth-required but no request state for $key",
       );
       return;
     }
 
-    final challenge = _lastChallengePerConnection[relayConnectivity.key];
-    if (challenge == null) {
-      Logger.log.w(
-        () =>
-            "Received CLOSED auth-required but no challenge stored for ${relayConnectivity.url}",
-      );
-      // Mark this relay as closed since we can't authenticate without a challenge
-      request.receivedClosed = true;
-      _checkNetworkClose(state, relayConnectivity);
-      return;
-    }
+    if (!key.isAnonymous) {
+      if (_authenticatedConnections.contains(key)) {
+        // the relay refused us while we were authenticated as the only identity
+        // this connection may ever assume, so there is nothing left to try
+        Logger.log.w(() => "REQ $reqId refused on authenticated $key");
+        request.receivedClosed = true;
+        _checkNetworkClose(state, relayConnectivity);
+        return;
+      }
 
-    // Collect accounts to authenticate
-    final accountsToAuth = <Account>{};
-    if (state.request.authenticateAs != null &&
-        state.request.authenticateAs!.isNotEmpty) {
-      accountsToAuth.addAll(state.request.authenticateAs!);
-    } else if (_accounts?.getLoggedAccount() != null) {
-      accountsToAuth.add(_accounts!.getLoggedAccount()!);
-    }
-
-    // Filter to accounts that can sign
-    final signableAccounts = accountsToAuth
-        .where((a) => a.signer.canSign())
-        .toList();
-
-    if (signableAccounts.isEmpty) {
-      Logger.log.w(
-        () =>
-            "Received CLOSED auth-required but no account can sign for ${relayConnectivity.url}",
-      );
-      // Mark this relay as closed and check if we can complete the request
-      request.receivedClosed = true;
-      _checkNetworkClose(state, relayConnectivity);
-      return;
-    }
-
-    Logger.log.d(
-      () =>
-          "AUTH required for REQ $reqId on ${relayConnectivity.url}, authenticating ${signableAccounts.length} account(s)...",
-    );
-
-    // Pause timeout during AUTH signing
-    state.pauseTimeout();
-
-    // Track how many AUTH OKs we need before re-sending REQ
-    int pendingAuthCount = signableAccounts.length;
-    int pendingSignCount = signableAccounts.length;
-
-    for (final account in signableAccounts) {
-      final auth = AuthEvent(
-        pubKey: account.pubkey,
-        tags: [
-          ["relay", relayConnectivity.url],
-          ["challenge", challenge],
-        ],
-      );
-
-      account.signer.sign(auth).then((signedAuth) {
-        // Resume timeout after all signings complete
-        pendingSignCount--;
-        if (pendingSignCount == 0) {
-          state.resumeTimeout();
+      Logger.log.d(() => "Authenticating $key to satisfy REQ $reqId");
+      state.pauseTimeout();
+      authenticateConnection(key).then((authenticated) {
+        state.resumeTimeout();
+        if (!authenticated) {
+          request.receivedClosed = true;
+          _checkNetworkClose(state, relayConnectivity);
+          return;
         }
-
-        // Store callback - only re-send REQ after last AUTH OK
-        _pendingAuthCallbacks[signedAuth.id] = () {
-          pendingAuthCount--;
-          if (pendingAuthCount == 0) {
-            Logger.log.d(
-              () =>
-                  "All AUTH OK received, re-sending REQ $reqId to ${relayConnectivity.url}",
-            );
-            List<dynamic> list = ["REQ", reqId];
-            list.addAll(request.filters.map((filter) => filter.toMap()));
-            final transport = relayConnectivity.relayTransport;
-            if (transport != null && transport.isOpen()) {
-              _sendRaw(relayConnectivity, transport, jsonEncode(list));
-            }
-          }
-        };
-
-        // Start timeout timer to clean up orphaned callbacks
-        _pendingAuthTimers[signedAuth.id] = Timer(authCallbackTimeout, () {
-          Logger.log.w(
-            () =>
-                "AUTH callback timeout for ${signedAuth.id} on ${relayConnectivity.url}",
-          );
-          _pendingAuthCallbacks.remove(signedAuth.id);
-          _pendingAuthTimers.remove(signedAuth.id);
-        });
-
         send(
           relayConnectivity,
-          ClientMsg(ClientMsgType.kAuth, event: signedAuth),
-        );
-        Logger.log.d(
-          () =>
-              "AUTH sent for ${account.pubkey.substring(0, 8)} to ${relayConnectivity.url}",
+          ClientMsg(ClientMsgType.kReq, id: reqId, filters: request.filters),
         );
       });
+      return;
     }
+
+    final account = _accountForRequest(state);
+    if (account == null) {
+      Logger.log.w(() => "Cannot satisfy auth-required for REQ $reqId on $key");
+      request.receivedClosed = true;
+      _checkNetworkClose(state, relayConnectivity);
+      return;
+    }
+
+    final target = RelayConnectionKey.authenticated(key.url, account.pubkey);
+
+    // register the retry before closing the refused entry, otherwise the
+    // request could complete while the bound connection is opening
+    state.addRequest(target, request.filters);
+    request.receivedClosed = true;
+
+    Logger.log.d(
+      () => "AUTH required for REQ $reqId on $key, retrying on $target",
+    );
+
+    state.pauseTimeout();
+    openConnectionAs(
+      key.url,
+      account,
+      connectionSource: relayConnectivity.relay.connectionSource,
+    ).then((bound) {
+      state.resumeTimeout();
+      final retry = state.requests[target];
+      if (retry == null) {
+        return;
+      }
+      if (bound == null) {
+        retry.receivedClosed = true;
+        _checkNetworkClose(state, relayConnectivity);
+        return;
+      }
+      // sent without waiting for the AUTH: a relay that only challenges on
+      // demand needs this request as the trigger, and the refusal that may
+      // follow lands on the branch above
+      send(
+        bound,
+        ClientMsg(ClientMsgType.kReq, id: reqId, filters: retry.filters),
+      );
+    });
+  }
+
+  /// Account a request authenticates as: the first one it asks for that can
+  /// sign, otherwise the logged one.
+  Account? _accountForRequest(RequestState state) {
+    final requested = state.request.authenticateAs;
+    if (requested != null && requested.isNotEmpty) {
+      for (final account in requested) {
+        if (account.signer.canSign()) {
+          return account;
+        }
+      }
+      return null;
+    }
+    final logged = _accounts?.getLoggedAccount();
+    return logged != null && logged.signer.canSign() ? logged : null;
   }
 
   /// Handles OK auth-required for broadcasts by authenticating and re-sending the EVENT
+  ///
+  /// This is the last place that still authenticates in place, because
+  /// BroadcastState is keyed by relay url and cannot yet track an event across
+  /// two connections. It goes away with the broadcast lot.
   void _handleBroadcastAuthRequired(
     String eventId,
     RelayConnectivity relayConnectivity,
@@ -1239,7 +1314,10 @@ class RelayManager<T> {
     // Sign and send AUTH, then re-send EVENT on OK
     account.signer.sign(auth).then((signedAuth) {
       // Store callback to re-send EVENT after AUTH OK
-      _pendingAuthCallbacks[signedAuth.id] = () {
+      _pendingAuthCallbacks[signedAuth.id] = (accepted) {
+        if (!accepted) {
+          return;
+        }
         Logger.log.d(
           () =>
               "AUTH OK received, re-sending EVENT $eventId to ${relayConnectivity.url}",
@@ -1347,25 +1425,28 @@ class RelayManager<T> {
     );
   }
 
-  /// Closes this url transport and removes
+  /// Closes every connection towards [url] and forgets them
   Future<void> closeTransport(String url) async {
-    final connectionKey = RelayConnectionKey.anonymous(url);
-    RelayConnectivity? connectivity = globalState.relays[connectionKey];
+    await Future.wait(_connectionKeysForRelay(url).map(closeConnection));
+  }
+
+  /// Closes one connection and forgets it
+  Future<void> closeConnection(RelayConnectionKey key) async {
+    RelayConnectivity? connectivity = globalState.relays[key];
     if (connectivity != null && connectivity.relayTransport != null) {
-      Logger.log.d(() => "Disconnecting $url...");
-      globalState.relays.remove(connectionKey);
-      _lastChallengePerConnection.remove(connectionKey);
+      Logger.log.d(() => "Disconnecting $key...");
+      globalState.relays.remove(key);
+      _authenticatedConnections.remove(key);
+      _lastChallengePerConnection.remove(key);
       return connectivity.close();
     }
   }
 
   /// Closes all transports
   Future<void> closeAllTransports() async {
-    Iterable<String> urls = globalState.relays.keys
-        .map((key) => key.url)
-        .toList();
+    final keys = globalState.relays.keys.toList();
     try {
-      await Future.wait(urls.map((url) => closeTransport(url)));
+      await Future.wait(keys.map(closeConnection));
     } catch (e) {
       Logger.log.e(() => e);
     }

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -515,18 +515,17 @@ class RelayManager<T> {
   /// this is needed so the response from a relay can be tracked back
   void registerRelayRequest({
     required String reqId,
-    required String relayUrl,
+    required RelayConnectionKey connectionKey,
     required List<Filter> filters,
   }) {
     // new tracking
-    if (globalState.inFlightRequests[reqId]!.requests[relayUrl] == null) {
-      globalState.inFlightRequests[reqId]!.requests[relayUrl] =
-          RelayRequestState(relayUrl, filters);
+    if (globalState.inFlightRequests[reqId]!.requests[connectionKey] == null) {
+      globalState.inFlightRequests[reqId]!.requests[connectionKey] =
+          RelayRequestState(connectionKey, filters);
     } else {
       // do not overwrite and add new filters
-      globalState.inFlightRequests[reqId]!.requests[relayUrl]!.filters.addAll(
-        filters,
-      );
+      globalState.inFlightRequests[reqId]!.requests[connectionKey]!.filters
+          .addAll(filters);
     }
   }
 
@@ -822,8 +821,8 @@ class RelayManager<T> {
       // Collect accounts from active requests on this relay
       final accountsToAuth = <Account>{};
       for (final state in globalState.inFlightRequests.values) {
-        final hasRequestOnThisRelay = state.requests.keys.contains(
-          relayConnectivity.url,
+        final hasRequestOnThisRelay = state.requests.containsKey(
+          relayConnectivity.key,
         );
         if (hasRequestOnThisRelay && state.request.authenticateAs != null) {
           accountsToAuth.addAll(state.request.authenticateAs!);
@@ -880,7 +879,7 @@ class RelayManager<T> {
   ) {
     // Pause timeout for all requests on this relay during AUTH signing
     final requestsOnRelay = globalState.inFlightRequests.values
-        .where((state) => state.requests.keys.contains(relayConnectivity.url))
+        .where((state) => state.requests.containsKey(relayConnectivity.key))
         .toList();
     for (final state in requestsOnRelay) {
       state.pauseTimeout();
@@ -968,7 +967,7 @@ class RelayManager<T> {
 
     RequestState? state = globalState.inFlightRequests[requestId];
     if (state != null) {
-      RelayRequestState? request = state.requests[connectivity.url];
+      RelayRequestState? request = state.requests[connectivity.key];
       if (request == null) {
         Logger.log.w(() => "No RelayRequestState found for id $requestId");
         return;
@@ -1002,7 +1001,7 @@ class RelayManager<T> {
         () =>
             "⛁ received EOSE from ${relayConnectivity.url} for REQ id $id, remaining requests from :${state.requests.keys} kind:${state.requests.values.first.filters.first.kinds}",
       );
-      RelayRequestState? request = state.requests[relayConnectivity.url];
+      RelayRequestState? request = state.requests[relayConnectivity.key];
       if (request != null) {
         request.receivedEOSE = true;
       }
@@ -1036,7 +1035,7 @@ class RelayManager<T> {
         () =>
             "⛁ received CLOSE from ${relayConnectivity.url} for REQ id $id, remaining requests from :${state.requests.keys} kind:${state.requests.values.first.filters.first.kinds}",
       );
-      RelayRequestState? request = state.requests[relayConnectivity.url];
+      RelayRequestState? request = state.requests[relayConnectivity.key];
       if (request != null) {
         request.receivedClosed = true;
       }
@@ -1060,7 +1059,7 @@ class RelayManager<T> {
       return;
     }
 
-    final request = state.requests[relayConnectivity.url];
+    final request = state.requests[relayConnectivity.key];
     if (request == null) {
       Logger.log.w(
         () =>
@@ -1286,18 +1285,17 @@ class RelayManager<T> {
 
     /// check if relays for this request are still connected
     /// if not ignore it and wait for the ones still alive to finish
-    final listOfRelaysForThisRequest = state.requests.keys.toList();
+    final connectionsForThisRequest = state.requests.keys.toList();
     final myNotConnectedRelays = globalState.relays.keys
-        .map((key) => key.url)
-        .where((url) => listOfRelaysForThisRequest.contains(url))
-        .where((url) => !isRelayConnected(url))
+        .where((key) => connectionsForThisRequest.contains(key))
+        .where((key) => !isConnectionOpen(key))
         .toList();
 
     final bool didAllRelaysFinish = state.requests.values.every(
       (element) =>
           element.receivedEOSE ||
           element.receivedClosed ||
-          myNotConnectedRelays.contains(element.url),
+          myNotConnectedRelays.contains(element.key),
     );
 
     if (didAllRelaysFinish) {

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -100,9 +100,6 @@ class RelayManager<T> {
   Stream<List<RelayConnectivity>> get relayConnectivityChanges =>
       _relayUpdatesStreamController.stream;
 
-  /// AUTH strategy: eager (on challenge) or lazy (on auth-required)
-  final bool eagerAuth;
-
   /// Creates a new relay manager.
   RelayManager({
     required this.globalState,
@@ -111,7 +108,6 @@ class RelayManager<T> {
     this.engineAdditionalDataFactory,
     List<String>? bootstrapRelays,
     allowReconnect = true,
-    this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
     this.authChallengeTimeout = RequestDefaults.DEFAULT_AUTH_CHALLENGE_TIMEOUT,
   }) : _accounts = accounts {

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -156,6 +156,19 @@ class RelayManager<T> {
       .where((connectivity) => connectivity.isConnected)
       .toList();
 
+  /// Connected connections bound to nobody, one per relay at most.
+  ///
+  /// Engines pick relays, not identities: sending on every connection of a
+  /// relay would duplicate the request, and sending on a bound one would make
+  /// it attributable. An identity is added later, by the re-route, and only on
+  /// the relays that ask for one.
+  List<RelayConnectivity> get connectedAnonymousRelays => globalState
+      .relays
+      .values
+      .where((connectivity) => connectivity.key.isAnonymous)
+      .where((connectivity) => connectivity.isConnected)
+      .toList();
+
   /// checks if a relay is connected, avoid using this
   bool isRelayConnected(String url) =>
       isConnectionOpen(RelayConnectionKey.anonymous(url));

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -92,10 +92,12 @@ class RelayManager<T> {
 
   /// stream controller for relay updates
   final _relayUpdatesStreamController =
-      BehaviorSubject<Map<String, RelayConnectivity>>();
+      BehaviorSubject<List<RelayConnectivity>>();
 
-  /// stream of relay updates, used to notify connectivity changes, latest value is cached
-  Stream<Map<String, RelayConnectivity>> get relayConnectivityChanges =>
+  /// stream of connection updates, used to notify connectivity changes, latest
+  /// value is cached. A relay can hold several connections, so this cannot be
+  /// indexed by url; group by [RelayConnectivity.url] if you need to.
+  Stream<List<RelayConnectivity>> get relayConnectivityChanges =>
       _relayUpdatesStreamController.stream;
 
   /// AUTH strategy: eager (on challenge) or lazy (on auth-required)
@@ -118,10 +120,7 @@ class RelayManager<T> {
   }
 
   void updateRelayConnectivity() {
-    _relayUpdatesStreamController.add({
-      for (final connectivity in globalState.relays.values)
-        connectivity.url: connectivity,
-    });
+    _relayUpdatesStreamController.add(globalState.relays.values.toList());
   }
 
   /// This will initialize the manager with bootstrap relays.

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -457,6 +457,7 @@ class RelayManager<T> {
       connectivity.relay.failedToConnect();
       _forgetAuthState(key);
       await connectivity.close();
+      _endAuthRetriesLeftBehind(key);
       updateRelayConnectivity();
     }
   }
@@ -733,7 +734,24 @@ class RelayManager<T> {
         if (connected) {
           reSubscribeInFlightSubscriptions(relayConnectivity);
         }
+        _endAuthRetriesLeftBehind(relayConnectivity.key);
       });
+      return;
+    }
+    _endAuthRetriesLeftBehind(relayConnectivity.key);
+  }
+
+  /// Gives up on the requests that were still waiting for [key] to replay them.
+  /// A request the replacement socket took back has stopped retrying by now, so
+  /// what is left here is what nothing will send again.
+  void _endAuthRetriesLeftBehind(RelayConnectionKey key) {
+    for (final state in globalState.inFlightRequests.values.toList()) {
+      final request = state.requests[key];
+      if (request == null || !request.retryingAuth) {
+        continue;
+      }
+      request.retryingAuth = false;
+      _checkNetworkClose(state);
     }
   }
 
@@ -1190,7 +1208,7 @@ class RelayManager<T> {
 
       if (state.request.closeOnEOSE) {
         _sendCloseToRelay(relayConnectivity, state.id);
-        _checkNetworkClose(state, relayConnectivity);
+        _checkNetworkClose(state);
         _logActiveRequests();
       }
     }
@@ -1222,7 +1240,7 @@ class RelayManager<T> {
         _endRequestOnRelay(relayConnectivity, request);
       }
 
-      _checkNetworkClose(state, relayConnectivity);
+      _checkNetworkClose(state);
       _logActiveRequests();
     }
     return;
@@ -1294,7 +1312,7 @@ class RelayManager<T> {
         // the relay refused us while we were authenticated as the only identity
         // this connection may ever assume, so there is nothing left to try
         Logger.log.w(() => "REQ $reqId refused on authenticated $key");
-        _checkNetworkClose(state, relayConnectivity);
+        _checkNetworkClose(state);
         return;
       }
 
@@ -1311,7 +1329,7 @@ class RelayManager<T> {
           // an authentication that died with its socket is not a refusal: stay
           // on the retry so the replacement replays the request
           request.retryingAuth = _generationOf(key) != generation;
-          _checkNetworkClose(state, relayConnectivity);
+          _checkNetworkClose(state);
           return;
         }
         _sendRequest(relayConnectivity, reqId, request);
@@ -1322,7 +1340,7 @@ class RelayManager<T> {
     final account = _accountForRequest(state);
     if (account == null) {
       Logger.log.w(() => "Cannot satisfy auth-required for REQ $reqId on $key");
-      _checkNetworkClose(state, relayConnectivity);
+      _checkNetworkClose(state);
       return;
     }
 
@@ -1349,7 +1367,7 @@ class RelayManager<T> {
       }
       if (bound == null) {
         retry.receivedClosed = true;
-        _checkNetworkClose(state, relayConnectivity);
+        _checkNetworkClose(state);
         return;
       }
       // sent without waiting for the AUTH: a relay that only challenges on
@@ -1479,10 +1497,7 @@ class RelayManager<T> {
     });
   }
 
-  void _checkNetworkClose(
-    RequestState state,
-    RelayConnectivity relayConnectivity,
-  ) {
+  void _checkNetworkClose(RequestState state) {
     /// received everything, close the network controller
     if (state.didAllRequestsFinish) {
       state.networkController.close();
@@ -1493,16 +1508,19 @@ class RelayManager<T> {
     /// check if relays for this request are still connected
     /// if not ignore it and wait for the ones still alive to finish. A
     /// connection that was dropped entirely counts as gone too, otherwise a
-    /// request left on it would wait for a socket nobody will reopen.
+    /// request left on it would wait for a socket nobody will reopen. One that
+    /// is retrying its authentication is the exception: its replacement is on
+    /// its way and owes it a replay.
     final myNotConnectedRelays = state.requests.keys
         .where((key) => !isConnectionOpen(key))
         .toList();
 
     final bool didAllRelaysFinish = state.requests.values.every(
       (element) =>
-          ((element.receivedEOSE || element.receivedClosed) &&
-              !element.retryingAuth) ||
-          myNotConnectedRelays.contains(element.key),
+          !element.retryingAuth &&
+          (element.receivedEOSE ||
+              element.receivedClosed ||
+              myNotConnectedRelays.contains(element.key)),
     );
 
     if (didAllRelaysFinish) {
@@ -1571,6 +1589,7 @@ class RelayManager<T> {
     }
     Logger.log.d(() => "Disconnecting $key...");
     _forgetAuthState(key);
+    _endAuthRetriesLeftBehind(key);
     return connectivity.close();
   }
 

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -203,12 +203,18 @@ class RelaySetsEngine implements NetworkEngine {
             "making fallback requests to ${_bootstrapRelays.length} bootstrap relays for ${filter.authors != null ? filter.authors!.length : 0} authors with kinds: ${filter.kinds}",
           );
           for (final url in _bootstrapRelays) {
-            state.addRequest(url, RelaySet.sliceFilterAuthors(filter));
+            state.addRequest(
+              RelayConnectionKey.anonymous(url),
+              RelaySet.sliceFilterAuthors(filter),
+            );
           }
         }
       } else {
         for (final url in relaySet.urls) {
-          state.addRequest(url, RelaySet.sliceFilterAuthors(filter));
+          state.addRequest(
+            RelayConnectionKey.anonymous(url),
+            RelaySet.sliceFilterAuthors(filter),
+          );
         }
       }
     }
@@ -217,15 +223,16 @@ class RelaySetsEngine implements NetworkEngine {
     // Late auth for subscriptions with authenticateAs
     if (state.request.authenticateAs != null &&
         state.request.authenticateAs!.isNotEmpty) {
-      for (final relayUrl in state.requests.keys) {
+      for (final connectionKey in state.requests.keys) {
         _relayManager.authenticateIfNeeded(
-          relayUrl,
+          connectionKey.url,
           state.request.authenticateAs!,
         );
       }
     }
 
-    for (MapEntry<String, RelayRequestState> entry in state.requests.entries) {
+    for (MapEntry<RelayConnectionKey, RelayRequestState> entry
+        in state.requests.entries) {
       doRelayRequest(state.id, entry.value);
     }
   }
@@ -257,25 +264,26 @@ class RelaySetsEngine implements NetworkEngine {
       for (final filter in state.request.filters) {
         filters.addAll(RelaySet.sliceFilterAuthors(filter));
       }
-      state.addRequest(url, filters);
+      state.addRequest(RelayConnectionKey.anonymous(url), filters);
     }
     _globalState.inFlightRequests[state.id] = state;
 
     // Late auth for subscriptions with authenticateAs
     if (state.request.authenticateAs != null &&
         state.request.authenticateAs!.isNotEmpty) {
-      for (final relayUrl in state.requests.keys) {
+      for (final connectionKey in state.requests.keys) {
         _relayManager.authenticateIfNeeded(
-          relayUrl,
+          connectionKey.url,
           state.request.authenticateAs!,
         );
       }
     }
 
-    for (MapEntry<String, RelayRequestState> entry in state.requests.entries) {
+    for (MapEntry<RelayConnectionKey, RelayRequestState> entry
+        in state.requests.entries) {
       doRelayRequest(state.id, entry.value).then((sent) {
         if (!sent) {
-          state.requests.remove(entry.value.url);
+          state.requests.remove(entry.key);
           if (state.requests.isEmpty) {
             state.networkController.close();
           }
@@ -305,14 +313,18 @@ class RelaySetsEngine implements NetworkEngine {
     );
 
     for (var url in urls) {
-      state.addRequest(url, RelaySet.sliceFilterAuthors(filter));
+      state.addRequest(
+        RelayConnectionKey.anonymous(url),
+        RelaySet.sliceFilterAuthors(filter),
+      );
     }
     _globalState.inFlightRequests[state.id] = state;
 
-    for (MapEntry<String, RelayRequestState> entry in state.requests.entries) {
+    for (MapEntry<RelayConnectionKey, RelayRequestState> entry
+        in state.requests.entries) {
       doRelayRequest(state.id, entry.value).then((sent) {
         if (!sent) {
-          state.requests.remove(entry.value.url);
+          state.requests.remove(entry.key);
           // start fix
           if (state.requests.isEmpty) {
             state.networkController.close();

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -382,8 +382,11 @@ class RelaySetsEngine implements NetworkEngine {
           cacheManager: _cacheManager,
         ));
         // make a copy of the keys since connectRelay may mutate the underlying map
+        // several connections can share a url, and broadcasting twice to the
+        // same relay would duplicate the event
         List<String> writeRelaysUrls = _relayManager.globalState.relays.keys
             .map((key) => key.url)
+            .toSet()
             .toList();
         if (nip65List.isNotEmpty) {
           writeRelaysUrls = nip65List.first.relays.entries

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -17,6 +17,7 @@ import '../entities/filter.dart';
 import '../entities/global_state.dart';
 import '../entities/ndk_request.dart';
 import '../entities/nip_01_event.dart';
+import '../entities/relay_connection_key.dart';
 import '../entities/relay_connectivity.dart';
 import '../entities/relay_set.dart';
 import '../entities/request_response.dart';
@@ -67,7 +68,8 @@ class RelaySetsEngine implements NetworkEngine {
       force: false,
     );
     if (connected) {
-      RelayConnectivity? relay = _globalState.relays[request.url];
+      RelayConnectivity? relay =
+          _globalState.relays[RelayConnectionKey.anonymous(request.url)];
       if (relay != null) {
         relay.stats.activeRequests++;
         try {
@@ -369,6 +371,7 @@ class RelaySetsEngine implements NetworkEngine {
         ));
         // make a copy of the keys since connectRelay may mutate the underlying map
         List<String> writeRelaysUrls = _relayManager.globalState.relays.keys
+            .map((key) => key.url)
             .toList();
         if (nip65List.isNotEmpty) {
           writeRelaysUrls = nip65List.first.relays.entries

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -71,7 +71,6 @@ class RelaySetsEngine implements NetworkEngine {
       RelayConnectivity? relay =
           _globalState.relays[RelayConnectionKey.anonymous(request.url)];
       if (relay != null) {
-        relay.stats.activeRequests++;
         try {
           await _relayManager.sendOrThrow(
             relay,

--- a/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
@@ -251,9 +251,9 @@ class Requests {
 
   /// Closes a Nostr network subscription
   Future<void> closeSubscription(String subId, {String debugLabel = ""}) async {
-    final relayUrls = _globalState.inFlightRequests[subId]?.requests.keys;
+    final connectionKeys = _globalState.inFlightRequests[subId]?.requests.keys;
 
-    if (relayUrls == null) {
+    if (connectionKeys == null) {
       Logger.log.w(
         () =>
             "no relay urls found for subscription $subId, cannot close :: debug: $debugLabel",
@@ -262,7 +262,7 @@ class Requests {
     }
     Iterable<RelayConnectivity> relays = _relayManager.connectedRelays
         .whereType<RelayConnectivity>()
-        .where((relay) => relayUrls.contains(relay.url));
+        .where((relay) => connectionKeys.contains(relay.key));
 
     for (final relay in relays) {
       _relayManager.sendCloseToRelay(relay.url, subId);
@@ -570,7 +570,7 @@ class Requests {
     }
 
     for (final entry in state.requests.entries) {
-      final relayUrl = entry.key;
+      final relayUrl = entry.key.url;
       final relayState = entry.value;
 
       if (!relayState.receivedEOSE) continue;

--- a/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
@@ -251,30 +251,31 @@ class Requests {
 
   /// Closes a Nostr network subscription
   Future<void> closeSubscription(String subId, {String debugLabel = ""}) async {
-    final connectionKeys = _globalState.inFlightRequests[subId]?.requests.keys;
+    final state = _globalState.inFlightRequests[subId];
 
-    if (connectionKeys == null) {
+    if (state == null) {
       Logger.log.w(
         () =>
             "no relay urls found for subscription $subId, cannot close :: debug: $debugLabel",
       );
       return;
     }
+
     Iterable<RelayConnectivity> relays = _relayManager.connectedRelays
         .whereType<RelayConnectivity>()
-        .where((relay) => connectionKeys.contains(relay.key));
+        .where((relay) => state.requests.containsKey(relay.key));
 
     for (final relay in relays) {
+      final request = state.requests[relay.key]!;
+      // a request the relay ended itself, with a CLOSED or with the EOSE of a
+      // query, is already closed on its side
+      final endedOnRelay =
+          request.receivedClosed ||
+          (state.request.closeOnEOSE && request.receivedEOSE);
+      if (endedOnRelay) {
+        continue;
+      }
       _relayManager.sendCloseToConnection(relay.key, subId);
-    }
-
-    final state = _globalState.inFlightRequests[subId];
-
-    if (state == null) {
-      Logger.log.w(
-        () => "no request state found for subscription $subId, cannot close",
-      );
-      return;
     }
 
     await state.close();

--- a/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
@@ -265,7 +265,7 @@ class Requests {
         .where((relay) => connectionKeys.contains(relay.key));
 
     for (final relay in relays) {
-      _relayManager.sendCloseToRelay(relay.url, subId);
+      _relayManager.sendCloseToConnection(relay.key, subId);
     }
 
     final state = _globalState.inFlightRequests[subId];

--- a/packages/ndk/lib/entities.dart
+++ b/packages/ndk/lib/entities.dart
@@ -23,6 +23,7 @@ export 'domain_layer/entities/pubkey_mapping.dart';
 export 'domain_layer/entities/read_write.dart';
 export 'domain_layer/entities/read_write_marker.dart';
 export 'domain_layer/entities/relay.dart';
+export 'domain_layer/entities/relay_connection_key.dart';
 export 'domain_layer/entities/relay_connectivity.dart';
 export 'domain_layer/entities/relay_info.dart';
 export 'domain_layer/entities/relay_set.dart';

--- a/packages/ndk/lib/ndk.dart
+++ b/packages/ndk/lib/ndk.dart
@@ -26,6 +26,7 @@ export 'domain_layer/entities/nip_51_list.dart';
 export 'domain_layer/entities/contact_list.dart';
 export 'domain_layer/entities/read_write.dart';
 export 'domain_layer/entities/relay.dart';
+export 'domain_layer/entities/relay_connection_key.dart';
 export 'domain_layer/entities/relay_set.dart';
 export 'domain_layer/entities/metadata.dart';
 export 'domain_layer/entities/event_filter.dart';

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -139,7 +139,6 @@ class Initialization {
           accounts: accounts,
           nostrTransportFactory: _webSocketNostrTransportFactory,
           bootstrapRelays: _ndkConfig.bootstrapRelays,
-          eagerAuth: _ndkConfig.eagerAuth,
           authCallbackTimeout: _ndkConfig.authCallbackTimeout,
         );
 
@@ -157,7 +156,6 @@ class Initialization {
           nostrTransportFactory: _webSocketNostrTransportFactory,
           bootstrapRelays: _ndkConfig.bootstrapRelays,
           engineAdditionalDataFactory: JitEngineRelayConnectivityDataFactory(),
-          eagerAuth: _ndkConfig.eagerAuth,
           authCallbackTimeout: _ndkConfig.authCallbackTimeout,
         );
 

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -112,8 +112,7 @@ class Initialization {
   CacheEvictionScheduler? cacheEvictionScheduler;
   late ProofOfWork proofOfWork;
   late TrustedAssertions trustedAssertions;
-  StreamSubscription<Map<String, RelayConnectivity>>?
-  _relayConnectivitySubscription;
+  StreamSubscription<List<RelayConnectivity>>? _relayConnectivitySubscription;
   final Map<String, bool> _relayOpenStates = {};
 
   late Nip05Usecase nip05;
@@ -409,14 +408,22 @@ class Initialization {
     await _relayConnectivitySubscription?.cancel();
   }
 
-  void _handleRelayConnectivityUpdate(Map<String, RelayConnectivity> relays) {
-    for (final entry in relays.entries) {
-      final relayUrl = entry.key;
-      final isOpen = entry.value.relayTransport?.isOpen() ?? false;
-      final wasOpen = _relayOpenStates[relayUrl] ?? false;
-      _relayOpenStates[relayUrl] = isOpen;
+  void _handleRelayConnectivityUpdate(List<RelayConnectivity> connections) {
+    // deliveries are still addressed by relay, so a relay counts as reachable
+    // as soon as one of its connections is open
+    final openByUrl = <String, bool>{};
+    for (final connection in connections) {
+      final isOpen = connection.relayTransport?.isOpen() ?? false;
+      openByUrl[connection.url] =
+          (openByUrl[connection.url] ?? false) || isOpen;
+    }
 
-      if (isOpen && !wasOpen) {
+    for (final entry in openByUrl.entries) {
+      final relayUrl = entry.key;
+      final wasOpen = _relayOpenStates[relayUrl] ?? false;
+      _relayOpenStates[relayUrl] = entry.value;
+
+      if (entry.value && !wasOpen) {
         unawaited(
           pendingBroadcastDelivery.retryInteractiveSigningForTransportRelay(
             relayUrl,
@@ -427,7 +434,7 @@ class Initialization {
     }
 
     final removedUrls = _relayOpenStates.keys
-        .where((relayUrl) => !relays.containsKey(relayUrl))
+        .where((relayUrl) => !openByUrl.containsKey(relayUrl))
         .toList();
     for (final relayUrl in removedUrls) {
       _relayOpenStates.remove(relayUrl);

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -78,9 +78,10 @@ class NdkConfig {
   /// Disabled by default for performance.
   bool fetchedRangesEnabled;
 
-  /// If true, AUTH immediately when relay sends challenge.
-  /// If false (default), AUTH only after relay responds with auth-required.
-  /// False is more privacy-respecting as it doesn't reveal identity until necessary.
+  /// Has no effect. A connection now carries at most one identity, chosen when
+  /// it is opened: an anonymous connection never answers a challenge and a
+  /// bound one always does, so there is nothing left to choose.
+  @Deprecated('Has no effect, a connection is bound to an identity or to none')
   bool eagerAuth;
 
   /// Timeout for AUTH callbacks (how long to wait for AUTH OK response).
@@ -138,6 +139,7 @@ class NdkConfig {
     this.userAgent = RequestDefaults.DEFAULT_USER_AGENT,
     this.cashuUserSeedphrase,
     this.fetchedRangesEnabled = false,
+    // ignore: deprecated_member_use_from_same_package
     this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
     this.pendingDeliveryRetryInterval = const Duration(seconds: 15),

--- a/packages/ndk/test/entities/relay_connection_key_test.dart
+++ b/packages/ndk/test/entities/relay_connection_key_test.dart
@@ -1,0 +1,155 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final pubkeyA = Bip340.generatePrivateKey().publicKey;
+  final pubkeyB = Bip340.generatePrivateKey().publicKey;
+
+  group('RelayConnectionKey normalization', () {
+    test('equivalent urls produce the same key', () {
+      final variants = [
+        'wss://relay.example.com',
+        'wss://relay.example.com/',
+        'wss://Relay.Example.com',
+        'wss://relay.example.com:443',
+        '  wss://relay.example.com  ',
+        'wss:///relay.example.com',
+      ];
+
+      final keys = variants.map(RelayConnectionKey.anonymous).toSet();
+
+      expect(keys, hasLength(1));
+      expect(keys.single.url, 'wss://relay.example.com');
+    });
+
+    test('different relays produce different keys', () {
+      expect(
+        RelayConnectionKey.anonymous('wss://a.example.com'),
+        isNot(RelayConnectionKey.anonymous('wss://b.example.com')),
+      );
+    });
+
+    test('an unparsable url is kept as given instead of throwing', () {
+      final key = RelayConnectionKey.anonymous('  not a url  ');
+
+      expect(key.url, 'not a url');
+      expect(key.isAnonymous, isTrue);
+    });
+  });
+
+  group('RelayConnectionKey identity', () {
+    test('anonymous and authenticated keys differ for the same relay', () {
+      final anonymous = RelayConnectionKey.anonymous('wss://relay.example.com');
+      final authenticated = RelayConnectionKey.authenticated(
+        'wss://relay.example.com',
+        pubkeyA,
+      );
+
+      expect(anonymous, isNot(authenticated));
+      expect(anonymous.isAnonymous, isTrue);
+      expect(authenticated.isAnonymous, isFalse);
+      expect(authenticated.pubkey, pubkeyA);
+    });
+
+    test('two accounts on the same relay produce different keys', () {
+      expect(
+        RelayConnectionKey.authenticated('wss://relay.example.com', pubkeyA),
+        isNot(
+          RelayConnectionKey.authenticated('wss://relay.example.com', pubkeyB),
+        ),
+      );
+    });
+
+    test('pubkey case does not create a second connection', () {
+      final upper = RelayConnectionKey.authenticated(
+        'wss://relay.example.com',
+        pubkeyA.toUpperCase(),
+      );
+      final lower = RelayConnectionKey.authenticated(
+        'wss://relay.example.com',
+        pubkeyA,
+      );
+
+      expect(upper, lower);
+      expect(upper.hashCode, lower.hashCode);
+      expect(upper.pubkey, pubkeyA);
+    });
+
+    test('a pubkey that is not 64 hex characters is rejected', () {
+      expect(
+        () =>
+            RelayConnectionKey.authenticated('wss://relay.example.com', 'abc'),
+        throwsArgumentError,
+      );
+      expect(
+        () => RelayConnectionKey.authenticated(
+          'wss://relay.example.com',
+          'npub1${'0' * 59}',
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('RelayConnectionKey as a map key', () {
+    test('lookup succeeds across url spellings', () {
+      final relays = <RelayConnectionKey, String>{
+        RelayConnectionKey.anonymous('wss://relay.example.com'): 'anonymous',
+        RelayConnectionKey.authenticated('wss://relay.example.com', pubkeyA):
+            'authenticated',
+      };
+
+      expect(
+        relays[RelayConnectionKey.anonymous('wss://relay.example.com/')],
+        'anonymous',
+      );
+      expect(
+        relays[RelayConnectionKey.authenticated(
+          'wss://RELAY.example.com',
+          pubkeyA.toUpperCase(),
+        )],
+        'authenticated',
+      );
+      expect(relays, hasLength(2));
+    });
+  });
+
+  group('RelayConnectionKey canonical form', () {
+    test('marks the anonymous connection', () {
+      expect(
+        RelayConnectionKey.anonymous('wss://relay.example.com/').canonical,
+        'wss://relay.example.com|anon',
+      );
+    });
+
+    test('carries the pubkey when authenticated', () {
+      expect(
+        RelayConnectionKey.authenticated(
+          'wss://relay.example.com',
+          pubkeyA,
+        ).canonical,
+        'wss://relay.example.com|$pubkeyA',
+      );
+    });
+
+    test('is what the key prints as', () {
+      final key = RelayConnectionKey.authenticated(
+        'wss://relay.example.com',
+        pubkeyA,
+      );
+
+      expect(key.toString(), key.canonical);
+    });
+
+    test('the anonymous marker cannot be produced by a real pubkey', () {
+      expect(
+        () => RelayConnectionKey.authenticated(
+          'wss://relay.example.com',
+          RelayConnectionKey.anonymousMarker,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -249,23 +249,23 @@ class MockRelay {
             : serverChallenge;
 
         if (customWelcomeMessage != null) {
-          webSocket.add(customWelcomeMessage!);
+          _send(webSocket, customWelcomeMessage!);
         }
         if ((requireAuthForRequests || requireAuthForEvents) &&
             sendAuthChallenge) {
-          webSocket.add(jsonEncode(["AUTH", challenge]));
+          _send(webSocket, jsonEncode(["AUTH", challenge]));
         }
         webSocket.listen(
           (message) async {
             if (allwaysSendBadJson) {
-              webSocket.add('{"bad_json":,}');
+              _send(webSocket, '{"bad_json":,}');
               return;
             }
             if (delayResponse != null) {
               await Future.delayed(delayResponse);
             }
             if (message == "ping") {
-              webSocket.add("pong");
+              _send(webSocket, "pong");
               return;
             }
             var eventJson = json.decode(message);
@@ -282,7 +282,8 @@ class MockRelay {
                 }
               }
 
-              webSocket.add(
+              _send(
+                webSocket,
                 jsonEncode([
                   "OK",
                   event.id,
@@ -298,7 +299,8 @@ class MockRelay {
                 _receivedEvents.add(newEvent);
                 if (rejectFirstEventPublishes > 0) {
                   rejectFirstEventPublishes--;
-                  webSocket.add(
+                  _send(
+                    webSocket,
                     jsonEncode(["OK", newEvent.id, false, rejectEventMessage]),
                   );
                   return;
@@ -307,7 +309,8 @@ class MockRelay {
 
                 // Check auth for events if required (any authenticated user is OK)
                 if (requireAuthForEvents && authenticatedPubkeys.isEmpty) {
-                  webSocket.add(
+                  _send(
+                    webSocket,
                     jsonEncode([
                       "OK",
                       newEvent.id,
@@ -399,9 +402,10 @@ class MockRelay {
                 if (shouldBroadcastToSubscriptions) {
                   _broadcastEventToSubscriptions(newEvent);
                 }
-                webSocket.add(jsonEncode(["OK", newEvent.id, true, ""]));
+                _send(webSocket, jsonEncode(["OK", newEvent.id, true, ""]));
               } else {
-                webSocket.add(
+                _send(
+                  webSocket,
                   jsonEncode(["OK", newEvent.id, false, "invalid signature"]),
                 );
               }
@@ -437,7 +441,8 @@ class MockRelay {
 
               // Check auth: any authenticated user can access all data
               if (requireAuthForRequests && authenticatedPubkeys.isEmpty) {
-                webSocket.add(
+                _send(
+                  webSocket,
                   jsonEncode([
                     "CLOSED",
                     requestId,
@@ -456,7 +461,7 @@ class MockRelay {
                 log(
                   "MockRelay: No valid filters provided for REQ $requestId, sending EOSE.",
                 );
-                webSocket.add(jsonEncode(["EOSE", requestId]));
+                _send(webSocket, jsonEncode(["EOSE", requestId]));
               }
               return;
             }
@@ -498,6 +503,17 @@ class MockRelay {
     return myPromise.future;
   }
 
+  /// Handlers can still be running after the connection was dropped, and
+  /// writing to a closed socket throws. readyState is not a usable guard: it
+  /// still reads as open right after close().
+  void _send(WebSocket socket, Object message) {
+    try {
+      socket.add(message);
+    } on StateError {
+      log('MockRelay: dropped a message for a closed socket');
+    }
+  }
+
   void _respondToRequest(
     WebSocket webSocket,
     List<Filter> filters,
@@ -506,8 +522,8 @@ class MockRelay {
     if (sendMalformedEvents) {
       final malformedEventJson =
           '["EVENT", "$requestId", {"id":null,"pubkey":null,"created_at":${DateTime.now().millisecondsSinceEpoch ~/ 1000},"kind":0,"tags":[],"content":null,"sig":null}]';
-      webSocket.add(malformedEventJson);
-      webSocket.add(jsonEncode(["EOSE", requestId]));
+      _send(webSocket, malformedEventJson);
+      _send(webSocket, jsonEncode(["EOSE", requestId]));
       return;
     }
 
@@ -682,7 +698,8 @@ class MockRelay {
     }
 
     for (final event in eventsToSend) {
-      webSocket.add(
+      _send(
+        webSocket,
         jsonEncode([
           "EVENT",
           requestId,
@@ -691,7 +708,7 @@ class MockRelay {
       );
     }
 
-    webSocket.add(jsonEncode(["EOSE", requestId]));
+    _send(webSocket, jsonEncode(["EOSE", requestId]));
   }
 
   /// Check if event matches since/until time filters
@@ -729,7 +746,10 @@ class MockRelay {
 
     // Send to all connected clients
     for (var clientSocket in _clientSubscriptions.keys) {
-      clientSocket.add(jsonEncode(["EVENT", subId, eventToSendModel.toJson()]));
+      _send(
+        clientSocket,
+        jsonEncode(["EVENT", subId, eventToSendModel.toJson()]),
+      );
     }
   }
 
@@ -737,7 +757,7 @@ class MockRelay {
   void sendClosed(String subId, {String message = ""}) {
     // Send to all connected clients
     for (var clientSocket in _clientSubscriptions.keys) {
-      clientSocket.add(jsonEncode(["CLOSED", subId, message]));
+      _send(clientSocket, jsonEncode(["CLOSED", subId, message]));
     }
   }
 
@@ -776,7 +796,8 @@ class MockRelay {
 
         for (var filter in filters) {
           if (_eventMatchesFilter(event, filter)) {
-            clientSocket.add(
+            _send(
+              clientSocket,
               jsonEncode([
                 "EVENT",
                 subscriptionId,
@@ -840,6 +861,8 @@ class MockRelay {
   /// Closes all connected client sockets while keeping the server running,
   /// simulating a relay-side disconnect.
   Future<void> closeClientSockets() async {
+    // Upgraded sockets are detached from the HttpServer, closing the server
+    // leaves them open, so they have to be closed one by one.
     final sockets = _clientSubscriptions.keys.toList();
     for (final socket in sockets) {
       await socket.close();
@@ -850,9 +873,11 @@ class MockRelay {
   Future<void> stopServer() async {
     if (server != null) {
       log('Closing server on localhost:$url');
+      // stop accepting before dropping the sockets, otherwise a client that
+      // reconnects on its own can come back in between and survive the stop
       await server!.close(force: true);
       server = null;
-      _clientSubscriptions.clear();
+      await closeClientSockets();
       _authenticatedPubkeys.clear();
       _requestedSubscriptions.clear();
     }

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -34,7 +34,28 @@ class MockRelay {
   // Track all connected clients with their subscriptions
   final Map<WebSocket, Map<String, List<Filter>>> _clientSubscriptions = {};
 
+  // NIP-42 authentication is per connection, so it is tracked per socket
+  final Map<WebSocket, Set<String>> _authenticatedPubkeys = {};
+
   int get connectedClientCount => _clientSubscriptions.length;
+
+  /// subscription ids carried by connections authenticated as [pubkey]
+  Set<String> subscriptionsAuthenticatedAs(String pubkey) => {
+    for (final entry in _clientSubscriptions.entries)
+      if (_authenticatedPubkeys[entry.key]?.contains(pubkey) ?? false)
+        ...entry.value.keys,
+  };
+
+  /// every REQ received per socket, recorded even when the relay refuses it
+  final Map<WebSocket, Set<String>> _requestedSubscriptions = {};
+
+  /// subscription ids that were requested on a connection which is not
+  /// authenticated as [pubkey], whether or not the relay served them
+  Set<String> subscriptionsRequestedOutside(String pubkey) => {
+    for (final entry in _requestedSubscriptions.entries)
+      if (!(_authenticatedPubkeys[entry.key]?.contains(pubkey) ?? false))
+        ...entry.value,
+  };
 
   int get activeSubscriptionCount => _clientSubscriptions.values.fold<int>(
     0,
@@ -206,7 +227,7 @@ class MockRelay {
         _clientSubscriptions[webSocket] = {};
 
         // NIP-42 authentication belongs to the connection, not to the server
-        Set<String> authenticatedPubkeys = {};
+        final authenticatedPubkeys = _authenticatedPubkeys[webSocket] = {};
 
         if (customWelcomeMessage != null) {
           webSocket.add(customWelcomeMessage!);
@@ -389,6 +410,12 @@ class MockRelay {
                 }
               }
 
+              // recorded before the auth check, so a REQ that gets refused is
+              // still visible to tests
+              _requestedSubscriptions
+                  .putIfAbsent(webSocket, () => {})
+                  .add(requestId);
+
               // Check auth: any authenticated user can access all data
               if (requireAuthForRequests && authenticatedPubkeys.isEmpty) {
                 webSocket.add(
@@ -435,6 +462,8 @@ class MockRelay {
           onDone: () {
             // Clean up when client disconnects
             _clientSubscriptions.remove(webSocket);
+            _authenticatedPubkeys.remove(webSocket);
+            _requestedSubscriptions.remove(webSocket);
             log("MockRelay: Client disconnected");
           },
         );
@@ -805,6 +834,8 @@ class MockRelay {
       await server!.close(force: true);
       server = null;
       _clientSubscriptions.clear();
+      _authenticatedPubkeys.clear();
+      _requestedSubscriptions.clear();
     }
     _releaseReservedPort(_port);
   }

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -57,6 +57,12 @@ class MockRelay {
         ...entry.value,
   };
 
+  /// how many connections carried a REQ for [subscriptionId]
+  int connectionsThatRequested(String subscriptionId) => _requestedSubscriptions
+      .values
+      .where((ids) => ids.contains(subscriptionId))
+      .length;
+
   int get activeSubscriptionCount => _clientSubscriptions.values.fold<int>(
     0,
     (count, subscriptions) => count + subscriptions.length,

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -41,6 +41,9 @@ class MockRelay {
   /// died, so a re-authentication can be told apart from a surviving one
   int acceptedAuths = 0;
 
+  /// every AUTH the relay received, answered or not
+  int receivedAuths = 0;
+
   int get connectedClientCount => _clientSubscriptions.length;
 
   /// subscription ids carried by connections authenticated as [pubkey]
@@ -91,6 +94,10 @@ class MockRelay {
   String? signEventContentOverride;
   int rejectFirstEventPublishes;
   String rejectEventMessage;
+
+  /// how many AUTH events are left unanswered, the way a relay that goes quiet
+  /// in the middle of an authentication does. The next ones are answered
+  int silenceFirstAuths;
 
   // NIP-46 Remote Signer Support
   static const int kNip46Kind = BunkerRequest.kKind;
@@ -170,6 +177,7 @@ class MockRelay {
     this.signEventContentOverride,
     this.rejectFirstEventPublishes = 0,
     this.rejectEventMessage = 'rate-limited: retry later',
+    this.silenceFirstAuths = 0,
     int? explicitPort,
   }) : _nip65s = nip65s,
        _explicitPort = explicitPort,
@@ -275,6 +283,11 @@ class MockRelay {
             var eventJson = json.decode(message);
 
             if (eventJson[0] == "AUTH") {
+              receivedAuths++;
+              if (silenceFirstAuths > 0) {
+                silenceFirstAuths--;
+                return;
+              }
               Nip01Event event = Nip01EventModel.fromJson(eventJson[1]);
               bool authSuccess = false;
               if (verify(event.pubKey, event.id, event.sig!)) {

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -199,12 +199,14 @@ class MockRelay {
 
     // Generate challenge once for the entire server lifetime (fixes race condition on reconnect)
     final String challenge = Helpers.getRandomString(10);
-    Set<String> authenticatedPubkeys = {};
 
     stream.listen(
       (webSocket) {
         // Register this client
         _clientSubscriptions[webSocket] = {};
+
+        // NIP-42 authentication belongs to the connection, not to the server
+        Set<String> authenticatedPubkeys = {};
 
         if (customWelcomeMessage != null) {
           webSocket.add(customWelcomeMessage!);

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -57,6 +57,11 @@ class MockRelay {
         ...entry.value,
   };
 
+  /// how many live connections are authenticated as [pubkey]
+  int connectionsAuthenticatedAs(String pubkey) => _authenticatedPubkeys.values
+      .where((pubkeys) => pubkeys.contains(pubkey))
+      .length;
+
   /// how many connections carried a REQ for [subscriptionId]
   int connectionsThatRequested(String subscriptionId) => _requestedSubscriptions
       .values
@@ -71,6 +76,9 @@ class MockRelay {
   bool requireAuthForRequests;
   bool requireAuthForEvents;
   bool sendAuthChallenge;
+
+  /// what real relays do: a challenge belongs to a socket, not to the server
+  bool challengePerConnection;
   bool allwaysSendBadJson;
   bool sendMalformedEvents;
   String? customWelcomeMessage;
@@ -149,6 +157,7 @@ class MockRelay {
     this.requireAuthForRequests = false,
     this.requireAuthForEvents = false,
     this.sendAuthChallenge = true,
+    this.challengePerConnection = false,
     this.allwaysSendBadJson = false,
     this.sendMalformedEvents = false,
     this.customWelcomeMessage,
@@ -225,7 +234,7 @@ class MockRelay {
     var stream = server.transform(WebSocketTransformer());
 
     // Generate challenge once for the entire server lifetime (fixes race condition on reconnect)
-    final String challenge = Helpers.getRandomString(10);
+    final String serverChallenge = Helpers.getRandomString(10);
 
     stream.listen(
       (webSocket) {
@@ -234,6 +243,10 @@ class MockRelay {
 
         // NIP-42 authentication belongs to the connection, not to the server
         final authenticatedPubkeys = _authenticatedPubkeys[webSocket] = {};
+
+        final challenge = challengePerConnection
+            ? Helpers.getRandomString(10)
+            : serverChallenge;
 
         if (customWelcomeMessage != null) {
           webSocket.add(customWelcomeMessage!);

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -37,6 +37,10 @@ class MockRelay {
   // NIP-42 authentication is per connection, so it is tracked per socket
   final Map<WebSocket, Set<String>> _authenticatedPubkeys = {};
 
+  /// every AUTH the relay accepted, kept even after the socket that sent it
+  /// died, so a re-authentication can be told apart from a surviving one
+  int acceptedAuths = 0;
+
   int get connectedClientCount => _clientSubscriptions.length;
 
   /// subscription ids carried by connections authenticated as [pubkey]
@@ -278,6 +282,7 @@ class MockRelay {
                 String? eventChallenge = event.getFirstTag("challenge");
                 if (eventChallenge == challenge && relay == url) {
                   authenticatedPubkeys.add(event.pubKey);
+                  acceptedAuths++;
                   authSuccess = true;
                 }
               }

--- a/packages/ndk/test/mocks/mock_relay_live_subscription_test.dart
+++ b/packages/ndk/test/mocks/mock_relay_live_subscription_test.dart
@@ -241,7 +241,13 @@ void main() {
 
       // Backdate the last connect attempt so the reconnect-on-close path is
       // not suppressed by the FAIL_RELAY_CONNECT_TRY_AFTER_SECONDS throttle.
-      ndkA.relays.globalState.relays[mockRelay.url]!.relay.lastConnectTry = 0;
+      ndkA
+              .relays
+              .globalState
+              .relays[RelayConnectionKey.anonymous(mockRelay.url)]!
+              .relay
+              .lastConnectTry =
+          0;
 
       // Relay-side disconnect: the server stays up, only the sockets die.
       await mockRelay.closeClientSockets();

--- a/packages/ndk/test/mocks/mock_relay_stop_server_test.dart
+++ b/packages/ndk/test/mocks/mock_relay_stop_server_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'mock_relay.dart';
+
+void main() {
+  test('stopServer closes the client websockets', () async {
+    final relay = MockRelay(name: 'stop server relay');
+    await relay.startServer();
+
+    final client = await WebSocket.connect(relay.url);
+    var closed = false;
+    client.listen((_) {}, onDone: () => closed = true);
+
+    await Future.delayed(const Duration(milliseconds: 100));
+    expect(client.readyState, WebSocket.open);
+
+    await relay.stopServer();
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    expect(closed, isTrue);
+    expect(client.readyState, WebSocket.closed);
+  });
+}

--- a/packages/ndk/test/relays/active_requests_test.dart
+++ b/packages/ndk/test/relays/active_requests_test.dart
@@ -1,0 +1,100 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+  fail(reason);
+}
+
+Map<RelayConnectionKey, int> _activeRequests(Ndk ndk) => {
+  for (final entry in ndk.relays.globalState.relays.entries)
+    entry.key: entry.value.stats.activeRequests,
+};
+
+void main() {
+  test('a query leaves no active request behind', () async {
+    final relay = MockRelay(name: "relay");
+    await relay.startServer();
+
+    final ndk = Ndk(
+      NdkConfig(
+        eventVerifier: Bip340EventVerifier(),
+        cache: MemCacheManager(),
+        bootstrapRelays: [relay.url],
+      ),
+    );
+
+    final response = ndk.requests.query(
+      filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+    );
+    await response.future;
+    await ndk.requests.closeSubscription(response.requestId);
+
+    expect(_activeRequests(ndk).values, everyElement(0));
+
+    await ndk.destroy();
+    await relay.stopServer();
+  });
+
+  test(
+    'a subscription re-routed for auth is counted on the connection carrying it',
+    timeout: const Timeout(Duration(seconds: 60)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final relay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+      );
+      await relay.startServer();
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final response = ndk.requests.subscription(
+        filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+      );
+      final subId = response.requestId;
+
+      await _waitUntil(
+        () => relay.subscriptionsAuthenticatedAs(key.publicKey).contains(subId),
+        reason: 'the subscription never reached an authenticated connection',
+      );
+
+      // the anonymous connection was refused, the bound one carries it
+      expect(_activeRequests(ndk), {
+        RelayConnectionKey.anonymous(relay.url): 0,
+        RelayConnectionKey.authenticated(relay.url, key.publicKey): 1,
+      });
+
+      await ndk.requests.closeSubscription(subId);
+
+      expect(_activeRequests(ndk).values, everyElement(0));
+
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
+}

--- a/packages/ndk/test/relays/auth_retry_reconnect_test.dart
+++ b/packages/ndk/test/relays/auth_retry_reconnect_test.dart
@@ -1,0 +1,94 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_event_verifier.dart';
+import '../mocks/mock_relay.dart';
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+  fail(reason);
+}
+
+void main() {
+  test(
+    'a query retrying its authentication is not closed by another relay',
+    timeout: const Timeout(Duration(seconds: 120)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final note = Nip01Event(
+        kind: Nip01Event.kTextNodeKind,
+        pubKey: key.publicKey,
+        content: "served after the reconnect",
+        tags: [],
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+
+      final authRelay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+        challengePerConnection: true,
+        // the authentication the query waits on is still unanswered when the
+        // relay goes away, so it fails while the connection has no socket
+        silenceFirstAuths: 1,
+      );
+      final slowRelay = MockRelay(name: "slow relay");
+      await authRelay.startServer(textNotes: {key: note});
+      // answers late enough for its EOSE to land while the other relay is gone
+      await slowRelay.startServer(delayResponse: const Duration(seconds: 5));
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [authRelay.url, slowRelay.url],
+        ),
+      );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final response = ndk.requests.query(
+        filter: Filter(authors: [key.publicKey]),
+        timeout: const Duration(seconds: 60),
+      );
+
+      await _waitUntil(
+        () => authRelay.receivedAuths == 1,
+        reason: 'the query never authenticated',
+      );
+
+      await authRelay.stopServer();
+      // the EOSE of the other relay lands here, on a request whose last relay
+      // is retrying its authentication on a socket that is not back yet
+      await Future<void>.delayed(const Duration(seconds: 6));
+      await authRelay.startServer(textNotes: {key: note});
+
+      final events = await response.future;
+
+      expect(
+        events.map((e) => e.content),
+        contains("served after the reconnect"),
+        reason:
+            'a request retrying its authentication must outlive the relays '
+            'that finished, and be replayed once its connection is back',
+      );
+
+      await ndk.destroy();
+      await authRelay.stopServer();
+      await slowRelay.stopServer();
+    },
+  );
+}

--- a/packages/ndk/test/relays/nip42_close_during_auth_test.dart
+++ b/packages/ndk/test/relays/nip42_close_during_auth_test.dart
@@ -1,0 +1,82 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+import '../mocks/mock_slow_signer.dart';
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+  fail(reason);
+}
+
+void main() {
+  test(
+    'a request closed while its authentication is pending is not sent again',
+    timeout: const Timeout(Duration(seconds: 60)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final relay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+      );
+      await relay.startServer();
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+      // slow enough that the close below lands while the AUTH is still pending
+      ndk.accounts.loginExternalSigner(
+        signer: MockSlowSigner(
+          innerSigner: Bip340EventSigner(
+            privateKey: key.privateKey!,
+            publicKey: key.publicKey,
+          ),
+          delay: const Duration(seconds: 3),
+        ),
+      );
+
+      final response = ndk.requests.subscription(
+        filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+      );
+      final subId = response.requestId;
+
+      // the anonymous attempt and the retry on the bound connection both got
+      // refused, so the bound one is now waiting on the AUTH we slowed down
+      await _waitUntil(
+        () => relay.connectionsThatRequested(subId) == 2,
+        reason: 'the request never reached the bound connection',
+      );
+
+      await ndk.requests.closeSubscription(subId);
+
+      await Future<void>.delayed(const Duration(seconds: 6));
+
+      expect(
+        relay.subscriptionsAuthenticatedAs(key.publicKey),
+        isNot(contains(subId)),
+        reason: "a closed request must not be sent once AUTH completes",
+      );
+      expect(relay.connectionsThatRequested(subId), 2);
+      expect(relay.activeSubscriptionCount, 0);
+
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
+}

--- a/packages/ndk/test/relays/nip42_reconnect_test.dart
+++ b/packages/ndk/test/relays/nip42_reconnect_test.dart
@@ -3,6 +3,7 @@ import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:test/test.dart';
 
 import '../mocks/mock_relay.dart';
+import '../mocks/mock_slow_signer.dart';
 
 /// Waits until [condition] holds, polling so the test does not depend on
 /// reconnect backoff timings.
@@ -22,6 +23,61 @@ Future<void> _waitUntil(
 }
 
 void main() {
+  test(
+    'a subscription whose authentication died with its socket comes back',
+    timeout: const Timeout(Duration(seconds: 90)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final relay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+        challengePerConnection: true,
+      );
+      await relay.startServer();
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+      // the AUTH the request waits on is still being signed when the socket dies
+      ndk.accounts.loginExternalSigner(
+        signer: MockSlowSigner(
+          innerSigner: Bip340EventSigner(
+            privateKey: key.privateKey!,
+            publicKey: key.publicKey,
+          ),
+          delay: const Duration(seconds: 3),
+        ),
+      );
+
+      final response = ndk.requests.subscription(
+        filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+      );
+      final subId = response.requestId;
+
+      await _waitUntil(
+        () => relay.connectionsThatRequested(subId) == 2,
+        reason: 'the request never reached the bound connection',
+      );
+
+      await relay.closeClientSockets();
+
+      await _waitUntil(
+        () => relay.subscriptionsAuthenticatedAs(key.publicKey).contains(subId),
+        timeout: const Duration(seconds: 30),
+        reason: 'the subscription was given up on instead of being replayed',
+      );
+
+      await ndk.requests.closeSubscription(subId);
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
+
   test(
     'a bound connection comes back and replays only its own subscriptions',
     timeout: const Timeout(Duration(seconds: 60)),

--- a/packages/ndk/test/relays/nip42_reconnect_test.dart
+++ b/packages/ndk/test/relays/nip42_reconnect_test.dart
@@ -1,0 +1,77 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+
+/// Waits until [condition] holds, polling so the test does not depend on
+/// reconnect backoff timings.
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+  fail(reason);
+}
+
+void main() {
+  test(
+    'a bound connection comes back and replays only its own subscriptions',
+    timeout: const Timeout(Duration(seconds: 60)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final relay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+      );
+      await relay.startServer();
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final response = ndk.requests.subscription(
+        filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+      );
+      final subId = response.requestId;
+
+      await _waitUntil(
+        () => relay.subscriptionsAuthenticatedAs(key.publicKey).contains(subId),
+        reason: 'the subscription never reached an authenticated connection',
+      );
+
+      await relay.closeClientSockets();
+
+      await _waitUntil(
+        () => relay.subscriptionsAuthenticatedAs(key.publicKey).contains(subId),
+        reason: 'the bound connection never came back with its subscription',
+      );
+
+      expect(
+        relay.subscriptionsRequestedOutside(key.publicKey),
+        isNot(contains(subId)),
+        reason: "a bound subscription must not be replayed on another connection",
+      );
+
+      await ndk.requests.closeSubscription(subId);
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
+}

--- a/packages/ndk/test/relays/nip42_test.dart
+++ b/packages/ndk/test/relays/nip42_test.dart
@@ -448,5 +448,115 @@ void main() async {
         await relay1.stopServer();
       },
     );
+
+    test(
+      'auth-required opens a second connection instead of promoting',
+      () async {
+        MockRelay relay1 = MockRelay(
+          name: "relay 1",
+          explicitPort: 3906,
+          requireAuthForRequests: true,
+          signEvents: false,
+        );
+
+        final note1 = textNote(key1, "note from key1");
+        await relay1.startServer(textNotes: {key1: note1});
+
+        final ndk = Ndk(
+          NdkConfig(
+            eventVerifier: Bip340EventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay1.url],
+          ),
+        );
+
+        ndk.accounts.loginPrivateKey(
+          pubkey: key1.publicKey,
+          privkey: key1.privateKey!,
+        );
+
+        await Future.delayed(Duration(seconds: 1));
+
+        final response = ndk.requests.query(
+          filter: Filter(
+            kinds: [Nip01Event.kTextNodeKind],
+            authors: [key1.publicKey],
+          ),
+        );
+        expect(await response.future, isNotEmpty);
+
+        final keysForRelay = ndk.relays.globalState.relays.keys
+            .where((key) => key.url == relay1.url)
+            .toList();
+
+        expect(
+          keysForRelay.where((key) => key.isAnonymous),
+          hasLength(1),
+          reason: 'the anonymous connection must stay anonymous',
+        );
+        expect(
+          keysForRelay.where((key) => key.pubkey == key1.publicKey),
+          hasLength(1),
+          reason: 'the request must move to its own authenticated connection',
+        );
+
+        await ndk.destroy();
+        await relay1.stopServer();
+      },
+    );
+
+    test('closing all transports leaves no authenticated connection', () async {
+      MockRelay relay1 = MockRelay(
+        name: "relay 1",
+        explicitPort: 3907,
+        requireAuthForRequests: true,
+        signEvents: false,
+      );
+
+      await relay1.startServer(
+        textNotes: {key1: textNote(key1, "note from key1")},
+      );
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay1.url],
+        ),
+      );
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: key1.publicKey,
+        privkey: key1.privateKey!,
+      );
+
+      await Future.delayed(Duration(seconds: 1));
+
+      await ndk.requests
+          .query(
+            filter: Filter(
+              kinds: [Nip01Event.kTextNodeKind],
+              authors: [key1.publicKey],
+            ),
+          )
+          .future;
+
+      expect(
+        ndk.relays.globalState.relays.keys.where((key) => !key.isAnonymous),
+        isNotEmpty,
+        reason: 'the query must have opened an authenticated connection',
+      );
+
+      await ndk.relays.closeAllTransports();
+
+      expect(
+        ndk.relays.globalState.relays,
+        isEmpty,
+        reason: 'an authenticated connection must not survive the close',
+      );
+
+      await ndk.destroy();
+      await relay1.stopServer();
+    });
   });
 }

--- a/packages/ndk/test/relays/nip42_test.dart
+++ b/packages/ndk/test/relays/nip42_test.dart
@@ -10,7 +10,17 @@ import 'package:test/test.dart';
 import '../mocks/mock_relay.dart';
 
 void main() async {
-  group('NIP-42', () {
+  for (final engine in NdkEngine.values) {
+    nip42Tests(engine);
+  }
+}
+
+/// The AUTH re-route lives under the engines, so both must reach an
+/// authenticated connection the same way.
+void nip42Tests(NdkEngine engine) {
+  final portBase = 3900 + engine.index * 20;
+
+  group('NIP-42 [${engine.name}]', () {
     KeyPair key1 = Bip340.generatePrivateKey();
 
     Map<KeyPair, String> keyNames = {key1: "key1"};
@@ -35,7 +45,7 @@ void main() async {
     test('respond to auth challenge', () async {
       MockRelay relay1 = MockRelay(
         name: "relay 1",
-        explicitPort: 3900,
+        explicitPort: portBase,
         requireAuthForRequests: true,
         signEvents: false,
       );
@@ -47,6 +57,7 @@ void main() async {
           cache: MemCacheManager(),
           // logLevel: Logger.logLevels.trace,
           bootstrapRelays: [relay1.url],
+          engine: engine,
         ),
       );
 
@@ -74,7 +85,7 @@ void main() async {
       () async {
         MockRelay relay1 = MockRelay(
           name: "relay 1",
-          explicitPort: 3900,
+          explicitPort: portBase,
           requireAuthForRequests: true,
         );
         await relay1.startServer(textNotes: key1TextNotes);
@@ -85,6 +96,7 @@ void main() async {
             cache: MemCacheManager(),
             // logLevel: Logger.logLevels.trace,
             bootstrapRelays: [relay1.url],
+            engine: engine,
           ),
         );
 
@@ -103,7 +115,7 @@ void main() async {
     );
   });
 
-  group('NIP-42 authenticateAs', () {
+  group('NIP-42 authenticateAs [${engine.name}]', () {
     KeyPair key1 = Bip340.generatePrivateKey();
     KeyPair key2 = Bip340.generatePrivateKey();
 
@@ -125,7 +137,7 @@ void main() async {
     test('authenticateAs sends AUTH for specified pubkey', () async {
       MockRelay relay1 = MockRelay(
         name: "relay 1",
-        explicitPort: 3901,
+        explicitPort: portBase + 1,
         requireAuthForRequests: true,
         signEvents: false,
       );
@@ -138,6 +150,7 @@ void main() async {
           eventVerifier: Bip340EventVerifier(),
           cache: MemCacheManager(),
           bootstrapRelays: [relay1.url],
+          engine: engine,
         ),
       );
 
@@ -178,7 +191,7 @@ void main() async {
     test('authenticateAs with multiple accounts sends AUTH for all', () async {
       MockRelay relay1 = MockRelay(
         name: "relay 1",
-        explicitPort: 3902,
+        explicitPort: portBase + 2,
         requireAuthForRequests: true,
         signEvents: false,
       );
@@ -192,6 +205,7 @@ void main() async {
           eventVerifier: Bip340EventVerifier(),
           cache: MemCacheManager(),
           bootstrapRelays: [relay1.url],
+          engine: engine,
         ),
       );
 
@@ -246,7 +260,7 @@ void main() async {
       () async {
         MockRelay relay1 = MockRelay(
           name: "relay 1",
-          explicitPort: 3903,
+          explicitPort: portBase + 3,
           requireAuthForRequests: true,
           signEvents: false,
         );
@@ -260,6 +274,7 @@ void main() async {
             eventVerifier: Bip340EventVerifier(),
             cache: MemCacheManager(),
             bootstrapRelays: [relay1.url],
+            engine: engine,
           ),
         );
 
@@ -333,7 +348,7 @@ void main() async {
       () async {
         MockRelay relay1 = MockRelay(
           name: "relay 1",
-          explicitPort: 3905,
+          explicitPort: portBase + 5,
           requireAuthForRequests: true,
           signEvents: false,
         );
@@ -347,6 +362,7 @@ void main() async {
             eventVerifier: Bip340EventVerifier(),
             cache: MemCacheManager(),
             bootstrapRelays: [relay1.url],
+            engine: engine,
           ),
         );
 
@@ -408,7 +424,7 @@ void main() async {
       () async {
         MockRelay relay1 = MockRelay(
           name: "relay 1",
-          explicitPort: 3904,
+          explicitPort: portBase + 4,
           requireAuthForRequests: true,
           signEvents: false,
         );
@@ -421,6 +437,7 @@ void main() async {
             eventVerifier: Bip340EventVerifier(),
             cache: MemCacheManager(),
             bootstrapRelays: [relay1.url],
+            engine: engine,
           ),
         );
 
@@ -454,7 +471,7 @@ void main() async {
       () async {
         MockRelay relay1 = MockRelay(
           name: "relay 1",
-          explicitPort: 3906,
+          explicitPort: portBase + 6,
           requireAuthForRequests: true,
           signEvents: false,
         );
@@ -467,6 +484,7 @@ void main() async {
             eventVerifier: Bip340EventVerifier(),
             cache: MemCacheManager(),
             bootstrapRelays: [relay1.url],
+            engine: engine,
           ),
         );
 
@@ -508,7 +526,7 @@ void main() async {
     test('closing all transports leaves no authenticated connection', () async {
       MockRelay relay1 = MockRelay(
         name: "relay 1",
-        explicitPort: 3907,
+        explicitPort: portBase + 7,
         requireAuthForRequests: true,
         signEvents: false,
       );
@@ -522,6 +540,7 @@ void main() async {
           eventVerifier: Bip340EventVerifier(),
           cache: MemCacheManager(),
           bootstrapRelays: [relay1.url],
+          engine: engine,
         ),
       );
 

--- a/packages/ndk/test/relays/nip42_transport_generation_test.dart
+++ b/packages/ndk/test/relays/nip42_transport_generation_test.dart
@@ -1,0 +1,80 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+import '../mocks/mock_slow_signer.dart';
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 25),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+  fail(reason);
+}
+
+void main() {
+  test(
+    'an authentication started on a dead socket does not stall its replacement',
+    timeout: const Timeout(Duration(seconds: 90)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final relay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+        challengePerConnection: true,
+      );
+      await relay.startServer();
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: Bip340EventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+      // the AUTH of the first socket is still being signed when it dies
+      ndk.accounts.loginExternalSigner(
+        signer: MockSlowSigner(
+          innerSigner: Bip340EventSigner(
+            privateKey: key.privateKey!,
+            publicKey: key.publicKey,
+          ),
+          delay: const Duration(seconds: 3),
+        ),
+      );
+
+      final response = ndk.requests.subscription(
+        filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+      );
+      final subId = response.requestId;
+
+      await _waitUntil(
+        () => relay.connectionsThatRequested(subId) == 2,
+        reason: 'the request never reached the bound connection',
+      );
+
+      await relay.closeClientSockets();
+
+      // the replacement socket must answer its own challenge. Sharing the
+      // attempt of the dead one replays a challenge this socket never sent,
+      // and the relay refuses it
+      await _waitUntil(
+        () => relay.connectionsAuthenticatedAs(key.publicKey) == 1,
+        reason: 'the replacement socket never authenticated',
+      );
+
+      await ndk.requests.closeSubscription(subId);
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
+}

--- a/packages/ndk/test/relays/query_replay_on_reconnect_test.dart
+++ b/packages/ndk/test/relays/query_replay_on_reconnect_test.dart
@@ -1,0 +1,81 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+import '../mocks/mock_event_verifier.dart';
+
+/// Waits until [condition] holds, polling so the test does not depend on
+/// reconnect backoff timings.
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+  fail(reason);
+}
+
+void main() {
+  test(
+    'a query whose socket died before EOSE is replayed on the new one',
+    timeout: const Timeout(Duration(seconds: 90)),
+    () async {
+      final author = Bip340.generatePrivateKey();
+      final note = Nip01Event(
+        kind: Nip01Event.kTextNodeKind,
+        pubKey: author.publicKey,
+        content: "survived the reconnect",
+        tags: [],
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+
+      final relay = MockRelay(name: "slow relay");
+      // holds every REQ long enough for the socket to die before the answer
+      await relay.startServer(
+        textNotes: {author: note},
+        delayResponse: const Duration(seconds: 5),
+      );
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+
+      final response = ndk.requests.query(
+        filter: Filter(authors: [author.publicKey]),
+        timeout: const Duration(seconds: 40),
+      );
+
+      await _waitUntil(
+        () => relay.connectedClientCount == 1,
+        reason: 'the query never reached the relay',
+      );
+      await Future<void>.delayed(const Duration(seconds: 1));
+
+      await relay.closeClientSockets();
+
+      final events = await response.future;
+
+      expect(
+        events.map((e) => e.content),
+        contains("survived the reconnect"),
+        reason:
+            'a query that lost its socket before EOSE must go back up on the '
+            'replacement connection instead of timing out empty',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
+}

--- a/packages/ndk/test/relays/relay_manager_test.dart
+++ b/packages/ndk/test/relays/relay_manager_test.dart
@@ -147,6 +147,33 @@ void main() async {
         // success
       }
     });
+    test('closing forgets a connection that lost its transport', () async {
+      MockRelay relay1 = MockRelay(name: "relay 1");
+      await relay1.startServer();
+
+      RelayManager manager = RelayManager(
+        globalState: GlobalState(),
+        bootstrapRelays: [relay1.url],
+        nostrTransportFactory: webSocketNostrTransportFactory,
+      );
+      await manager.connectRelay(
+        dirtyUrl: relay1.url,
+        connectionSource: ConnectionSource.seed,
+      );
+      expect(manager.globalState.relays, isNotEmpty);
+
+      await manager.resetTransport(relay1.url);
+      await manager.closeAllTransports();
+
+      expect(
+        manager.globalState.relays,
+        isEmpty,
+        reason: "a connection without transport must not survive the close",
+      );
+
+      await relay1.stopServer();
+    });
+
     test('Try to connect to wss://brb.io', skip: true, () async {
       RelayManager manager = RelayManager(
         nostrTransportFactory: webSocketNostrTransportFactory,

--- a/packages/ndk/test/relays/relay_manager_test.dart
+++ b/packages/ndk/test/relays/relay_manager_test.dart
@@ -57,7 +57,10 @@ void main() async {
           });
 
       expect(
-        manager.globalState.relays[relay1.url]!.relay
+        manager
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay1.url)]!
+            .relay
             .wasLastConnectTryLongerThanSeconds(120),
         false,
       );
@@ -91,7 +94,8 @@ void main() async {
       }
       expect(relay1.connectedClientCount, 1);
 
-      final relayConnectivity = manager.globalState.relays[relay1.url]!;
+      final relayConnectivity =
+          manager.globalState.relays[RelayConnectionKey.anonymous(relay1.url)]!;
       expect(relayConnectivity.stats.connections, 1);
 
       // Backdate the last connect attempt so the reconnect is not suppressed
@@ -120,7 +124,8 @@ void main() async {
       // Keep the teardown from racing another reconnect attempt against the
       // stopped server.
       manager.allowReconnectRelays = false;
-      await manager.globalState.relays[relay1.url]?.close();
+      await manager.globalState.relays[RelayConnectionKey.anonymous(relay1.url)]
+          ?.close();
       await relay1.stopServer();
     });
 

--- a/packages/ndk/test/relays/relay_manager_test.dart
+++ b/packages/ndk/test/relays/relay_manager_test.dart
@@ -214,23 +214,29 @@ void main() async {
         // Register the request with both relays
         manager.registerRelayRequest(
           reqId: requestId,
-          relayUrl: relay1.url,
+          connectionKey: RelayConnectionKey.anonymous(relay1.url),
           filters: testFilters,
         );
         manager.registerRelayRequest(
           reqId: requestId,
-          relayUrl: relay2.url,
+          connectionKey: RelayConnectionKey.anonymous(relay2.url),
           filters: testFilters,
         );
 
         // Verify both relay requests are registered
         expect(manager.globalState.inFlightRequests[requestId], isNotNull);
         expect(
-          manager.globalState.inFlightRequests[requestId]!.requests[relay1.url],
+          manager
+              .globalState
+              .inFlightRequests[requestId]!
+              .requests[RelayConnectionKey.anonymous(relay1.url)],
           isNotNull,
         );
         expect(
-          manager.globalState.inFlightRequests[requestId]!.requests[relay2.url],
+          manager
+              .globalState
+              .inFlightRequests[requestId]!
+              .requests[RelayConnectionKey.anonymous(relay2.url)],
           isNotNull,
         );
 
@@ -277,7 +283,10 @@ void main() async {
 
         // The request should still have relay2's entry, but relay1's should be removed or marked as closed
         expect(
-          manager.globalState.inFlightRequests[requestId]!.requests[relay2.url],
+          manager
+              .globalState
+              .inFlightRequests[requestId]!
+              .requests[RelayConnectionKey.anonymous(relay2.url)],
           isNotNull,
           reason: "Relay2's request entry should still exist",
         );

--- a/packages/ndk/test/relays/socket_error_reconnect_test.dart
+++ b/packages/ndk/test/relays/socket_error_reconnect_test.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+
+import 'package:ndk/data_layer/repositories/nostr_transport/websocket_nostr_transport_factory.dart';
+import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
+import 'package:ndk/domain_layer/repositories/nostr_transport.dart';
+import 'package:ndk/domain_layer/usecases/accounts/accounts.dart';
+import 'package:ndk/domain_layer/usecases/relay_manager.dart';
+import 'package:ndk/entities.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 15),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+  fail(reason);
+}
+
+/// A real transport whose stream can be made to end with an error, the way a
+/// socket that breaks instead of closing cleanly does.
+class _FaultyTransport implements NostrTransport {
+  _FaultyTransport(this._inner);
+
+  final NostrTransport _inner;
+  final StreamController _out = StreamController();
+  StreamSubscription? _innerSubscription;
+
+  void breakStream() => _out.addError(StateError("socket blew up"));
+
+  @override
+  StreamSubscription listen(
+    void Function(dynamic) onData, {
+    Function? onError,
+    void Function()? onDone,
+  }) {
+    _innerSubscription = _inner.listen(
+      _out.add,
+      onError: _out.addError,
+      onDone: _out.close,
+    );
+    return _out.stream.listen(onData, onError: onError, onDone: onDone);
+  }
+
+  @override
+  Future<void> close() async {
+    await _innerSubscription?.cancel();
+    _innerSubscription = null;
+    if (!_out.isClosed) {
+      await _out.close();
+    }
+    await _inner.close();
+  }
+
+  @override
+  Future<void> get ready => _inner.ready;
+
+  @override
+  set ready(Future<void> value) => _inner.ready = value;
+
+  @override
+  bool isOpen() => _inner.isOpen();
+
+  @override
+  bool isConnecting() => _inner.isConnecting();
+
+  @override
+  void send(data) => _inner.send(data);
+
+  @override
+  int? closeCode() => _inner.closeCode();
+
+  @override
+  String? closeReason() => _inner.closeReason();
+}
+
+class _FaultyTransportFactory implements NostrTransportFactory {
+  final _inner = WebSocketNostrTransportFactory();
+  final List<_FaultyTransport> created = [];
+
+  @override
+  NostrTransport call(
+    String url, {
+    Function? onReconnect,
+    Function(int?, Object?, String?)? onDisconnect,
+  }) {
+    final transport = _FaultyTransport(
+      _inner(url, onReconnect: onReconnect, onDisconnect: onDisconnect),
+    );
+    created.add(transport);
+    return transport;
+  }
+}
+
+void main() {
+  test('a socket that ends with an error reconnects', () async {
+    final relay = MockRelay(name: "relay 1");
+    await relay.startServer();
+
+    final factory = _FaultyTransportFactory();
+    final manager = RelayManager(
+      globalState: GlobalState(),
+      bootstrapRelays: [relay.url],
+      nostrTransportFactory: factory,
+    );
+    await manager.connectRelay(
+      dirtyUrl: relay.url,
+      connectionSource: ConnectionSource.seed,
+    );
+
+    final connectivity =
+        manager.globalState.relays[RelayConnectionKey.anonymous(relay.url)]!;
+    expect(connectivity.stats.connections, 1);
+
+    // otherwise FAIL_RELAY_CONNECT_TRY_AFTER_SECONDS suppresses the reconnect
+    connectivity.relay.lastConnectTry = 0;
+
+    factory.created.last.breakStream();
+
+    await _waitUntil(
+      () => connectivity.stats.connections >= 2,
+      reason:
+          'a socket that ended with an error must be reconnected, like one '
+          'that closed cleanly',
+    );
+
+    await manager.closeAllTransports();
+    await relay.stopServer();
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test(
+    'an authentication does not survive a socket that ended with an error',
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final accounts = Accounts(const Bip340EventSignerFactory());
+      accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final relay = MockRelay(
+        name: "relay requiring auth",
+        requireAuthForRequests: true,
+        signEvents: false,
+        challengePerConnection: true,
+      );
+      await relay.startServer();
+
+      final factory = _FaultyTransportFactory();
+      final manager = RelayManager(
+        globalState: GlobalState(),
+        bootstrapRelays: [],
+        nostrTransportFactory: factory,
+        accounts: accounts,
+      );
+
+      final account = accounts.getLoggedAccount()!;
+      final connectivity = await manager.openConnectionAs(relay.url, account);
+      expect(connectivity, isNotNull);
+      expect(await manager.authenticateConnection(connectivity!.key), true);
+      expect(relay.acceptedAuths, 1);
+
+      connectivity.relay.lastConnectTry = 0;
+      factory.created.last.breakStream();
+
+      await _waitUntil(
+        () => relay.acceptedAuths == 2,
+        reason:
+            'the replacement socket never answered its own challenge: the '
+            'AUTH the relay accepted on the socket that broke was kept',
+      );
+      expect(relay.connectionsAuthenticatedAs(key.publicKey), 1);
+
+      await manager.closeAllTransports();
+      await relay.stopServer();
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+}

--- a/packages/ndk/test/relays/transient_disconnect_test.dart
+++ b/packages/ndk/test/relays/transient_disconnect_test.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
 import 'package:ndk/data_layer/repositories/nostr_transport/websocket_nostr_transport_factory.dart';
-import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
 import 'package:ndk/domain_layer/repositories/nostr_transport.dart';
-import 'package:ndk/domain_layer/usecases/accounts/accounts.dart';
 import 'package:ndk/domain_layer/usecases/relay_manager.dart';
 import 'package:ndk/entities.dart';
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/client_msg.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:test/test.dart';
@@ -13,17 +13,29 @@ import 'package:test/test.dart';
 import '../mocks/mock_relay.dart';
 
 /// A transport that loses its connection the way web_socket_client does: the
-/// message stream stays open across the outage, so only onDisconnect fires.
+/// message stream stays open across the outage, so only onDisconnect fires,
+/// and a send issued while it is down waits on [ready] and flushes once the
+/// connection is back.
 class _FlakyTransport implements NostrTransport {
-  _FlakyTransport(this._inner, {this.onDisconnect});
+  _FlakyTransport(this._inner, {this.onDisconnect, this.onReconnect});
 
   final NostrTransport _inner;
   final Function(int?, Object?, String?)? onDisconnect;
+  final Function? onReconnect;
   bool _down = false;
+  Completer<void>? _downReady;
 
   void dropConnection() {
     _down = true;
+    _downReady = Completer<void>();
     onDisconnect?.call(1006, null, "connection lost");
+  }
+
+  void restoreConnection() {
+    _down = false;
+    _downReady?.complete();
+    _downReady = null;
+    onReconnect?.call();
   }
 
   @override
@@ -37,7 +49,7 @@ class _FlakyTransport implements NostrTransport {
   Future<void> close() => _inner.close();
 
   @override
-  Future<void> get ready => _inner.ready;
+  Future<void> get ready => _downReady?.future ?? _inner.ready;
 
   @override
   set ready(Future<void> value) => _inner.ready = value;
@@ -74,6 +86,7 @@ class _FlakyTransportFactory implements NostrTransportFactory {
     final transport = _FlakyTransport(
       _inner(url, onReconnect: onReconnect, onDisconnect: onDisconnect),
       onDisconnect: onDisconnect,
+      onReconnect: onReconnect,
     );
     created.add(transport);
     return transport;
@@ -170,4 +183,130 @@ void main() {
     await manager.closeAllTransports();
     await relay.stopServer();
   }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test(
+    'a subscription replayed after a transient disconnect is counted once',
+    () async {
+      final subscribed = await _subscribeOnFlakyRelay();
+      final connectivity = subscribed.connectivity;
+
+      subscribed.transport.dropConnection();
+      expect(
+        connectivity.stats.activeRequests,
+        0,
+        reason: 'the requests died with the socket that carried them',
+      );
+
+      subscribed.transport.restoreConnection();
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(
+        connectivity.stats.activeRequests,
+        1,
+        reason:
+            'the replayed subscription was counted on top of the one the dead '
+            'socket carried',
+      );
+
+      subscribed.manager.sendCloseToConnection(connectivity.key, _subId);
+      await _waitUntil(() => connectivity.stats.activeRequests == 0);
+
+      await subscribed.tearDown();
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test('a subscription closed during an outage is counted once', () async {
+    final subscribed = await _subscribeOnFlakyRelay();
+    final connectivity = subscribed.connectivity;
+
+    subscribed.transport.dropConnection();
+    // the CLOSE waits for the socket to come back, and by then nothing replays
+    // the subscription: it is not in flight anymore
+    subscribed.manager.sendCloseToConnection(connectivity.key, _subId);
+    subscribed.manager.globalState.inFlightRequests.remove(_subId);
+
+    subscribed.transport.restoreConnection();
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    expect(
+      connectivity.stats.activeRequests,
+      0,
+      reason: 'the late CLOSE counted below what the connection had open',
+    );
+
+    await subscribed.tearDown();
+  }, timeout: const Timeout(Duration(seconds: 60)));
+}
+
+const _subId = "sub";
+
+class _SubscribedOnFlakyRelay {
+  _SubscribedOnFlakyRelay(this.manager, this.connectivity, this.transport,
+      this._relay);
+
+  final RelayManager manager;
+  final RelayConnectivity connectivity;
+  final _FlakyTransport transport;
+  final MockRelay _relay;
+
+  Future<void> tearDown() async {
+    await manager.closeAllTransports();
+    await _relay.stopServer();
+  }
+}
+
+/// Opens a connection carrying one subscription, counted as open on it
+Future<_SubscribedOnFlakyRelay> _subscribeOnFlakyRelay() async {
+  final relay = MockRelay(name: "relay", signEvents: false);
+  await relay.startServer();
+
+  final factory = _FlakyTransportFactory();
+  final manager = RelayManager(
+    globalState: GlobalState(),
+    bootstrapRelays: [],
+    nostrTransportFactory: factory,
+  );
+  await manager.connectRelay(
+    dirtyUrl: relay.url,
+    connectionSource: ConnectionSource.seed,
+  );
+
+  final connectionKey = RelayConnectionKey.anonymous(relay.url);
+  final connectivity = manager.globalState.relays[connectionKey]!;
+  final filters = [
+    Filter(kinds: [Nip01Event.kTextNodeKind]),
+  ];
+  manager.globalState.inFlightRequests[_subId] = RequestState(
+    NdkRequest.subscription(_subId, filters: filters),
+  );
+  manager.registerRelayRequest(
+    reqId: _subId,
+    connectionKey: connectionKey,
+    filters: filters,
+  );
+  manager.send(
+    connectivity,
+    ClientMsg(ClientMsgType.kReq, id: _subId, filters: filters),
+  );
+  await _waitUntil(() => connectivity.stats.activeRequests == 1);
+
+  return _SubscribedOnFlakyRelay(
+    manager,
+    connectivity,
+    factory.created.last,
+    relay,
+  );
+}
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+  fail('condition never became true');
 }

--- a/packages/ndk/test/relays/transient_disconnect_test.dart
+++ b/packages/ndk/test/relays/transient_disconnect_test.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:ndk/data_layer/repositories/nostr_transport/websocket_nostr_transport_factory.dart';
+import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
+import 'package:ndk/domain_layer/repositories/nostr_transport.dart';
+import 'package:ndk/domain_layer/usecases/accounts/accounts.dart';
+import 'package:ndk/domain_layer/usecases/relay_manager.dart';
+import 'package:ndk/entities.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:ndk/shared/nips/nip01/key_pair.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_relay.dart';
+
+/// A transport that loses its connection the way web_socket_client does: the
+/// message stream stays open across the outage, so only onDisconnect fires.
+class _FlakyTransport implements NostrTransport {
+  _FlakyTransport(this._inner, {this.onDisconnect});
+
+  final NostrTransport _inner;
+  final Function(int?, Object?, String?)? onDisconnect;
+  bool _down = false;
+
+  void dropConnection() {
+    _down = true;
+    onDisconnect?.call(1006, null, "connection lost");
+  }
+
+  @override
+  StreamSubscription listen(
+    void Function(dynamic) onData, {
+    Function? onError,
+    void Function()? onDone,
+  }) => _inner.listen(onData, onError: onError, onDone: onDone);
+
+  @override
+  Future<void> close() => _inner.close();
+
+  @override
+  Future<void> get ready => _inner.ready;
+
+  @override
+  set ready(Future<void> value) => _inner.ready = value;
+
+  @override
+  bool isOpen() => !_down && _inner.isOpen();
+
+  @override
+  bool isConnecting() => _down || _inner.isConnecting();
+
+  @override
+  void send(data) {
+    if (_down) return;
+    _inner.send(data);
+  }
+
+  @override
+  int? closeCode() => _down ? 1006 : _inner.closeCode();
+
+  @override
+  String? closeReason() => _down ? "connection lost" : _inner.closeReason();
+}
+
+class _FlakyTransportFactory implements NostrTransportFactory {
+  final _inner = WebSocketNostrTransportFactory();
+  final List<_FlakyTransport> created = [];
+
+  @override
+  NostrTransport call(
+    String url, {
+    Function? onReconnect,
+    Function(int?, Object?, String?)? onDisconnect,
+  }) {
+    final transport = _FlakyTransport(
+      _inner(url, onReconnect: onReconnect, onDisconnect: onDisconnect),
+      onDisconnect: onDisconnect,
+    );
+    created.add(transport);
+    return transport;
+  }
+}
+
+void main() {
+  late KeyPair key;
+  late Accounts accounts;
+
+  setUp(() {
+    key = Bip340.generatePrivateKey();
+    accounts = Accounts(const Bip340EventSignerFactory());
+    accounts.loginPrivateKey(pubkey: key.publicKey, privkey: key.privateKey!);
+  });
+
+  test('an authentication does not survive a transient disconnect', () async {
+    final relay = MockRelay(
+      name: "relay requiring auth",
+      requireAuthForRequests: true,
+      signEvents: false,
+      challengePerConnection: true,
+    );
+    await relay.startServer();
+
+    final factory = _FlakyTransportFactory();
+    final manager = RelayManager(
+      globalState: GlobalState(),
+      bootstrapRelays: [],
+      nostrTransportFactory: factory,
+      accounts: accounts,
+    );
+
+    final account = accounts.getLoggedAccount()!;
+    final connectivity = await manager.openConnectionAs(relay.url, account);
+    expect(await manager.authenticateConnection(connectivity!.key), true);
+    expect(relay.acceptedAuths, 1);
+
+    factory.created.last.dropConnection();
+
+    expect(manager.isConnectionOpen(connectivity.key), false);
+    expect(
+      await manager.authenticateConnection(connectivity.key),
+      false,
+      reason:
+          'the connection is down, so it cannot still claim the AUTH the relay '
+          'accepted on it',
+    );
+
+    await manager.closeAllTransports();
+    await relay.stopServer();
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test('an in-flight AUTH fails with the socket it was sent on', () async {
+    final relay = MockRelay(
+      name: "relay going quiet mid auth",
+      requireAuthForRequests: true,
+      signEvents: false,
+      challengePerConnection: true,
+      silenceFirstAuths: 1,
+    );
+    await relay.startServer();
+
+    final factory = _FlakyTransportFactory();
+    final manager = RelayManager(
+      globalState: GlobalState(),
+      bootstrapRelays: [],
+      nostrTransportFactory: factory,
+      accounts: accounts,
+      authCallbackTimeout: const Duration(seconds: 10),
+    );
+
+    final account = accounts.getLoggedAccount()!;
+    final connectivity = await manager.openConnectionAs(relay.url, account);
+    final authenticating = manager.authenticateConnection(connectivity!.key);
+
+    while (relay.receivedAuths < 1) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+
+    final elapsed = Stopwatch()..start();
+    factory.created.last.dropConnection();
+    expect(await authenticating, false);
+    elapsed.stop();
+
+    expect(
+      elapsed.elapsed,
+      lessThan(const Duration(seconds: 5)),
+      reason:
+          'the AUTH waited for its callback timeout instead of failing with '
+          'the socket it was sent on',
+    );
+
+    await manager.closeAllTransports();
+    await relay.stopServer();
+  }, timeout: const Timeout(Duration(seconds: 60)));
+}

--- a/packages/ndk/test/usecases/connectivity/connectivity_test.dart
+++ b/packages/ndk/test/usecases/connectivity/connectivity_test.dart
@@ -41,14 +41,18 @@ void main() async {
     });
 
     test('state updates are received', () async {
-      final completer = Completer<Map<String, RelayConnectivity>>();
+      final completer = Completer<List<RelayConnectivity>>();
+
+      bool isConnected(List<RelayConnectivity> connections, String url) =>
+          connections.any(
+            (connection) => connection.url == url && connection.isConnected,
+          );
 
       final subscription = ndk.connectivity.relayConnectivityChanges.listen((
         event,
       ) {
         // When we detect a change where one relay is disconnected, complete the completer
-        if (event[relay0.url]?.isConnected == true &&
-            event[relay1.url]?.isConnected == true) {
+        if (isConnected(event, relay0.url) && isConnected(event, relay1.url)) {
           completer.complete(event);
         }
       });
@@ -67,8 +71,8 @@ void main() async {
             throw TimeoutException('Relay connection event not received'),
       );
 
-      expect(result[relay0.url]?.isConnected, true);
-      expect(result[relay1.url]?.isConnected, true);
+      expect(isConnected(result, relay0.url), true);
+      expect(isConnected(result, relay1.url), true);
 
       subscription.cancel();
     });

--- a/packages/ndk/test/usecases/connectivity/connectivity_test.dart
+++ b/packages/ndk/test/usecases/connectivity/connectivity_test.dart
@@ -82,19 +82,61 @@ void main() async {
       );
 
       await _waitForRelayConnectionState(ndk, relay1.url, true);
-      expect(ndk.relays.globalState.relays[relay0.url]?.isConnected, true);
-      expect(ndk.relays.globalState.relays[relay1.url]?.isConnected, true);
+      expect(
+        ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay0.url)]
+            ?.isConnected,
+        true,
+      );
+      expect(
+        ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay1.url)]
+            ?.isConnected,
+        true,
+      );
 
       await ndk.relays.resetTransport(relay1.url);
 
       await _waitForRelayConnectionState(ndk, relay1.url, false);
-      expect(ndk.relays.globalState.relays[relay0.url]?.isConnected, true);
-      expect(ndk.relays.globalState.relays[relay1.url]?.isConnected, false);
+      expect(
+        ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay0.url)]
+            ?.isConnected,
+        true,
+      );
+      expect(
+        ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay1.url)]
+            ?.isConnected,
+        false,
+      );
 
       await ndk.connectivity.tryReconnect();
       await _waitForRelayConnectionState(ndk, relay1.url, true);
-      expect(ndk.relays.globalState.relays[relay0.url]?.isConnected, true);
-      expect(ndk.relays.globalState.relays[relay1.url]?.isConnected, true);
+      expect(
+        ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay0.url)]
+            ?.isConnected,
+        true,
+      );
+      expect(
+        ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relay1.url)]
+            ?.isConnected,
+        true,
+      );
     });
   });
 }
@@ -107,7 +149,12 @@ Future<void> _waitForRelayConnectionState(
   final deadline = DateTime.now().add(const Duration(seconds: 5));
 
   while (DateTime.now().isBefore(deadline)) {
-    if (ndk.relays.globalState.relays[relayUrl]?.isConnected == expectedState) {
+    if (ndk
+            .relays
+            .globalState
+            .relays[RelayConnectionKey.anonymous(relayUrl)]
+            ?.isConnected ==
+        expectedState) {
       return;
     }
     await Future<void>.delayed(const Duration(milliseconds: 50));

--- a/packages/ndk/test/usecases/duplicate_request_test.dart
+++ b/packages/ndk/test/usecases/duplicate_request_test.dart
@@ -29,7 +29,12 @@ void main() {
       final current = ndk.relays.getRelayConnectivity(relay.url);
       if (current?.isConnected != true) {
         await ndk.connectivity.relayConnectivityChanges
-            .firstWhere((relays) => relays[relay.url]?.isConnected == true)
+            .firstWhere(
+              (connections) => connections.any(
+                (connection) =>
+                    connection.url == relay.url && connection.isConnected,
+              ),
+            )
             .timeout(const Duration(seconds: 10));
       }
 

--- a/packages/ndk/test/usecases/local_first/local_first_test.dart
+++ b/packages/ndk/test/usecases/local_first/local_first_test.dart
@@ -1200,7 +1200,11 @@ Future<void> _waitForRelayConnected({
   }
 
   await ndk.connectivity.relayConnectivityChanges
-      .firstWhere((relays) => relays[relayUrl]?.isConnected == true)
+      .firstWhere(
+        (connections) => connections.any(
+          (connection) => connection.url == relayUrl && connection.isConnected,
+        ),
+      )
       .timeout(timeout);
 }
 

--- a/packages/ndk/test/usecases/local_first/local_first_test.dart
+++ b/packages/ndk/test/usecases/local_first/local_first_test.dart
@@ -179,7 +179,11 @@ void main() {
           ),
           privateKey: remoteAuthor.privateKey!,
         );
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+        ndk = await _createNdk(
+          tempDir.path,
+          bootstrapRelays: [relay.url],
+          pendingDeliveryRetryInterval: const Duration(seconds: 1),
+        );
 
         await relay.startServer(textNotes: {remoteAuthor: rootEvent});
 

--- a/packages/ndk/test/usecases/nip42_auth_test.dart
+++ b/packages/ndk/test/usecases/nip42_auth_test.dart
@@ -6,101 +6,68 @@ import '../mocks/mock_event_verifier.dart';
 import '../mocks/mock_relay.dart';
 
 void main() {
-  test(
-    'request on auth-required relay should return events after AUTH',
-    () async {
+  for (final engine in NdkEngine.values) {
+    authTests(engine);
+  }
+}
+
+/// The AUTH re-route lives under the engines, so both must reach an
+/// authenticated connection the same way.
+void authTests(NdkEngine engine) {
+  group('NIP-42 auth [${engine.name}]', () {
+    test(
+      'request on auth-required relay should return events after AUTH',
+      () async {
+        final key = Bip340.generatePrivateKey();
+        final relay = MockRelay(name: "relay", requireAuthForRequests: true);
+
+        final testEvent =
+            await Bip340EventSigner(
+              privateKey: key.privateKey!,
+              publicKey: key.publicKey,
+            ).sign(
+              Nip01Event(
+                pubKey: key.publicKey,
+                kind: Nip01Event.kTextNodeKind,
+                tags: [],
+                content: "test event",
+              ),
+            );
+
+        await relay.startServer(textNotes: {key: testEvent});
+
+        final ndk = Ndk(
+          NdkConfig(
+            eventVerifier: MockEventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay.url],
+            engine: engine,
+          ),
+        );
+
+        ndk.accounts.loginPrivateKey(
+          pubkey: key.publicKey,
+          privkey: key.privateKey!,
+        );
+
+        final result = await ndk.requests
+            .query(
+              filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
+              explicitRelays: [relay.url],
+            )
+            .future;
+
+        expect(result, isNotEmpty);
+        expect(result.first.content, "test event");
+
+        await ndk.destroy();
+        await relay.stopServer();
+      },
+    );
+
+    test('broadcast on auth-required relay should succeed after AUTH', () async {
       final key = Bip340.generatePrivateKey();
-      final relay = MockRelay(name: "relay", requireAuthForRequests: true);
-
-      final testEvent =
-          await Bip340EventSigner(
-            privateKey: key.privateKey!,
-            publicKey: key.publicKey,
-          ).sign(
-            Nip01Event(
-              pubKey: key.publicKey,
-              kind: Nip01Event.kTextNodeKind,
-              tags: [],
-              content: "test event",
-            ),
-          );
-
-      await relay.startServer(textNotes: {key: testEvent});
-
-      final ndk = Ndk(
-        NdkConfig(
-          eventVerifier: MockEventVerifier(),
-          cache: MemCacheManager(),
-          bootstrapRelays: [relay.url],
-        ),
-      );
-
-      ndk.accounts.loginPrivateKey(
-        pubkey: key.publicKey,
-        privkey: key.privateKey!,
-      );
-
-      final result = await ndk.requests
-          .query(
-            filter: Filter(kinds: [Nip01Event.kTextNodeKind]),
-            explicitRelays: [relay.url],
-          )
-          .future;
-
-      expect(result, isNotEmpty);
-      expect(result.first.content, "test event");
-
-      await ndk.destroy();
-      await relay.stopServer();
-    },
-  );
-
-  test('broadcast on auth-required relay should succeed after AUTH', () async {
-    final key = Bip340.generatePrivateKey();
-    final relay = MockRelay(name: "relay", requireAuthForEvents: true);
-
-    await relay.startServer();
-
-    final ndk = Ndk(
-      NdkConfig(
-        eventVerifier: MockEventVerifier(),
-        cache: MemCacheManager(),
-        bootstrapRelays: [relay.url],
-      ),
-    );
-
-    ndk.accounts.loginPrivateKey(
-      pubkey: key.publicKey,
-      privkey: key.privateKey!,
-    );
-
-    final event = Nip01Event(
-      pubKey: key.publicKey,
-      kind: Nip01Event.kTextNodeKind,
-      tags: [],
-      content: "test broadcast",
-    );
-
-    final result = await ndk.broadcast
-        .broadcast(nostrEvent: event, specificRelays: [relay.url])
-        .broadcastDoneFuture;
-
-    expect(result.any((r) => r.broadcastSuccessful), isTrue);
-
-    await ndk.destroy();
-    await relay.stopServer();
-  });
-
-  test(
-    'gift wrap broadcast on auth-required relay should authenticate as sender',
-    timeout: const Timeout(Duration(seconds: 5)),
-    () async {
-      final senderKey = Bip340.generatePrivateKey();
-      final recipientKey = Bip340.generatePrivateKey();
-      final relay = MockRelay(
-        name: "gift wrap auth relay",
-        requireAuthForEvents: true,
-      );
+      final relay = MockRelay(name: "relay", requireAuthForEvents: true);
 
       await relay.startServer();
 
@@ -109,123 +76,171 @@ void main() {
           eventVerifier: MockEventVerifier(),
           cache: MemCacheManager(),
           bootstrapRelays: [relay.url],
-          defaultBroadcastTimeout: const Duration(seconds: 2),
+          engine: engine,
         ),
       );
 
-      addTearDown(() async {
-        await ndk.destroy();
-        await relay.stopServer();
-      });
-
       ndk.accounts.loginPrivateKey(
-        pubkey: senderKey.publicKey,
-        privkey: senderKey.privateKey!,
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
       );
 
-      final rumor = await ndk.giftWrap.createRumor(
-        content: "gift wrap auth-required broadcast",
+      final event = Nip01Event(
+        pubKey: key.publicKey,
         kind: Nip01Event.kTextNodeKind,
-        tags: [
-          ["p", recipientKey.publicKey],
-        ],
-      );
-      final giftWrap = await ndk.giftWrap.toGiftWrap(
-        rumor: rumor,
-        recipientPubkey: recipientKey.publicKey,
+        tags: [],
+        content: "test broadcast",
       );
 
       final result = await ndk.broadcast
-          .broadcast(nostrEvent: giftWrap, specificRelays: [relay.url])
+          .broadcast(nostrEvent: event, specificRelays: [relay.url])
           .broadcastDoneFuture;
 
       expect(result.any((r) => r.broadcastSuccessful), isTrue);
-    },
-  );
-
-  test(
-    'request should complete when relay requires auth but sends no challenge',
-    timeout: const Timeout(Duration(seconds: 5)),
-    () async {
-      final key = Bip340.generatePrivateKey();
-      final relay = MockRelay(
-        name: "relay auth no challenge",
-        requireAuthForRequests: true,
-        sendAuthChallenge: false,
-      );
-
-      await relay.startServer();
-
-      final ndk = Ndk(
-        NdkConfig(
-          eventVerifier: MockEventVerifier(),
-          cache: MemCacheManager(),
-          bootstrapRelays: [relay.url],
-        ),
-      );
-
-      final result = await ndk.requests
-          .query(
-            filter: Filter(
-              kinds: [Nip01Event.kTextNodeKind],
-              authors: [key.publicKey],
-            ),
-          )
-          .future;
-
-      expect(result, isEmpty);
 
       await ndk.destroy();
       await relay.stopServer();
-    },
-  );
+    });
 
-  test(
-    'request completes when an account is available but the relay never challenges',
-    timeout: const Timeout(Duration(seconds: 10)),
-    () async {
-      final key = Bip340.generatePrivateKey();
-      final relay = MockRelay(
-        name: "relay auth no challenge with account",
-        requireAuthForRequests: true,
-        sendAuthChallenge: false,
-      );
+    test(
+      'gift wrap broadcast on auth-required relay should authenticate as sender',
+      timeout: const Timeout(Duration(seconds: 5)),
+      () async {
+        final senderKey = Bip340.generatePrivateKey();
+        final recipientKey = Bip340.generatePrivateKey();
+        final relay = MockRelay(
+          name: "gift wrap auth relay",
+          requireAuthForEvents: true,
+        );
 
-      await relay.startServer();
+        await relay.startServer();
 
-      final ndk = Ndk(
-        NdkConfig(
-          eventVerifier: MockEventVerifier(),
-          cache: MemCacheManager(),
-          bootstrapRelays: [relay.url],
-        ),
-      );
+        final ndk = Ndk(
+          NdkConfig(
+            eventVerifier: MockEventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay.url],
+            defaultBroadcastTimeout: const Duration(seconds: 2),
+            engine: engine,
+          ),
+        );
 
-      ndk.accounts.loginPrivateKey(
-        pubkey: key.publicKey,
-        privkey: key.privateKey!,
-      );
+        addTearDown(() async {
+          await ndk.destroy();
+          await relay.stopServer();
+        });
 
-      final result = await ndk.requests
-          .query(
-            filter: Filter(
-              kinds: [Nip01Event.kTextNodeKind],
-              authors: [key.publicKey],
-            ),
-          )
-          .future;
+        ndk.accounts.loginPrivateKey(
+          pubkey: senderKey.publicKey,
+          privkey: senderKey.privateKey!,
+        );
 
-      expect(result, isEmpty);
-      expect(
-        ndk.relays.globalState.relays.keys.where(
-          (connectionKey) => connectionKey.pubkey == key.publicKey,
-        ),
-        isNotEmpty,
-        reason: 'the request must still have reached a bound connection',
-      );
+        final rumor = await ndk.giftWrap.createRumor(
+          content: "gift wrap auth-required broadcast",
+          kind: Nip01Event.kTextNodeKind,
+          tags: [
+            ["p", recipientKey.publicKey],
+          ],
+        );
+        final giftWrap = await ndk.giftWrap.toGiftWrap(
+          rumor: rumor,
+          recipientPubkey: recipientKey.publicKey,
+        );
 
-      await ndk.destroy();
-      await relay.stopServer();
-    },
-  );
+        final result = await ndk.broadcast
+            .broadcast(nostrEvent: giftWrap, specificRelays: [relay.url])
+            .broadcastDoneFuture;
+
+        expect(result.any((r) => r.broadcastSuccessful), isTrue);
+      },
+    );
+
+    test(
+      'request should complete when relay requires auth but sends no challenge',
+      timeout: const Timeout(Duration(seconds: 5)),
+      () async {
+        final key = Bip340.generatePrivateKey();
+        final relay = MockRelay(
+          name: "relay auth no challenge",
+          requireAuthForRequests: true,
+          sendAuthChallenge: false,
+        );
+
+        await relay.startServer();
+
+        final ndk = Ndk(
+          NdkConfig(
+            eventVerifier: MockEventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay.url],
+            engine: engine,
+          ),
+        );
+
+        final result = await ndk.requests
+            .query(
+              filter: Filter(
+                kinds: [Nip01Event.kTextNodeKind],
+                authors: [key.publicKey],
+              ),
+            )
+            .future;
+
+        expect(result, isEmpty);
+
+        await ndk.destroy();
+        await relay.stopServer();
+      },
+    );
+
+    test(
+      'request completes when an account is available but the relay never challenges',
+      timeout: const Timeout(Duration(seconds: 10)),
+      () async {
+        final key = Bip340.generatePrivateKey();
+        final relay = MockRelay(
+          name: "relay auth no challenge with account",
+          requireAuthForRequests: true,
+          sendAuthChallenge: false,
+        );
+
+        await relay.startServer();
+
+        final ndk = Ndk(
+          NdkConfig(
+            eventVerifier: MockEventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay.url],
+            engine: engine,
+          ),
+        );
+
+        ndk.accounts.loginPrivateKey(
+          pubkey: key.publicKey,
+          privkey: key.privateKey!,
+        );
+
+        final result = await ndk.requests
+            .query(
+              filter: Filter(
+                kinds: [Nip01Event.kTextNodeKind],
+                authors: [key.publicKey],
+              ),
+            )
+            .future;
+
+        expect(result, isEmpty);
+        expect(
+          ndk.relays.globalState.relays.keys.where(
+            (connectionKey) => connectionKey.pubkey == key.publicKey,
+          ),
+          isNotEmpty,
+          reason: 'the request must still have reached a bound connection',
+        );
+
+        await ndk.destroy();
+        await relay.stopServer();
+      },
+    );
+  });
 }

--- a/packages/ndk/test/usecases/nip42_auth_test.dart
+++ b/packages/ndk/test/usecases/nip42_auth_test.dart
@@ -179,4 +179,53 @@ void main() {
       await relay.stopServer();
     },
   );
+
+  test(
+    'request completes when an account is available but the relay never challenges',
+    timeout: const Timeout(Duration(seconds: 10)),
+    () async {
+      final key = Bip340.generatePrivateKey();
+      final relay = MockRelay(
+        name: "relay auth no challenge with account",
+        requireAuthForRequests: true,
+        sendAuthChallenge: false,
+      );
+
+      await relay.startServer();
+
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final result = await ndk.requests
+          .query(
+            filter: Filter(
+              kinds: [Nip01Event.kTextNodeKind],
+              authors: [key.publicKey],
+            ),
+          )
+          .future;
+
+      expect(result, isEmpty);
+      expect(
+        ndk.relays.globalState.relays.keys.where(
+          (connectionKey) => connectionKey.pubkey == key.publicKey,
+        ),
+        isNotEmpty,
+        reason: 'the request must still have reached a bound connection',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    },
+  );
 }


### PR DESCRIPTION
# One authenticated identity per relay connection

A connection is identified by `(relay url, pubkey | null)` instead of by url
alone. The key says which identity a socket may ever assume, not that it is
already authenticated:

- an anonymous connection is bound to nobody and never answers a challenge
- a bound connection may only ever authenticate as the account it was opened for

A relay refusing a request with `auth-required` no longer triggers an AUTH on
the socket it refused: the request moves to a connection bound to the account,
and both attempts stay in the request state. Relays send their challenge
whenever they want, and some only once a request needs one, so a bound
connection sends first and answers when asked.

## Breaking

- `relayConnectivityChanges` emits `List<RelayConnectivity>` instead of a map
  keyed by url, which could only carry one connection per relay
- `GlobalState.relays` and `RequestState.requests` are keyed by
  `RelayConnectionKey`, `registerRelayRequest` takes a `connectionKey`
- `NdkConfig.eagerAuth` is deprecated and has no effect: an anonymous
  connection never authenticates and a bound one always does. This one is
  silent, nothing fails to compile.

## Deliberately left out

- broadcasts still authenticate in place, `BroadcastState` is keyed by url and
  cannot follow an event across two connections (see #665)
- fetched ranges still ignore the identity (see #707). The key must become the
  identity whose AUTH was accepted, not the connection's binding, otherwise a
  bound connection that never authenticated records anonymous data as if it had
  been fetched identified and the gap is never re-fetched.

## Testing

Two new ones pin what would regress silently: the anonymous
connection survives a retry instead of being promoted, and closing all
transports leaves no authenticated connection behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for separate anonymous and authenticated connections to the same relay.
- Added public relay connection identity support.
- Connectivity updates now support connection lists and per-connection management.
- Added a default three-second authentication challenge timeout.

## Bug Fixes
- Improved authenticated request routing, retries, reconnection, cleanup, and relay state tracking.
- Improved subscription and query replay after connection failures.

## Tests
- Expanded coverage for authentication, reconnection, connection identity, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->