### PR TITLE
style: apply dart format for Dart 3.13

### DIFF
--- a/packages/bc_ur/lib/bytewords.dart
+++ b/packages/bc_ur/lib/bytewords.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ur/utils.dart';
 import 'package:collection/collection.dart';
 

--- a/packages/bc_ur/lib/cashu_animated_qr_example.dart
+++ b/packages/bc_ur/lib/cashu_animated_qr_example.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_print
 import 'package:ndk/domain_layer/entities/cashu/cashu_proof.dart';
 import 'package:ndk/domain_layer/entities/cashu/cashu_token.dart';
+
 import 'cashu_token_ur_encoder.dart';
 
 /// Example demonstrating NUT-16 Animated QR codes using UR encoding
@@ -28,8 +29,7 @@ void singlePartExample() {
       CashuProof(
         amount: 8,
         secret: 'my-secret-proof-data',
-        unblindedSig:
-            '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+        unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
         keysetId: '009a1f293253e41e',
       ),
     ],

--- a/packages/bc_ur/lib/crc32.dart
+++ b/packages/bc_ur/lib/crc32.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ur/constants.dart';
 
 class CRC32 {

--- a/packages/bc_ur/lib/fountain_decoder.dart
+++ b/packages/bc_ur/lib/fountain_decoder.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ur/fountain_encoder.dart';
 import 'package:ur/fountain_utils.dart';
 import 'package:ur/utils.dart';

--- a/packages/bc_ur/lib/fountain_encoder.dart
+++ b/packages/bc_ur/lib/fountain_encoder.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'dart:typed_data';
+
 import 'package:ur/cbor_lite.dart';
 import 'package:ur/fountain_utils.dart';
 import 'package:ur/utils.dart';

--- a/packages/bc_ur/lib/fountain_utils.dart
+++ b/packages/bc_ur/lib/fountain_utils.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ur/random_sampler.dart';
 import 'package:ur/utils.dart';
 import 'package:ur/xoshiro256.dart';

--- a/packages/bc_ur/lib/ur.dart
+++ b/packages/bc_ur/lib/ur.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ur/utils.dart';
 
 class InvalidType implements Exception {

--- a/packages/bc_ur/lib/utils.dart
+++ b/packages/bc_ur/lib/utils.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'dart:convert';
+
 import 'package:ur/crc32.dart';
 
 Uint8List crc32Bytes(Uint8List buf) {

--- a/packages/bc_ur/lib/xoshiro256.dart
+++ b/packages/bc_ur/lib/xoshiro256.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 import 'package:ur/utils.dart';
 import 'package:ur/constants.dart';

--- a/packages/bc_ur/test/cashu_token_ur_encoder_test.dart
+++ b/packages/bc_ur/test/cashu_token_ur_encoder_test.dart
@@ -1,6 +1,8 @@
 import 'package:ndk/domain_layer/entities/cashu/cashu_proof.dart';
 import 'package:ndk/domain_layer/entities/cashu/cashu_token.dart';
+
 import '../lib/cashu_token_ur_encoder.dart';
+
 import 'package:test/test.dart';
 
 void main() {
@@ -12,8 +14,7 @@ void main() {
           CashuProof(
             amount: 8,
             secret: 'test-secret-123',
-            unblindedSig:
-                '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+            unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
             keysetId: '009a1f293253e41e',
           ),
         ],
@@ -47,8 +48,7 @@ void main() {
           CashuProof(
             amount: 16,
             secret: 'another-secret',
-            unblindedSig:
-                '03b01869f528337e161a6768e480fcf9af32c76ff5dcf90bb4d1993c5c4e6e8e59',
+            unblindedSig: '03b01869f528337e161a6768e480fcf9af32c76ff5dcf90bb4d1993c5c4e6e8e59',
             keysetId: '009a1f293253e41e',
           ),
         ],
@@ -71,22 +71,19 @@ void main() {
           CashuProof(
             amount: 1,
             secret: 'secret-1',
-            unblindedSig:
-                '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+            unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
             keysetId: '009a1f293253e41e',
           ),
           CashuProof(
             amount: 2,
             secret: 'secret-2',
-            unblindedSig:
-                '03b01869f528337e161a6768e480fcf9af32c76ff5dcf90bb4d1993c5c4e6e8e59',
+            unblindedSig: '03b01869f528337e161a6768e480fcf9af32c76ff5dcf90bb4d1993c5c4e6e8e59',
             keysetId: '009a1f293253e41e',
           ),
           CashuProof(
             amount: 4,
             secret: 'secret-3',
-            unblindedSig:
-                '02c0ee6e3ecf9f2e6aa06a4b0cf0b9c4c3e6c9b8d0a0f3a4c3d9e8b7a6c5d4e3f2',
+            unblindedSig: '02c0ee6e3ecf9f2e6aa06a4b0cf0b9c4c3e6c9b8d0a0f3a4c3d9e8b7a6c5d4e3f2',
             keysetId: '009a1f293253e41e',
           ),
         ],
@@ -129,8 +126,7 @@ void main() {
         (i) => CashuProof(
           amount: 1 << i, // Powers of 2: 1, 2, 4, 8, 16, etc.
           secret: 'secret-$i-with-some-long-text-to-make-it-larger-${"x" * 50}',
-          unblindedSig:
-              '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+          unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
           keysetId: '009a1f293253e41e',
         ),
       );
@@ -159,8 +155,7 @@ void main() {
         (i) => CashuProof(
           amount: 1 << i,
           secret: 'secret-$i-${"x" * 30}',
-          unblindedSig:
-              '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+          unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
           keysetId: '009a1f293253e41e',
         ),
       );
@@ -218,8 +213,7 @@ void main() {
         (i) => CashuProof(
           amount: 1 << i,
           secret: 'secret-$i-${"x" * 30}',
-          unblindedSig:
-              '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+          unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
           keysetId: '009a1f293253e41e',
         ),
       );
@@ -263,8 +257,7 @@ void main() {
         (i) => CashuProof(
           amount: 1,
           secret: 'secret-$i-${"x" * 30}',
-          unblindedSig:
-              '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+          unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
           keysetId: '009a1f293253e41e',
         ),
       );
@@ -300,8 +293,7 @@ void main() {
         (i) => CashuProof(
           amount: 1 << i,
           secret: 'secret-$i-${"x" * 25}',
-          unblindedSig:
-              '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+          unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
           keysetId: '009a1f293253e41e',
         ),
       );
@@ -370,8 +362,7 @@ void main() {
           CashuProof(
             amount: 8,
             secret: 'test-secret',
-            unblindedSig:
-                '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+            unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
             keysetId: '009a1f293253e41e',
           ),
         ],
@@ -393,8 +384,7 @@ void main() {
           CashuProof(
             amount: 8,
             secret: '特殊字符-🎉-émojis-тест',
-            unblindedSig:
-                '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
+            unblindedSig: '02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2',
             keysetId: '009a1f293253e41e',
           ),
         ],

--- a/packages/bc_ur/test/test_utils.dart
+++ b/packages/bc_ur/test/test_utils.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ur/xoshiro256.dart';
 import 'package:ur/cbor_lite.dart';
 import 'package:ur/ur.dart';

--- a/packages/drift/lib/src/database/database.g.dart
+++ b/packages/drift/lib/src/database/database.g.dart
@@ -6769,32 +6769,30 @@ abstract class _$NdkCacheDatabase extends GeneratedDatabase {
   ];
 }
 
-typedef $$EventsTableCreateCompanionBuilder =
-    EventsCompanion Function({
-      required String id,
-      required String pubKey,
-      required int kind,
-      required int createdAt,
-      required String content,
-      Value<String?> sig,
-      Value<bool?> validSig,
-      required String tagsJson,
-      required String sourcesJson,
-      Value<int> rowid,
-    });
-typedef $$EventsTableUpdateCompanionBuilder =
-    EventsCompanion Function({
-      Value<String> id,
-      Value<String> pubKey,
-      Value<int> kind,
-      Value<int> createdAt,
-      Value<String> content,
-      Value<String?> sig,
-      Value<bool?> validSig,
-      Value<String> tagsJson,
-      Value<String> sourcesJson,
-      Value<int> rowid,
-    });
+typedef $$EventsTableCreateCompanionBuilder = EventsCompanion Function({
+  required String id,
+  required String pubKey,
+  required int kind,
+  required int createdAt,
+  required String content,
+  Value<String?> sig,
+  Value<bool?> validSig,
+  required String tagsJson,
+  required String sourcesJson,
+  Value<int> rowid,
+});
+typedef $$EventsTableUpdateCompanionBuilder = EventsCompanion Function({
+  Value<String> id,
+  Value<String> pubKey,
+  Value<int> kind,
+  Value<int> createdAt,
+  Value<String> content,
+  Value<String?> sig,
+  Value<bool?> validSig,
+  Value<String> tagsJson,
+  Value<String> sourcesJson,
+  Value<int> rowid,
+});
 
 class $$EventsTableFilterComposer
     extends Composer<_$NdkCacheDatabase, $EventsTable> {
@@ -7236,30 +7234,28 @@ typedef $$UserRelayListsTableProcessedTableManager =
       DbUserRelayList,
       PrefetchHooks Function()
     >;
-typedef $$RelaySetsTableCreateCompanionBuilder =
-    RelaySetsCompanion Function({
-      required String id,
-      required String name,
-      required String pubKey,
-      required int relayMinCountPerPubkey,
-      required int direction,
-      required String relaysMapJson,
-      required bool fallbackToBootstrapRelays,
-      required String notCoveredPubkeysJson,
-      Value<int> rowid,
-    });
-typedef $$RelaySetsTableUpdateCompanionBuilder =
-    RelaySetsCompanion Function({
-      Value<String> id,
-      Value<String> name,
-      Value<String> pubKey,
-      Value<int> relayMinCountPerPubkey,
-      Value<int> direction,
-      Value<String> relaysMapJson,
-      Value<bool> fallbackToBootstrapRelays,
-      Value<String> notCoveredPubkeysJson,
-      Value<int> rowid,
-    });
+typedef $$RelaySetsTableCreateCompanionBuilder = RelaySetsCompanion Function({
+  required String id,
+  required String name,
+  required String pubKey,
+  required int relayMinCountPerPubkey,
+  required int direction,
+  required String relaysMapJson,
+  required bool fallbackToBootstrapRelays,
+  required String notCoveredPubkeysJson,
+  Value<int> rowid,
+});
+typedef $$RelaySetsTableUpdateCompanionBuilder = RelaySetsCompanion Function({
+  Value<String> id,
+  Value<String> name,
+  Value<String> pubKey,
+  Value<int> relayMinCountPerPubkey,
+  Value<int> direction,
+  Value<String> relaysMapJson,
+  Value<bool> fallbackToBootstrapRelays,
+  Value<String> notCoveredPubkeysJson,
+  Value<int> rowid,
+});
 
 class $$RelaySetsTableFilterComposer
     extends Composer<_$NdkCacheDatabase, $RelaySetsTable> {
@@ -7501,24 +7497,22 @@ typedef $$RelaySetsTableProcessedTableManager =
       DbRelaySet,
       PrefetchHooks Function()
     >;
-typedef $$Nip05sTableCreateCompanionBuilder =
-    Nip05sCompanion Function({
-      required String pubKey,
-      required String nip05,
-      required bool valid,
-      Value<int?> networkFetchTime,
-      required String relaysJson,
-      Value<int> rowid,
-    });
-typedef $$Nip05sTableUpdateCompanionBuilder =
-    Nip05sCompanion Function({
-      Value<String> pubKey,
-      Value<String> nip05,
-      Value<bool> valid,
-      Value<int?> networkFetchTime,
-      Value<String> relaysJson,
-      Value<int> rowid,
-    });
+typedef $$Nip05sTableCreateCompanionBuilder = Nip05sCompanion Function({
+  required String pubKey,
+  required String nip05,
+  required bool valid,
+  Value<int?> networkFetchTime,
+  required String relaysJson,
+  Value<int> rowid,
+});
+typedef $$Nip05sTableUpdateCompanionBuilder = Nip05sCompanion Function({
+  Value<String> pubKey,
+  Value<String> nip05,
+  Value<bool> valid,
+  Value<int?> networkFetchTime,
+  Value<String> relaysJson,
+  Value<int> rowid,
+});
 
 class $$Nip05sTableFilterComposer
     extends Composer<_$NdkCacheDatabase, $Nip05sTable> {
@@ -9695,18 +9689,16 @@ typedef $$CashuSecretCountersTableProcessedTableManager =
       DbCashuSecretCounter,
       PrefetchHooks Function()
     >;
-typedef $$KeyValuesTableCreateCompanionBuilder =
-    KeyValuesCompanion Function({
-      required String key,
-      Value<String?> value,
-      Value<int> rowid,
-    });
-typedef $$KeyValuesTableUpdateCompanionBuilder =
-    KeyValuesCompanion Function({
-      Value<String> key,
-      Value<String?> value,
-      Value<int> rowid,
-    });
+typedef $$KeyValuesTableCreateCompanionBuilder = KeyValuesCompanion Function({
+  required String key,
+  Value<String?> value,
+  Value<int> rowid,
+});
+typedef $$KeyValuesTableUpdateCompanionBuilder = KeyValuesCompanion Function({
+  Value<String> key,
+  Value<String?> value,
+  Value<int> rowid,
+});
 
 class $$KeyValuesTableFilterComposer
     extends Composer<_$NdkCacheDatabase, $KeyValuesTable> {
@@ -9793,22 +9785,16 @@ class $$KeyValuesTableTableManager
               $$KeyValuesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$KeyValuesTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<String> key = const Value.absent(),
-                Value<String?> value = const Value.absent(),
-                Value<int> rowid = const Value.absent(),
-              }) => KeyValuesCompanion(key: key, value: value, rowid: rowid),
-          createCompanionCallback:
-              ({
-                required String key,
-                Value<String?> value = const Value.absent(),
-                Value<int> rowid = const Value.absent(),
-              }) => KeyValuesCompanion.insert(
-                key: key,
-                value: value,
-                rowid: rowid,
-              ),
+          updateCompanionCallback: ({
+            Value<String> key = const Value.absent(),
+            Value<String?> value = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) => KeyValuesCompanion(key: key, value: value, rowid: rowid),
+          createCompanionCallback: ({
+            required String key,
+            Value<String?> value = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) => KeyValuesCompanion.insert(key: key, value: value, rowid: rowid),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
@@ -9834,24 +9820,22 @@ typedef $$KeyValuesTableProcessedTableManager =
       DbKeyValue,
       PrefetchHooks Function()
     >;
-typedef $$WalletsTableCreateCompanionBuilder =
-    WalletsCompanion Function({
-      required String id,
-      required String name,
-      required String type,
-      required String supportedUnitsJson,
-      required String metadataJson,
-      Value<int> rowid,
-    });
-typedef $$WalletsTableUpdateCompanionBuilder =
-    WalletsCompanion Function({
-      Value<String> id,
-      Value<String> name,
-      Value<String> type,
-      Value<String> supportedUnitsJson,
-      Value<String> metadataJson,
-      Value<int> rowid,
-    });
+typedef $$WalletsTableCreateCompanionBuilder = WalletsCompanion Function({
+  required String id,
+  required String name,
+  required String type,
+  required String supportedUnitsJson,
+  required String metadataJson,
+  Value<int> rowid,
+});
+typedef $$WalletsTableUpdateCompanionBuilder = WalletsCompanion Function({
+  Value<String> id,
+  Value<String> name,
+  Value<String> type,
+  Value<String> supportedUnitsJson,
+  Value<String> metadataJson,
+  Value<int> rowid,
+});
 
 class $$WalletsTableFilterComposer
     extends Composer<_$NdkCacheDatabase, $WalletsTable> {

--- a/packages/ndk/example/bunkers_example.dart
+++ b/packages/ndk/example/bunkers_example.dart
@@ -7,8 +7,7 @@ Future<void> main() async {
 
   try {
     await ndk.accounts.loginWithBunkerUrl(
-      bunkerUrl:
-          "bunker://a1fe3664f7a2b24db97e5b63869e8011c947f9abd8c03f98befafd27c38467d2?relay=wss://relay.nsec.app&secret=devsecret123",
+      bunkerUrl: "bunker://a1fe3664f7a2b24db97e5b63869e8011c947f9abd8c03f98befafd27c38467d2?relay=wss://relay.nsec.app&secret=devsecret123",
       bunkers: ndk.bunkers,
     );
 

--- a/packages/ndk/example/files/files_example_test.dart
+++ b/packages/ndk/example/files/files_example_test.dart
@@ -8,8 +8,7 @@ void main() async {
     final ndk = Ndk.defaultConfig();
 
     final downloadResult = await ndk.files.download(
-      url:
-          "https://cdn.hzrd149.com/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf",
+      url: "https://cdn.hzrd149.com/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf",
     );
 
     print(

--- a/packages/ndk/example/nwc/connect_get_info.dart
+++ b/packages/ndk/example/nwc/connect_get_info.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_print
 
 import 'dart:io';
+
 import 'package:ndk/ndk.dart';
 
 void main() async {

--- a/packages/ndk/example/nwc/make_hold_invoice.dart
+++ b/packages/ndk/example/nwc/make_hold_invoice.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 import 'package:convert/convert.dart';
 import 'package:ndk/domain_layer/usecases/nwc/nwc_notification.dart';

--- a/packages/ndk/example/sembast/sembast_cache_manager_example.dart
+++ b/packages/ndk/example/sembast/sembast_cache_manager_example.dart
@@ -36,8 +36,7 @@ Future<void> main() async {
         ['t', 'nostr'],
         ['t', 'bitcoin'],
       ],
-      content:
-          'Hello Nostr! This is my first cached event using SembastCacheManager 🎉',
+      content: 'Hello Nostr! This is my first cached event using SembastCacheManager 🎉',
       createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
 

--- a/packages/ndk/hook/build.dart
+++ b/packages/ndk/hook/build.dart
@@ -3,8 +3,7 @@ import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
-    await RustBuilder(
-      assetName: 'src/rust_lib.dart',
-    ).run(input: input, output: output);
+    await RustBuilder(assetName: 'src/rust_lib.dart')
+        .run(input: input, output: output);
   });
 }

--- a/packages/ndk/lib/data_layer/repositories/blossom/blossom_impl.dart
+++ b/packages/ndk/lib/data_layer/repositories/blossom/blossom_impl.dart
@@ -697,9 +697,8 @@ class BlossomRepositoryImpl implements BlossomRepository {
         }
 
         final response = await client.get(
-          url: Uri.parse(
-            '$url/list/$pubkey',
-          ).replace(queryParameters: queryParams),
+          url: Uri.parse('$url/list/$pubkey')
+              .replace(queryParameters: queryParams),
           headers: headers,
         );
 

--- a/packages/ndk/lib/data_layer/repositories/cache_manager/sembast_cache_manager.dart
+++ b/packages/ndk/lib/data_layer/repositories/cache_manager/sembast_cache_manager.dart
@@ -1,6 +1,7 @@
 import 'package:ndk/entities.dart';
 import 'package:ndk/ndk.dart';
 import 'package:sembast/sembast.dart' as sembast;
+
 import '../../../shared/nips/nip01/event_kind_classification.dart';
 import '../../../shared/nips/nip01/event_eviction_planner.dart';
 import '../../../shared/nips/nip01/helpers.dart';
@@ -1177,9 +1178,8 @@ class SembastCacheManager extends CacheManager {
           .record(pubKey)
           .put(
             _database,
-            UserRelayList.fromNip65(
-              Nip65.fromEvent(latestNip65),
-            ).toJsonForStorage(),
+            UserRelayList.fromNip65(Nip65.fromEvent(latestNip65))
+                .toJsonForStorage(),
           );
       return;
     }
@@ -1189,9 +1189,8 @@ class SembastCacheManager extends CacheManager {
           .record(pubKey)
           .put(
             _database,
-            UserRelayList.fromNip02EventContent(
-              latestContactListWithRelays,
-            ).toJsonForStorage(),
+            UserRelayList.fromNip02EventContent(latestContactListWithRelays)
+                .toJsonForStorage(),
           );
       return;
     }

--- a/packages/ndk/lib/data_layer/repositories/cashu_seed_secret_generator/dart_cashu_key_derivation.dart
+++ b/packages/ndk/lib/data_layer/repositories/cashu_seed_secret_generator/dart_cashu_key_derivation.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'dart:convert';
+
 import 'package:crypto/crypto.dart';
 
 import 'package:convert/convert.dart';

--- a/packages/ndk/lib/domain_layer/entities/broadcast_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/broadcast_state.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+
 import 'package:rxdart/rxdart.dart';
+
 import 'nip_01_event.dart';
 
 /// hols information about a individual relay broadcast response \

--- a/packages/ndk/lib/domain_layer/entities/contact_list.dart
+++ b/packages/ndk/lib/domain_layer/entities/contact_list.dart
@@ -134,7 +134,7 @@ class ContactList {
     }).toList();
   }
 
-  List<List<String>> tagListToJson(final List<String> list, String tag) {
+  List<List<String>> tagListToJson(List<String> list, String tag) {
     return list.map((value) {
       List<String> list = [tag, value];
       return list;

--- a/packages/ndk/lib/domain_layer/entities/filter_fetched_ranges.dart
+++ b/packages/ndk/lib/domain_layer/entities/filter_fetched_ranges.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:math';
+
 import 'package:crypto/crypto.dart';
 
 import 'filter.dart';

--- a/packages/ndk/lib/domain_layer/entities/wallet/providers/lnurl/lnurl_wallet_provider.dart
+++ b/packages/ndk/lib/domain_layer/entities/wallet/providers/lnurl/lnurl_wallet_provider.dart
@@ -4,6 +4,7 @@ import 'package:ndk/domain_layer/usecases/lnurl/lnurl.dart';
 import 'package:ndk/domain_layer/usecases/lnurl/lnurl_response.dart';
 import 'package:ndk/shared/logger/logger.dart';
 import 'package:ndk/domain_layer/usecases/nwc/responses/pay_invoice_response.dart';
+
 import '../../wallet.dart';
 import '../../wallet_balance.dart';
 import '../../wallet_provider.dart';

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast.dart
@@ -97,7 +97,7 @@ class Broadcast {
           nostrEvent,
           responses,
         );
-      } catch (_, __) {}
+      } catch (_) {}
       return responses;
     });
     return NdkBroadcastResponse(

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu.dart
@@ -72,8 +72,7 @@ class Cashu {
     );
     if (cashuUserSeedphrase == null) {
       Logger.log.w(
-        () =>
-            'Cashu initialized without user seed phrase, cashu features will not work \nSet the seed phrase using NdkConfig or Cashu.setCashuSeedPhrase()',
+        () => 'Cashu initialized without user seed phrase, cashu features will not work \nSet the seed phrase using NdkConfig or Cashu.setCashuSeedPhrase()',
       );
     }
   }

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu_export_import.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu_export_import.dart
@@ -116,8 +116,7 @@ class CashuStateExportImport {
         export['seedPhrase'] = _cashuSeed.getSeedPhrase().sentence;
       } catch (_) {
         Logger.log.w(
-          () =>
-              'Cashu export: no seed phrase set, exporting without it. The export will not be restorable on a new device.',
+          () => 'Cashu export: no seed phrase set, exporting without it. The export will not be restorable on a new device.',
         );
       }
     }

--- a/packages/ndk/lib/domain_layer/usecases/cashu/cashu_restore.dart
+++ b/packages/ndk/lib/domain_layer/usecases/cashu/cashu_restore.dart
@@ -271,8 +271,7 @@ class CashuRestore {
     } else {
       // Fallback: try to match by attempting unblinding with each blinded message
       Logger.log.w(
-        () =>
-            'No outputs in restore response or length mismatch, using fallback matching',
+        () => 'No outputs in restore response or length mismatch, using fallback matching',
       );
 
       final Set<String> usedBlindedMessages = {};

--- a/packages/ndk/lib/domain_layer/usecases/decrypted_event_payloads/decrypted_event_payloads.dart
+++ b/packages/ndk/lib/domain_layer/usecases/decrypted_event_payloads/decrypted_event_payloads.dart
@@ -4,8 +4,10 @@ import '../../entities/nip_01_event.dart';
 import '../../repositories/cache_manager.dart';
 
 typedef EventPayloadDecryptor = Future<String?> Function();
-typedef DecryptedPayloadFailureClassifier =
-    DecryptedPayloadStatus? Function(Object error, StackTrace stackTrace);
+typedef DecryptedPayloadFailureClassifier = DecryptedPayloadStatus? Function(
+  Object error,
+  StackTrace stackTrace,
+);
 
 /// Read-through cache for decrypted payload sidecars.
 ///

--- a/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
+++ b/packages/ndk/lib/domain_layer/usecases/files/blossom.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 
 import '../../../config/blossom_config.dart';

--- a/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
+++ b/packages/ndk/lib/domain_layer/usecases/lists/lists.dart
@@ -1,4 +1,5 @@
 import 'package:rxdart/rxdart.dart';
+
 import 'dart:convert';
 
 import '../../../shared/nips/nip01/helpers.dart';

--- a/packages/ndk/lib/domain_layer/usecases/lnurl/lnurl.dart
+++ b/packages/ndk/lib/domain_layer/usecases/lnurl/lnurl.dart
@@ -73,9 +73,8 @@ class Lnurl {
         zapRequest != null &&
         zapRequest.sig != null &&
         zapRequest.sig!.isNotEmpty) {
-      final zapRequstString = Nip01EventModel.fromEntity(
-        zapRequest,
-      ).toJsonString();
+      final zapRequstString = Nip01EventModel.fromEntity(zapRequest)
+          .toJsonString();
       final eventStr = Uri.encodeQueryComponent(zapRequstString);
       callback += "&nostr=$eventStr";
     }

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc_connection.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:ndk/ndk.dart';
+
 import 'nwc_notification.dart';
 
 import 'responses/nwc_response.dart';

--- a/packages/ndk/lib/domain_layer/usecases/nwc/responses/list_transactions_response.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/responses/list_transactions_response.dart
@@ -1,9 +1,11 @@
 // ignore_for_file: camel_case_types
 
 import 'package:equatable/equatable.dart';
+
 import '../consts/transaction_type.dart';
 import '../nwc_notification.dart';
 import 'nwc_response.dart';
+
 import 'package:ndk/domain_layer/usecases/nwc/consts/nwc_method.dart';
 
 /// Represents the result of a 'list_transactions' response.

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets/relay_sets.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets/relay_sets.dart
@@ -221,22 +221,22 @@ class RelaySets {
     );
 
     /// sort by pubKeys count for each relay descending
-    List<MapEntry<String, Set<PubkeyMapping>>>
-    sortedEntries = pubKeysByRelayUrl.entries.toList()
-      /// todo: use more stuff to improve sorting
-      ..sort((a, b) {
-        int rr = b.value.length.compareTo(a.value.length);
-        if (rr == 0) {
-          // if amount of pubKeys is equal check for webSocket connected, and prioritize connected
-          bool aC = _relayManager.isRelayConnected(a.key);
-          bool bC = _relayManager.isRelayConnected(b.key);
-          if (aC != bC) {
-            return aC ? -1 : 1;
-          }
-          return 0;
-        }
-        return rr;
-      });
+    List<MapEntry<String, Set<PubkeyMapping>>> sortedEntries =
+        pubKeysByRelayUrl.entries.toList()
+          /// todo: use more stuff to improve sorting
+          ..sort((a, b) {
+            int rr = b.value.length.compareTo(a.value.length);
+            if (rr == 0) {
+              // if amount of pubKeys is equal check for webSocket connected, and prioritize connected
+              bool aC = _relayManager.isRelayConnected(a.key);
+              bool bC = _relayManager.isRelayConnected(b.key);
+              if (aC != bC) {
+                return aC ? -1 : 1;
+              }
+              return 0;
+            }
+            return rr;
+          });
 
     return Map<String, Set<PubkeyMapping>>.fromEntries(sortedEntries);
   }

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -377,8 +377,7 @@ class RelaySetsEngine implements NetworkEngine {
               .toList();
         } else {
           Logger.log.w(
-            () =>
-                "could not find user relay list from nip65, using default bootstrap relays",
+            () => "could not find user relay list from nip65, using default bootstrap relays",
           );
         }
 

--- a/packages/ndk/lib/domain_layer/usecases/requests/concurrency_check.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/concurrency_check.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:crypto/crypto.dart';
 
 import '../../entities/filter.dart';

--- a/packages/ndk/lib/domain_layer/usecases/requests/verify_event_stream.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/verify_event_stream.dart
@@ -1,4 +1,5 @@
 import 'package:rxdart/rxdart.dart';
+
 import '../../../shared/logger/logger.dart';
 import '../../entities/nip_01_event.dart';
 import '../../repositories/event_verifier.dart';

--- a/packages/ndk/lib/domain_layer/usecases/search/search.dart
+++ b/packages/ndk/lib/domain_layer/usecases/search/search.dart
@@ -30,17 +30,17 @@ class Search {
   /// [limit] limit of results \
   /// [cacheOnly] if true only cache is used (a lot faster but no network fetch)
   Future<Iterable<Nip01Event>> searchEvents({
-    final List<String>? ids,
-    final List<String>? authors,
-    final List<int>? kinds,
-    final Map<String, List<String>>? tags,
-    final int? since,
-    final int? until,
-    final String? search,
-    final int limit = 100,
+    List<String>? ids,
+    List<String>? authors,
+    List<int>? kinds,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int limit = 100,
 
     /// cache only is much faster but does not fetch from the network
-    final bool cacheOnly = false,
+    bool cacheOnly = false,
   }) async {
     final localEvents = _cacheManager.searchEvents(
       ids: ids,

--- a/packages/ndk/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
+++ b/packages/ndk/lib/domain_layer/usecases/stream_response_cleaner/stream_response_cleaner.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import '../../../shared/logger/logger.dart';
 import '../../entities/event_filter.dart';
 import '../../entities/nip_01_event.dart';

--- a/packages/ndk/lib/domain_layer/usecases/wallets/wallets.dart
+++ b/packages/ndk/lib/domain_layer/usecases/wallets/wallets.dart
@@ -169,15 +169,14 @@ class Wallets {
 
     // Listen to discovered wallets from all providers
     _walletsUsecaseSubscription =
-        Rx.merge(_providers.values.map((p) => p.discoveredWallets)).listen((
-          wallets,
-        ) {
-          for (final wallet in wallets) {
-            if (!_wallets.any((w) => w.id == wallet.id)) {
-              addWallet(wallet);
-            }
-          }
-        });
+        Rx.merge(_providers.values.map((p) => p.discoveredWallets))
+            .listen((wallets) {
+              for (final wallet in wallets) {
+                if (!_wallets.any((w) => w.id == wallet.id)) {
+                  addWallet(wallet);
+                }
+              }
+            });
 
     if (_isDisposed) {
       return;

--- a/packages/ndk/lib/domain_layer/usecases/zaps/zaps.dart
+++ b/packages/ndk/lib/domain_layer/usecases/zaps/zaps.dart
@@ -39,7 +39,7 @@ class Zaps {
     }
 
     try {
-      return _lnurl.fetchInvoice(
+      return await _lnurl.fetchInvoice(
         lnurlResponse: lnurlResponse,
         amountSats: amountSats,
         zapRequest: zapRequest,

--- a/packages/ndk/lib/shared/bloom_filter/bloom_filter.dart
+++ b/packages/ndk/lib/shared/bloom_filter/bloom_filter.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'dart:typed_data';
 import 'dart:convert' show base64Decode, base64Encode, utf8;
+
 import 'package:xxh3/xxh3.dart';
 
 /// generic bloom filter with xxh3

--- a/packages/ndk/lib/shared/isolates/isolate_manager_io.dart
+++ b/packages/ndk/lib/shared/isolates/isolate_manager_io.dart
@@ -24,8 +24,10 @@ final int computeIsolatePoolSize = math.max(
   ),
 );
 
-typedef StreamComputeTask<Q, P> =
-    FutureOr<void> Function(Q argument, void Function(P progress) emit);
+typedef StreamComputeTask<Q, P> = FutureOr<void> Function(
+  Q argument,
+  void Function(P progress) emit,
+);
 
 class IsolateConfig {
   Isolate isolate;

--- a/packages/ndk/lib/shared/isolates/isolate_manager_stub.dart
+++ b/packages/ndk/lib/shared/isolates/isolate_manager_stub.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
-typedef StreamComputeTask<Q, P> =
-    FutureOr<void> Function(Q argument, void Function(P progress) emit);
+typedef StreamComputeTask<Q, P> = FutureOr<void> Function(
+  Q argument,
+  void Function(P progress) emit,
+);
 
 /// Web implementation of IsolateManager that runs tasks on the main thread.
 /// Isolates are not supported on web platforms, so this implementation

--- a/packages/ndk/lib/shared/nips/nip01/bip340.dart
+++ b/packages/ndk/lib/shared/nips/nip01/bip340.dart
@@ -1,5 +1,6 @@
 import 'package:bip340/bip340.dart' as bip340;
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
+
 import 'helpers.dart';
 
 class Bip340 {

--- a/packages/ndk/lib/shared/nips/nip13/nip13.dart
+++ b/packages/ndk/lib/shared/nips/nip13/nip13.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+
 import '../../../domain_layer/entities/nip_01_event.dart';
 import '../../isolates/isolate_manager.dart';
 

--- a/packages/ndk/lib/shared/nips/nip44/nip44.dart
+++ b/packages/ndk/lib/shared/nips/nip44/nip44.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:elliptic/ecdh.dart';
 import 'package:elliptic/elliptic.dart';
 import 'package:meta/meta.dart';
+
 import 'utils.dart';
 
 /// NIP-44 encryption and decryption functions.

--- a/packages/ndk/lib/shared/nips/nip44/utils.dart
+++ b/packages/ndk/lib/shared/nips/nip44/utils.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
+
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:cryptography/cryptography.dart';

--- a/packages/ndk/lib/shared/nips/nip77/negentropy.dart
+++ b/packages/ndk/lib/shared/nips/nip77/negentropy.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 
 /// Negentropy protocol encoder implementation for NIP-77

--- a/packages/ndk/test/cashu/cashu_dart_key_derivation_test.dart
+++ b/packages/ndk/test/cashu/cashu_dart_key_derivation_test.dart
@@ -7,6 +7,7 @@ import 'package:ndk/data_layer/repositories/cashu_seed_secret_generator/dart_cas
 import 'package:test/test.dart';
 
 import 'package:ndk/domain_layer/usecases/cashu/cashu_seed.dart';
+
 import '../tools/simple_profiler.dart';
 
 void main() {
@@ -90,42 +91,32 @@ void main() {
         final testCases = [
           {
             'counter': 0,
-            'secret':
-                "485875df74771877439ac06339e284c3acfcd9be7abf3bc20b516faeadfe77ae",
-            'r':
-                "ad00d431add9c673e843d4c2bf9a778a5f402b985b8da2d5550bf39cda41d679",
+            'secret': "485875df74771877439ac06339e284c3acfcd9be7abf3bc20b516faeadfe77ae",
+            'r': "ad00d431add9c673e843d4c2bf9a778a5f402b985b8da2d5550bf39cda41d679",
             'path': "m/129372'/0'/864559728'/0'",
           },
           {
             'counter': 1,
-            'secret':
-                "8f2b39e8e594a4056eb1e6dbb4b0c38ef13b1b2c751f64f810ec04ee35b77270",
-            'r':
-                "967d5232515e10b81ff226ecf5a9e2e2aff92d66ebc3edf0987eb56357fd6248",
+            'secret': "8f2b39e8e594a4056eb1e6dbb4b0c38ef13b1b2c751f64f810ec04ee35b77270",
+            'r': "967d5232515e10b81ff226ecf5a9e2e2aff92d66ebc3edf0987eb56357fd6248",
             'path': "m/129372'/0'/864559728'/1'",
           },
           {
             'counter': 2,
-            'secret':
-                "bc628c79accd2364fd31511216a0fab62afd4a18ff77a20deded7b858c9860c8",
-            'r':
-                "b20f47bb6ae083659f3aa986bfa0435c55c6d93f687d51a01f26862d9b9a4899",
+            'secret': "bc628c79accd2364fd31511216a0fab62afd4a18ff77a20deded7b858c9860c8",
+            'r': "b20f47bb6ae083659f3aa986bfa0435c55c6d93f687d51a01f26862d9b9a4899",
             'path': "m/129372'/0'/864559728'/2'",
           },
           {
             'counter': 3,
-            'secret':
-                "59284fd1650ea9fa17db2b3acf59ecd0f2d52ec3261dd4152785813ff27a33bf",
-            'r':
-                "fb5fca398eb0b1deb955a2988b5ac77d32956155f1c002a373535211a2dfdc29",
+            'secret': "59284fd1650ea9fa17db2b3acf59ecd0f2d52ec3261dd4152785813ff27a33bf",
+            'r': "fb5fca398eb0b1deb955a2988b5ac77d32956155f1c002a373535211a2dfdc29",
             'path': "m/129372'/0'/864559728'/3'",
           },
           {
             'counter': 4,
-            'secret':
-                "576c23393a8b31cc8da6688d9c9a96394ec74b40fdaf1f693a6bb84284334ea0",
-            'r':
-                "5f09bfbfe27c439a597719321e061e2e40aad4a36768bb2bcc3de547c9644bf9",
+            'secret': "576c23393a8b31cc8da6688d9c9a96394ec74b40fdaf1f693a6bb84284334ea0",
+            'r': "5f09bfbfe27c439a597719321e061e2e40aad4a36768bb2bcc3de547c9644bf9",
             'path': "m/129372'/0'/864559728'/4'",
           },
         ];
@@ -214,38 +205,28 @@ void main() {
         final testCases = [
           {
             'counter': 0,
-            'secret':
-                "db5561a07a6e6490f8dadeef5be4e92f7cebaecf2f245356b5b2a4ec40687298",
-            'r':
-                "6d26181a3695e32e9f88b80f039ba1ae2ab5a200ad4ce9dbc72c6d3769f2b035",
+            'secret': "db5561a07a6e6490f8dadeef5be4e92f7cebaecf2f245356b5b2a4ec40687298",
+            'r': "6d26181a3695e32e9f88b80f039ba1ae2ab5a200ad4ce9dbc72c6d3769f2b035",
           },
           {
             'counter': 1,
-            'secret':
-                "b70e7b10683da3bf1cdf0411206f8180c463faa16014663f39f2529b2fda922e",
-            'r':
-                "bde4354cee75545bea1a2eee035a34f2d524cee2bb01613823636e998386952e",
+            'secret': "b70e7b10683da3bf1cdf0411206f8180c463faa16014663f39f2529b2fda922e",
+            'r': "bde4354cee75545bea1a2eee035a34f2d524cee2bb01613823636e998386952e",
           },
           {
             'counter': 2,
-            'secret':
-                "78a7ac32ccecc6b83311c6081b89d84bb4128f5a0d0c5e1af081f301c7a513f5",
-            'r':
-                "f40cc1218f085b395c8e1e5aaa25dccc851be3c6c7526a0f4e57108f12d6dac4",
+            'secret': "78a7ac32ccecc6b83311c6081b89d84bb4128f5a0d0c5e1af081f301c7a513f5",
+            'r': "f40cc1218f085b395c8e1e5aaa25dccc851be3c6c7526a0f4e57108f12d6dac4",
           },
           {
             'counter': 3,
-            'secret':
-                "094a2b6c63bfa7970bc09cda0e1cfc9cd3d7c619b8e98fabcfc60aea9e4963e5",
-            'r':
-                "099ed70fc2f7ac769bc20b2a75cb662e80779827b7cc358981318643030577d0",
+            'secret': "094a2b6c63bfa7970bc09cda0e1cfc9cd3d7c619b8e98fabcfc60aea9e4963e5",
+            'r': "099ed70fc2f7ac769bc20b2a75cb662e80779827b7cc358981318643030577d0",
           },
           {
             'counter': 4,
-            'secret':
-                "5e89fc5d30d0bf307ddf0a3ac34aa7a8ee3702169dafa3d3fe1d0cae70ecd5ef",
-            'r':
-                "5550337312d223ba62e3f75cfe2ab70477b046d98e3e71804eade3956c7b98cf",
+            'secret': "5e89fc5d30d0bf307ddf0a3ac34aa7a8ee3702169dafa3d3fe1d0cae70ecd5ef",
+            'r': "5550337312d223ba62e3f75cfe2ab70477b046d98e3e71804eade3956c7b98cf",
           },
         ];
 

--- a/packages/ndk/test/cashu/cashu_fund_test.dart
+++ b/packages/ndk/test/cashu/cashu_fund_test.dart
@@ -193,8 +193,7 @@ void main() {
         http.Response(
           jsonEncode({
             "quote": "d00e6cbc-04c9-4661-8909-e47c19612bf0",
-            "request":
-                "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
+            "request": "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
             "amount": 5,
             "unit": "sat",
             "state": "UNPAID",
@@ -211,8 +210,7 @@ void main() {
         http.Response(
           jsonEncode({
             "quote": "d00e6cbc-04c9-4661-8909-e47c19612bf0",
-            "request":
-                "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
+            "request": "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
             "amount": 5,
             "unit": "sat",
             "state": "UNPAID",
@@ -226,8 +224,7 @@ void main() {
       final cashu = CashuTestTools.mockHttpCashu(
         customMockClient: myHttpMock,
         seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
         ),
       );
 
@@ -278,8 +275,7 @@ void main() {
       final cashu = CashuTestTools.mockHttpCashu(
         customMockClient: myHttpMock,
         seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
         ),
       );
 

--- a/packages/ndk/test/cashu/cashu_redeem_test.dart
+++ b/packages/ndk/test/cashu/cashu_redeem_test.dart
@@ -50,110 +50,112 @@ void main() {
       },
     );
 
-    test("redeem - offline mint should fail immediately on redeem stream", () async {
-      final cache = MemCacheManager();
+    test(
+      "redeem - offline mint should fail immediately on redeem stream",
+      () async {
+        final cache = MemCacheManager();
 
-      // Save mint info so it doesn't try to fetch from network
-      await cache.saveMintInfo(
-        mintInfo: CashuMintInfo(
-          name: 'Test Offline Mint',
-          pubkey: null,
-          version: null,
-          description: null,
-          descriptionLong: null,
-          contact: const [],
-          nuts: const {},
-          motd: null,
-          urls: const ['https://offline.mint.example.com'],
-        ),
-      );
-
-      await cache.saveKeyset(
-        CahsuKeyset(
-          id: 'testKeyset',
-          mintUrl: 'https://offline.mint.example.com',
-          unit: 'sat',
-          active: true,
-          inputFeePPK: 0,
-          fetchedAt:
-              DateTime.now().millisecondsSinceEpoch ~/ 1000, // mark as fresh
-          mintKeyPairs: {
-            CahsuMintKeyPair(amount: 1, pubkey: 'testPubKey-1'),
-            CahsuMintKeyPair(amount: 2, pubkey: 'testPubKey-2'),
-          },
-        ),
-      );
-
-      await cache.saveProofs(
-        proofs: [
-          CashuProof(
-            keysetId: 'testKeyset',
-            amount: 1,
-            secret: 'testSecret-1',
-            unblindedSig: '',
+        // Save mint info so it doesn't try to fetch from network
+        await cache.saveMintInfo(
+          mintInfo: CashuMintInfo(
+            name: 'Test Offline Mint',
+            pubkey: null,
+            version: null,
+            description: null,
+            descriptionLong: null,
+            contact: const [],
+            nuts: const {},
+            motd: null,
+            urls: const ['https://offline.mint.example.com'],
           ),
-          CashuProof(
-            keysetId: 'testKeyset',
+        );
+
+        await cache.saveKeyset(
+          CahsuKeyset(
+            id: 'testKeyset',
+            mintUrl: 'https://offline.mint.example.com',
+            unit: 'sat',
+            active: true,
+            inputFeePPK: 0,
+            fetchedAt:
+                DateTime.now().millisecondsSinceEpoch ~/ 1000, // mark as fresh
+            mintKeyPairs: {
+              CahsuMintKeyPair(amount: 1, pubkey: 'testPubKey-1'),
+              CahsuMintKeyPair(amount: 2, pubkey: 'testPubKey-2'),
+            },
+          ),
+        );
+
+        await cache.saveProofs(
+          proofs: [
+            CashuProof(
+              keysetId: 'testKeyset',
+              amount: 1,
+              secret: 'testSecret-1',
+              unblindedSig: '',
+            ),
+            CashuProof(
+              keysetId: 'testKeyset',
+              amount: 2,
+              secret: 'testSecret-2',
+              unblindedSig: '',
+            ),
+          ],
+          mintUrl: 'https://offline.mint.example.com',
+        );
+
+        final walletsRepo = MemWalletsRepo();
+
+        // Use a Cashu instance with a real HTTP client (not mock) and our custom cache
+        // This will attempt real network calls and timeout quickly
+        final cashu = Cashu(
+          cashuRepo: CashuRepoImpl(client: HttpRequestDS(http.Client())),
+          walletsRepo: walletsRepo,
+          cacheManager: cache,
+          cashuKeyDerivation: DartCashuKeyDerivation(),
+          cashuUserSeedphrase: CashuUserSeedphrase(
+            seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          ),
+        );
+
+        final draftTransaction = CashuWalletTransaction(
+          id: "test-redeem-offline",
+          mintUrl: 'https://offline.mint.example.com',
+          walletId: 'https://offline.mint.example.com',
+          changeAmount: -2,
+          unit: "sat",
+          walletType: WalletType.CASHU,
+          state: WalletTransactionState.draft,
+          method: "bolt11",
+          qouteMelt: CashuQuoteMelt(
+            quoteId: 'test-quote',
             amount: 2,
-            secret: 'testSecret-2',
-            unblindedSig: '',
+            feeReserve: null,
+            paid: false,
+            expiry: null,
+            mintUrl: 'https://offline.mint.example.com',
+            state: CashuQuoteState.unpaid,
+            unit: 'sat',
+            request: 'lnbc1...',
           ),
-        ],
-        mintUrl: 'https://offline.mint.example.com',
-      );
+        );
 
-      final walletsRepo = MemWalletsRepo();
+        final redeemStream = cashu.redeem(
+          draftRedeemTransaction: draftTransaction,
+        );
 
-      // Use a Cashu instance with a real HTTP client (not mock) and our custom cache
-      // This will attempt real network calls and timeout quickly
-      final cashu = Cashu(
-        cashuRepo: CashuRepoImpl(client: HttpRequestDS(http.Client())),
-        walletsRepo: walletsRepo,
-        cacheManager: cache,
-        cashuKeyDerivation: DartCashuKeyDerivation(),
-        cashuUserSeedphrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
-        ),
-      );
+        // The stream should emit pending first, then fail with a failed transaction
+        // This should not hang - it should fail quickly (within timeout period)
+        final transactions = await redeemStream.toList();
 
-      final draftTransaction = CashuWalletTransaction(
-        id: "test-redeem-offline",
-        mintUrl: 'https://offline.mint.example.com',
-        walletId: 'https://offline.mint.example.com',
-        changeAmount: -2,
-        unit: "sat",
-        walletType: WalletType.CASHU,
-        state: WalletTransactionState.draft,
-        method: "bolt11",
-        qouteMelt: CashuQuoteMelt(
-          quoteId: 'test-quote',
-          amount: 2,
-          feeReserve: null,
-          paid: false,
-          expiry: null,
-          mintUrl: 'https://offline.mint.example.com',
-          state: CashuQuoteState.unpaid,
-          unit: 'sat',
-          request: 'lnbc1...',
-        ),
-      );
-
-      final redeemStream = cashu.redeem(
-        draftRedeemTransaction: draftTransaction,
-      );
-
-      // The stream should emit pending first, then fail with a failed transaction
-      // This should not hang - it should fail quickly (within timeout period)
-      final transactions = await redeemStream.toList();
-
-      // Should have at least 2 transactions: pending and failed
-      expect(transactions.length, greaterThanOrEqualTo(2));
-      expect(transactions.first.state, WalletTransactionState.pending);
-      expect(transactions.last.state, WalletTransactionState.failed);
-      expect(transactions.last.completionMsg, isNotNull);
-      expect(transactions.last.completionMsg, contains('failed'));
-    });
+        // Should have at least 2 transactions: pending and failed
+        expect(transactions.length, greaterThanOrEqualTo(2));
+        expect(transactions.first.state, WalletTransactionState.pending);
+        expect(transactions.last.state, WalletTransactionState.failed);
+        expect(transactions.last.completionMsg, isNotNull);
+        expect(transactions.last.completionMsg, contains('failed'));
+      },
+    );
 
     test("invalid mint url", () async {
       final ndk = _ndk();
@@ -259,8 +261,7 @@ void main() {
 
       final cashu = CashuTestTools.mockHttpCashu(
         seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
         ),
         customMockClient: myHttpMock,
         customCache: cache,
@@ -318,117 +319,118 @@ void main() {
       );
     });
 
-    test("redeem fails after proofs spent on mint - proofs marked as spent", () async {
-      // This test verifies the fix for the broken proofs issue:
-      // When meltTokens() fails AFTER the mint has already spent the proofs,
-      // the proofs should be marked as spent locally (not released back to the wallet).
-      // Without this fix, proofs would be marked as unspent and become "broken" -
-      // appearing available in the wallet but actually already burned on the mint.
+    test(
+      "redeem fails after proofs spent on mint - proofs marked as spent",
+      () async {
+        // This test verifies the fix for the broken proofs issue:
+        // When meltTokens() fails AFTER the mint has already spent the proofs,
+        // the proofs should be marked as spent locally (not released back to the wallet).
+        // Without this fix, proofs would be marked as unspent and become "broken" -
+        // appearing available in the wallet but actually already burned on the mint.
 
-      final cache = MemCacheManager();
-      final myHttpMock = MockCashuHttpClient();
+        final cache = MemCacheManager();
+        final myHttpMock = MockCashuHttpClient();
 
-      // Use the mock repo that simulates melt failure after proofs are spent
-      final mockRepo = CashuRepoMeltFailAfterSpendMock(
-        client: HttpRequestDS(myHttpMock),
-      );
+        // Use the mock repo that simulates melt failure after proofs are spent
+        final mockRepo = CashuRepoMeltFailAfterSpendMock(
+          client: HttpRequestDS(myHttpMock),
+        );
 
-      final cashu = CashuTestTools.mockHttpCashu(
-        seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
-        ),
-        customMockClient: myHttpMock,
-        customCache: cache,
-        customRepo: mockRepo,
-      );
+        final cashu = CashuTestTools.mockHttpCashu(
+          seedPhrase: CashuUserSeedphrase(
+            seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          ),
+          customMockClient: myHttpMock,
+          customCache: cache,
+          customRepo: mockRepo,
+        );
 
-      // Add test proofs to cache
-      final testProofs = [
-        CashuProof(
-          keysetId: '00c726786980c4d9',
-          amount: 1,
-          secret: 'proof-s-1',
-          unblindedSig: 'sig1',
-        ),
-        CashuProof(
-          keysetId: '00c726786980c4d9',
-          amount: 2,
-          secret: 'proof-s-2',
-          unblindedSig: 'sig2',
-        ),
-        CashuProof(
-          keysetId: '00c726786980c4d9',
-          amount: 4,
-          secret: 'proof-s-4',
-          unblindedSig: 'sig4',
-        ),
-      ];
+        // Add test proofs to cache
+        final testProofs = [
+          CashuProof(
+            keysetId: '00c726786980c4d9',
+            amount: 1,
+            secret: 'proof-s-1',
+            unblindedSig: 'sig1',
+          ),
+          CashuProof(
+            keysetId: '00c726786980c4d9',
+            amount: 2,
+            secret: 'proof-s-2',
+            unblindedSig: 'sig2',
+          ),
+          CashuProof(
+            keysetId: '00c726786980c4d9',
+            amount: 4,
+            secret: 'proof-s-4',
+            unblindedSig: 'sig4',
+          ),
+        ];
 
-      await cache.saveProofs(proofs: testProofs, mintUrl: mockMintUrl);
+        await cache.saveProofs(proofs: testProofs, mintUrl: mockMintUrl);
 
-      // Verify proofs are initially in unspent state
-      final initialProofs = await cache.getProofs(mintUrl: mockMintUrl);
-      expect(
-        initialProofs.every((p) => p.state == CashuProofState.unspend),
-        isTrue,
-        reason: "All proofs should initially be unspent",
-      );
+        // Verify proofs are initially in unspent state
+        final initialProofs = await cache.getProofs(mintUrl: mockMintUrl);
+        expect(
+          initialProofs.every((p) => p.state == CashuProofState.unspend),
+          isTrue,
+          reason: "All proofs should initially be unspent",
+        );
 
-      final meltQuoteTransaction = await cashu.initiateRedeem(
-        mintUrl: mockMintUrl,
-        request: "lnbc1...",
-        unit: "sat",
-        method: "bolt11",
-      );
+        final meltQuoteTransaction = await cashu.initiateRedeem(
+          mintUrl: mockMintUrl,
+          request: "lnbc1...",
+          unit: "sat",
+          method: "bolt11",
+        );
 
-      final redeemStream = cashu.redeem(
-        draftRedeemTransaction: meltQuoteTransaction,
-      );
+        final redeemStream = cashu.redeem(
+          draftRedeemTransaction: meltQuoteTransaction,
+        );
 
-      // Collect all events from the stream
-      final events = await redeemStream.toList();
+        // Collect all events from the stream
+        final events = await redeemStream.toList();
 
-      // Should emit pending then failed
-      expect(events.length, equals(2));
-      expect(events[0].state, equals(WalletTransactionState.pending));
-      expect(events[1].state, equals(WalletTransactionState.failed));
-      expect(
-        events[1].completionMsg,
-        contains("Proofs were spent but melt failed"),
-      );
+        // Should emit pending then failed
+        expect(events.length, equals(2));
+        expect(events[0].state, equals(WalletTransactionState.pending));
+        expect(events[1].state, equals(WalletTransactionState.failed));
+        expect(
+          events[1].completionMsg,
+          contains("Proofs were spent but melt failed"),
+        );
 
-      // CRITICAL ASSERTION: Verify selected proofs are marked as spent (not unspent/broken)
-      // This is the key behavior that prevents broken proofs
-      final spentProofs = await cache.getProofs(
-        mintUrl: mockMintUrl,
-        state: CashuProofState.spend,
-      );
+        // CRITICAL ASSERTION: Verify selected proofs are marked as spent (not unspent/broken)
+        // This is the key behavior that prevents broken proofs
+        final spentProofs = await cache.getProofs(
+          mintUrl: mockMintUrl,
+          state: CashuProofState.spend,
+        );
 
-      // The melt quote has amount=1 + fee_reserve=2 = 3 sats total
-      // With proofs [1, 2, 4], selection should pick 1+2=3, so 2 proofs
-      expect(
-        spentProofs.length,
-        equals(2),
-        reason:
-            "Selected proofs should be marked as spent since they were burned on the mint",
-      );
-      expect(
-        spentProofs.every((p) => p.state == CashuProofState.spend),
-        isTrue,
-        reason: "All selected proofs should be in spent state",
-      );
+        // The melt quote has amount=1 + fee_reserve=2 = 3 sats total
+        // With proofs [1, 2, 4], selection should pick 1+2=3, so 2 proofs
+        expect(
+          spentProofs.length,
+          equals(2),
+          reason: "Selected proofs should be marked as spent since they were burned on the mint",
+        );
+        expect(
+          spentProofs.every((p) => p.state == CashuProofState.spend),
+          isTrue,
+          reason: "All selected proofs should be in spent state",
+        );
 
-      // Verify unselected proofs remain unspent
-      final unspentProofs = await cache.getProofs(
-        mintUrl: mockMintUrl,
-        state: CashuProofState.unspend,
-      );
-      expect(
-        unspentProofs.length,
-        equals(1),
-        reason: "Unselected proofs should remain unspent",
-      );
-    });
+        // Verify unselected proofs remain unspent
+        final unspentProofs = await cache.getProofs(
+          mintUrl: mockMintUrl,
+          state: CashuProofState.unspend,
+        );
+        expect(
+          unspentProofs.length,
+          equals(1),
+          reason: "Unselected proofs should remain unspent",
+        );
+      },
+    );
   });
 }

--- a/packages/ndk/test/cashu/cashu_restore_test.dart
+++ b/packages/ndk/test/cashu/cashu_restore_test.dart
@@ -14,212 +14,207 @@ const mockMintUrl = 'http://mock.mint';
 void main() {
   group('Cashu Restore Tests', () {
     // cannot test real external mints on tests
-    test(
-      skip: true,
-      'restore - fund wallet1 and restore to wallet2 with real mint',
-      () async {
-        // Create a shared seed phrase for both wallets
-        final seedPhrase = CashuSeed.generateSeedPhrase();
-        final userSeedPhrase = CashuUserSeedphrase(seedPhrase: seedPhrase);
+    test(skip: true, 'restore - fund wallet1 and restore to wallet2 with real mint', () async {
+      // Create a shared seed phrase for both wallets
+      final seedPhrase = CashuSeed.generateSeedPhrase();
+      final userSeedPhrase = CashuUserSeedphrase(seedPhrase: seedPhrase);
 
+      print(
+        'Using seed phrase for test (first 5 words): ${seedPhrase.split(' ').take(5).join(' ')}...',
+      );
+
+      // Create wallet1
+      final httpClient1 = http.Client();
+      final httpRequestDS1 = HttpRequestDS(httpClient1);
+      final cashuRepo1 = CashuRepoImpl(client: httpRequestDS1);
+      final cacheManager1 = MemCacheManager();
+      final keyDerivation1 = DartCashuKeyDerivation();
+
+      final wallet1 = Cashu(
+        cashuRepo: cashuRepo1,
+        walletsRepo: MemWalletsRepo(),
+        cacheManager: cacheManager1,
+        cashuKeyDerivation: keyDerivation1,
+        cashuUserSeedphrase: userSeedPhrase,
+      );
+
+      const fundAmount = 21;
+      const mintUrl = devMintUrl;
+      const unit = "sat";
+
+      print('Step 1: Funding wallet1 with $fundAmount $unit...');
+
+      // Fund wallet1
+      final draftTransaction = await wallet1.initiateFund(
+        mintUrl: mintUrl,
+        amount: fundAmount,
+        unit: unit,
+        method: "bolt11",
+      );
+
+      print('Quote created: ${draftTransaction.qoute!.quoteId}');
+      print('Payment request: ${draftTransaction.qoute!.request}');
+      print('Waiting for payment...');
+
+      final transactionStream = wallet1.retrieveFunds(
+        draftTransaction: draftTransaction,
+      );
+
+      await expectLater(
+        transactionStream,
+        emitsInOrder([
+          isA<CashuWalletTransaction>().having(
+            (t) => t.state,
+            'state',
+            WalletTransactionState.pending,
+          ),
+          isA<CashuWalletTransaction>().having(
+            (t) => t.state,
+            'state',
+            WalletTransactionState.completed,
+          ),
+        ]),
+      );
+
+      print('Wallet1 funded successfully!');
+      // cycle proofs 2
+      final spendResult = await wallet1.initiateSpend(
+        mintUrl: mintUrl,
+        amount: 2,
+        unit: unit,
+      );
+
+      final stream = wallet1.receive(spendResult.token.toV4TokenString());
+
+      await expectLater(
+        stream,
+        emitsInOrder([
+          isA<CashuWalletTransaction>().having(
+            (t) => t.state,
+            'state',
+            WalletTransactionState.pending,
+          ),
+          isA<CashuWalletTransaction>().having(
+            (t) => t.state,
+            'state',
+            WalletTransactionState.completed,
+          ),
+        ]),
+      );
+
+      print('Proofs cycled successfully!');
+
+      // Check wallet1 balance
+      final wallet1Balances = await wallet1.getBalances();
+      final wallet1Balance = wallet1Balances
+          .where((element) => element.mintUrl == mintUrl)
+          .first
+          .balances[unit]!;
+
+      print('Step 2: Wallet1 funded successfully!');
+      print('Wallet1 balance: $wallet1Balance $unit');
+      expect(wallet1Balance, equals(fundAmount));
+
+      // Get wallet1 proofs to verify later
+      final wallet1Proofs = await cacheManager1.getProofs(mintUrl: mintUrl);
+      print('Wallet1 has ${wallet1Proofs.length} proofs');
+
+      // Create wallet2 with the SAME seed phrase but DIFFERENT cache
+      print('\nStep 3: Creating wallet2 with same seed phrase...');
+
+      final httpClient2 = http.Client();
+      final httpRequestDS2 = HttpRequestDS(httpClient2);
+      final cashuRepo2 = CashuRepoImpl(client: httpRequestDS2);
+      final cacheManager2 = MemCacheManager(); // Fresh cache - empty!
+      final keyDerivation2 = DartCashuKeyDerivation();
+
+      final wallet2 = Cashu(
+        cashuRepo: cashuRepo2,
+        walletsRepo: MemWalletsRepo(),
+        cacheManager: cacheManager2,
+        cashuKeyDerivation: keyDerivation2,
+        cashuUserSeedphrase: userSeedPhrase, // SAME seed phrase!
+      );
+
+      // Wallet2 should have 0 balance before restore (fresh cache)
+      final wallet2BalancesBefore = await wallet2.getBalances();
+      final wallet2BalanceBefore = wallet2BalancesBefore
+          .where((element) => element.mintUrl == mintUrl)
+          .firstOrNull
+          ?.balances[unit];
+
+      print(
+        'Wallet2 balance before restore: ${wallet2BalanceBefore ?? 0} $unit',
+      );
+      expect(wallet2BalanceBefore, anyOf(isNull, equals(0)));
+
+      // Restore wallet2 using the seed phrase
+      print('\nStep 4: Restoring wallet2 from seed phrase...');
+
+      CashuRestoreResult? restoreResult;
+      final restoreStream = wallet2.restore(mintUrl: mintUrl, unit: unit);
+
+      await for (final result in restoreStream) {
+        restoreResult = result;
         print(
-          'Using seed phrase for test (first 5 words): ${seedPhrase.split(' ').take(5).join(' ')}...',
+          '  Progress: ${result.totalProofsRestored} proofs restored so far...',
         );
+      }
 
-        // Create wallet1
-        final httpClient1 = http.Client();
-        final httpRequestDS1 = HttpRequestDS(httpClient1);
-        final cashuRepo1 = CashuRepoImpl(client: httpRequestDS1);
-        final cacheManager1 = MemCacheManager();
-        final keyDerivation1 = DartCashuKeyDerivation();
-
-        final wallet1 = Cashu(
-          cashuRepo: cashuRepo1,
-          walletsRepo: MemWalletsRepo(),
-          cacheManager: cacheManager1,
-          cashuKeyDerivation: keyDerivation1,
-          cashuUserSeedphrase: userSeedPhrase,
-        );
-
-        const fundAmount = 21;
-        const mintUrl = devMintUrl;
-        const unit = "sat";
-
-        print('Step 1: Funding wallet1 with $fundAmount $unit...');
-
-        // Fund wallet1
-        final draftTransaction = await wallet1.initiateFund(
-          mintUrl: mintUrl,
-          amount: fundAmount,
-          unit: unit,
-          method: "bolt11",
-        );
-
-        print('Quote created: ${draftTransaction.qoute!.quoteId}');
-        print('Payment request: ${draftTransaction.qoute!.request}');
-        print('Waiting for payment...');
-
-        final transactionStream = wallet1.retrieveFunds(
-          draftTransaction: draftTransaction,
-        );
-
-        await expectLater(
-          transactionStream,
-          emitsInOrder([
-            isA<CashuWalletTransaction>().having(
-              (t) => t.state,
-              'state',
-              WalletTransactionState.pending,
-            ),
-            isA<CashuWalletTransaction>().having(
-              (t) => t.state,
-              'state',
-              WalletTransactionState.completed,
-            ),
-          ]),
-        );
-
-        print('Wallet1 funded successfully!');
-        // cycle proofs 2
-        final spendResult = await wallet1.initiateSpend(
-          mintUrl: mintUrl,
-          amount: 2,
-          unit: unit,
-        );
-
-        final stream = wallet1.receive(spendResult.token.toV4TokenString());
-
-        await expectLater(
-          stream,
-          emitsInOrder([
-            isA<CashuWalletTransaction>().having(
-              (t) => t.state,
-              'state',
-              WalletTransactionState.pending,
-            ),
-            isA<CashuWalletTransaction>().having(
-              (t) => t.state,
-              'state',
-              WalletTransactionState.completed,
-            ),
-          ]),
-        );
-
-        print('Proofs cycled successfully!');
-
-        // Check wallet1 balance
-        final wallet1Balances = await wallet1.getBalances();
-        final wallet1Balance = wallet1Balances
-            .where((element) => element.mintUrl == mintUrl)
-            .first
-            .balances[unit]!;
-
-        print('Step 2: Wallet1 funded successfully!');
-        print('Wallet1 balance: $wallet1Balance $unit');
-        expect(wallet1Balance, equals(fundAmount));
-
-        // Get wallet1 proofs to verify later
-        final wallet1Proofs = await cacheManager1.getProofs(mintUrl: mintUrl);
-        print('Wallet1 has ${wallet1Proofs.length} proofs');
-
-        // Create wallet2 with the SAME seed phrase but DIFFERENT cache
-        print('\nStep 3: Creating wallet2 with same seed phrase...');
-
-        final httpClient2 = http.Client();
-        final httpRequestDS2 = HttpRequestDS(httpClient2);
-        final cashuRepo2 = CashuRepoImpl(client: httpRequestDS2);
-        final cacheManager2 = MemCacheManager(); // Fresh cache - empty!
-        final keyDerivation2 = DartCashuKeyDerivation();
-
-        final wallet2 = Cashu(
-          cashuRepo: cashuRepo2,
-          walletsRepo: MemWalletsRepo(),
-          cacheManager: cacheManager2,
-          cashuKeyDerivation: keyDerivation2,
-          cashuUserSeedphrase: userSeedPhrase, // SAME seed phrase!
-        );
-
-        // Wallet2 should have 0 balance before restore (fresh cache)
-        final wallet2BalancesBefore = await wallet2.getBalances();
-        final wallet2BalanceBefore = wallet2BalancesBefore
-            .where((element) => element.mintUrl == mintUrl)
-            .firstOrNull
-            ?.balances[unit];
-
+      print('Restore completed!');
+      print('Total proofs restored: ${restoreResult!.totalProofsRestored}');
+      for (final keysetResult in restoreResult.keysetResults) {
         print(
-          'Wallet2 balance before restore: ${wallet2BalanceBefore ?? 0} $unit',
+          '  Keyset ${keysetResult.keysetId}: ${keysetResult.restoredProofs.length} proofs',
         );
-        expect(wallet2BalanceBefore, anyOf(isNull, equals(0)));
+      }
 
-        // Restore wallet2 using the seed phrase
-        print('\nStep 4: Restoring wallet2 from seed phrase...');
+      // Check wallet2 balance after restore
+      final wallet2BalancesAfter = await wallet2.getBalances();
+      final wallet2BalanceAfter = wallet2BalancesAfter
+          .where((element) => element.mintUrl == mintUrl)
+          .first
+          .balances[unit]!;
 
-        CashuRestoreResult? restoreResult;
-        final restoreStream = wallet2.restore(mintUrl: mintUrl, unit: unit);
+      print('\nStep 5: Verification');
+      print('Wallet1 balance: $wallet1Balance $unit');
+      print('Wallet2 balance after restore: $wallet2BalanceAfter $unit');
 
-        await for (final result in restoreStream) {
-          restoreResult = result;
-          print(
-            '  Progress: ${result.totalProofsRestored} proofs restored so far...',
-          );
-        }
+      // Verify both wallets have the same balance
+      expect(
+        wallet2BalanceAfter,
+        equals(wallet1Balance),
+        reason: 'Wallet2 should have the same balance as wallet1 after restore',
+      );
+      expect(
+        wallet2BalanceAfter,
+        equals(fundAmount),
+        reason: 'Wallet2 should have the funded amount',
+      );
 
-        print('Restore completed!');
-        print('Total proofs restored: ${restoreResult!.totalProofsRestored}');
-        for (final keysetResult in restoreResult.keysetResults) {
-          print(
-            '  Keyset ${keysetResult.keysetId}: ${keysetResult.restoredProofs.length} proofs',
-          );
-        }
+      // Verify wallet2 has proofs
+      final wallet2Proofs = await cacheManager2.getProofs(mintUrl: mintUrl);
+      print('Wallet2 has ${wallet2Proofs.length} proofs after restore');
+      expect(
+        wallet2Proofs.length,
+        greaterThan(0),
+        reason: 'Wallet2 should have proofs after restore',
+      );
 
-        // Check wallet2 balance after restore
-        final wallet2BalancesAfter = await wallet2.getBalances();
-        final wallet2BalanceAfter = wallet2BalancesAfter
-            .where((element) => element.mintUrl == mintUrl)
-            .first
-            .balances[unit]!;
+      // Verify that proofs have different secrets (the bug we fixed!)
+      final secrets = wallet2Proofs.map((p) => p.secret).toSet();
+      print('Wallet2 has ${secrets.length} unique secrets');
+      expect(
+        secrets.length,
+        equals(wallet2Proofs.length),
+        reason: 'Each proof should have a unique secret',
+      );
 
-        print('\nStep 5: Verification');
-        print('Wallet1 balance: $wallet1Balance $unit');
-        print('Wallet2 balance after restore: $wallet2BalanceAfter $unit');
+      print('\n✅ Test passed! Restore functionality works correctly.');
+      print('Wallet1 and Wallet2 both have $fundAmount $unit');
 
-        // Verify both wallets have the same balance
-        expect(
-          wallet2BalanceAfter,
-          equals(wallet1Balance),
-          reason:
-              'Wallet2 should have the same balance as wallet1 after restore',
-        );
-        expect(
-          wallet2BalanceAfter,
-          equals(fundAmount),
-          reason: 'Wallet2 should have the funded amount',
-        );
-
-        // Verify wallet2 has proofs
-        final wallet2Proofs = await cacheManager2.getProofs(mintUrl: mintUrl);
-        print('Wallet2 has ${wallet2Proofs.length} proofs after restore');
-        expect(
-          wallet2Proofs.length,
-          greaterThan(0),
-          reason: 'Wallet2 should have proofs after restore',
-        );
-
-        // Verify that proofs have different secrets (the bug we fixed!)
-        final secrets = wallet2Proofs.map((p) => p.secret).toSet();
-        print('Wallet2 has ${secrets.length} unique secrets');
-        expect(
-          secrets.length,
-          equals(wallet2Proofs.length),
-          reason: 'Each proof should have a unique secret',
-        );
-
-        print('\n✅ Test passed! Restore functionality works correctly.');
-        print('Wallet1 and Wallet2 both have $fundAmount $unit');
-
-        httpClient1.close();
-        httpClient2.close();
-      },
-    );
+      httpClient1.close();
+      httpClient2.close();
+    });
   });
 }

--- a/packages/ndk/test/cashu/cashu_spend_test.dart
+++ b/packages/ndk/test/cashu/cashu_spend_test.dart
@@ -62,8 +62,7 @@ void main() {
       final cashu = CashuTestTools.mockHttpCashu(
         customCache: cache,
         seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
         ),
       );
 
@@ -94,8 +93,7 @@ void main() {
     test("spend - no unit for mint", () {
       final cashu = CashuTestTools.mockHttpCashu(
         seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
         ),
       );
 
@@ -142,8 +140,7 @@ void main() {
       final cashu = CashuTestTools.mockHttpCashu(
         customCache: cache,
         seedPhrase: CashuUserSeedphrase(
-          seedPhrase:
-              "reduce invest lunch step couch traffic measure civil want steel trip jar",
+          seedPhrase: "reduce invest lunch step couch traffic measure civil want steel trip jar",
         ),
       );
 

--- a/packages/ndk/test/cashu/mocks/cashu_http_client_mock.dart
+++ b/packages/ndk/test/cashu/mocks/cashu_http_client_mock.dart
@@ -108,70 +108,38 @@ class MockCashuHttpClient extends http.BaseClient {
             "id": "00c726786980c4d9",
             "unit": "sat",
             "keys": {
-              "1":
-                  "02e67dd580169fb31cda6fe475581937a3a04bb0b422c624bfd6eeee1f6da6fa3c",
-              "1024":
-                  "028fb71ffae7afbb43d04a8992b4ea268b0d9aff0921d0abed85ccd2099821b80a",
-              "1048576":
-                  "03556358859d99dca7e6672bac4f12afcf88d0feee2c834800e917d0223b4e37a9",
-              "1073741824":
-                  "031f80815097783a515dbf515578e35542f5675ce92caa158c95db64e68571ad5d",
-              "128":
-                  "03ac769f6d6d4ca6ef83549bf8535280ff70676f45045df782ac20e80f37f0012f",
-              "131072":
-                  "03c711b7a810fc4c8bb42f3ae1d2259cd29cde521fbfd1a96053b7828c8b34a22a",
-              "134217728":
-                  "027e651c25fbcfaf2dc5ef9f6a09286df5d19d07c7c894a2accd2a2a8602f7f6f6",
-              "16":
-                  "03de6848400b656115c502fcf6bc27266ee372b4e256cb337e10e5ee897380f80a",
-              "16384":
-                  "03e5ce94bb082f26cb0978f65dab72acababe8f6691a9cf88dbaede223a0221925",
-              "16777216":
-                  "03572b3fed165a371f54563fadef13f9bc8cfd7841ff200f049a3c57226bd0e0b2",
-              "2":
-                  "03633147c9a55a7d354ab15960675981e0c879d969643cea7da6889963afb90d3d",
-              "2048":
-                  "028644efab3ad590188508f7d3c462b57d592932c5a726b9311342003ec52a084b",
-              "2097152":
-                  "02df9890ef6ecd31146660485a1102979cf6365a80025636ba8c8c1a9a36a0ba89",
-              "2147483648":
-                  "02cc0f4252dc5f4672b863a261b3f7630bd65bd3201580cfff75de6634807c12b3",
-              "256":
-                  "03e4b4bb96562a4855a88814a8659eb7f7eab2df7639d7b646086d5dbe3ae0c7e2",
-              "262144":
-                  "0369d8da14ce6fcd33aa3aff9467b013aad9da5e12515bc6079bebf0da85daea5b",
-              "268435456":
-                  "03ca1e98639a08c2e3724711bbce00fd6a427c27a9b0b6cf7f327b44918b5c43c6",
-              "32":
-                  "030f589815a72b4c2fa4fe728e8b38a102228ef1eb490085d92d567d6ec8c97c09",
-              "32768":
-                  "0353fd1089a6ff7db8c15f82e4c767789e76b0995da1ede24e7243f33b8301d082",
-              "33554432":
-                  "0247abfe7eddd1f55e6c0f8e01c6160bde9b3fc98ee9413f192817a472e0abfcc8",
-              "4":
-                  "0393db23532a95b722da09168f39010561babd79c73e63313890ac6fd5e100e6ac",
-              "4096":
-                  "02718e4fca012601ebb320459fb57607ef9942f901683bf54ab6d6ec2eba2a523d",
-              "4194304":
-                  "020030f75e5a64e7e09150cba9e2572720504d37d438d00b22b16434c7676617e3",
-              "512":
-                  "032b95061460afaebdd0d9f3bad6c1d18dbb738b5daacf64a517e131d47133aad1",
-              "524288":
-                  "02d4ebcf9edec380d52b7190f77d44e6fd7fc195f0f60df656772c74775f2ef653",
-              "536870912":
-                  "02775c491ed9705b84fc0d1dd3abfec5e75fad5b1109240c67ae655b0024c06d1b",
-              "64":
-                  "03d3bab9f316f22c6ceebafb73d9506a9d43863c453a2d3bf7940a0b1e8bba0fb9",
-              "65536":
-                  "03344277ddad3a2cf49c21c5cac9ea620bb24f48fb534abd1539c4a5f3aa620749",
-              "67108864":
-                  "034824c572029074aa94de30fba1bfaa3e9f090da0d1166888dfd11285f1a7874d",
-              "8":
-                  "02ce8f0423a31496b3a405ce472a19f270dc526330d767beae8ec43a4812cbe43b",
-              "8192":
-                  "02e47c542ba5c3664a839e6c5e3968b69916ae9e9387b8eaf973897f4f4ff9de72",
-              "8388608":
-                  "02c7690d8e9032602cb29f4b0123bf8131dd58f42c0d4f457491b33594181a87c7",
+              "1": "02e67dd580169fb31cda6fe475581937a3a04bb0b422c624bfd6eeee1f6da6fa3c",
+              "1024": "028fb71ffae7afbb43d04a8992b4ea268b0d9aff0921d0abed85ccd2099821b80a",
+              "1048576": "03556358859d99dca7e6672bac4f12afcf88d0feee2c834800e917d0223b4e37a9",
+              "1073741824": "031f80815097783a515dbf515578e35542f5675ce92caa158c95db64e68571ad5d",
+              "128": "03ac769f6d6d4ca6ef83549bf8535280ff70676f45045df782ac20e80f37f0012f",
+              "131072": "03c711b7a810fc4c8bb42f3ae1d2259cd29cde521fbfd1a96053b7828c8b34a22a",
+              "134217728": "027e651c25fbcfaf2dc5ef9f6a09286df5d19d07c7c894a2accd2a2a8602f7f6f6",
+              "16": "03de6848400b656115c502fcf6bc27266ee372b4e256cb337e10e5ee897380f80a",
+              "16384": "03e5ce94bb082f26cb0978f65dab72acababe8f6691a9cf88dbaede223a0221925",
+              "16777216": "03572b3fed165a371f54563fadef13f9bc8cfd7841ff200f049a3c57226bd0e0b2",
+              "2": "03633147c9a55a7d354ab15960675981e0c879d969643cea7da6889963afb90d3d",
+              "2048": "028644efab3ad590188508f7d3c462b57d592932c5a726b9311342003ec52a084b",
+              "2097152": "02df9890ef6ecd31146660485a1102979cf6365a80025636ba8c8c1a9a36a0ba89",
+              "2147483648": "02cc0f4252dc5f4672b863a261b3f7630bd65bd3201580cfff75de6634807c12b3",
+              "256": "03e4b4bb96562a4855a88814a8659eb7f7eab2df7639d7b646086d5dbe3ae0c7e2",
+              "262144": "0369d8da14ce6fcd33aa3aff9467b013aad9da5e12515bc6079bebf0da85daea5b",
+              "268435456": "03ca1e98639a08c2e3724711bbce00fd6a427c27a9b0b6cf7f327b44918b5c43c6",
+              "32": "030f589815a72b4c2fa4fe728e8b38a102228ef1eb490085d92d567d6ec8c97c09",
+              "32768": "0353fd1089a6ff7db8c15f82e4c767789e76b0995da1ede24e7243f33b8301d082",
+              "33554432": "0247abfe7eddd1f55e6c0f8e01c6160bde9b3fc98ee9413f192817a472e0abfcc8",
+              "4": "0393db23532a95b722da09168f39010561babd79c73e63313890ac6fd5e100e6ac",
+              "4096": "02718e4fca012601ebb320459fb57607ef9942f901683bf54ab6d6ec2eba2a523d",
+              "4194304": "020030f75e5a64e7e09150cba9e2572720504d37d438d00b22b16434c7676617e3",
+              "512": "032b95061460afaebdd0d9f3bad6c1d18dbb738b5daacf64a517e131d47133aad1",
+              "524288": "02d4ebcf9edec380d52b7190f77d44e6fd7fc195f0f60df656772c74775f2ef653",
+              "536870912": "02775c491ed9705b84fc0d1dd3abfec5e75fad5b1109240c67ae655b0024c06d1b",
+              "64": "03d3bab9f316f22c6ceebafb73d9506a9d43863c453a2d3bf7940a0b1e8bba0fb9",
+              "65536": "03344277ddad3a2cf49c21c5cac9ea620bb24f48fb534abd1539c4a5f3aa620749",
+              "67108864": "034824c572029074aa94de30fba1bfaa3e9f090da0d1166888dfd11285f1a7874d",
+              "8": "02ce8f0423a31496b3a405ce472a19f270dc526330d767beae8ec43a4812cbe43b",
+              "8192": "02e47c542ba5c3664a839e6c5e3968b69916ae9e9387b8eaf973897f4f4ff9de72",
+              "8388608": "02c7690d8e9032602cb29f4b0123bf8131dd58f42c0d4f457491b33594181a87c7",
             },
           },
         ],
@@ -187,70 +155,38 @@ class MockCashuHttpClient extends http.BaseClient {
             "id": "00c726786980c4d9",
             "unit": "sat",
             "keys": {
-              "1":
-                  "02e67dd580169fb31cda6fe475581937a3a04bb0b422c624bfd6eeee1f6da6fa3c",
-              "1024":
-                  "028fb71ffae7afbb43d04a8992b4ea268b0d9aff0921d0abed85ccd2099821b80a",
-              "1048576":
-                  "03556358859d99dca7e6672bac4f12afcf88d0feee2c834800e917d0223b4e37a9",
-              "1073741824":
-                  "031f80815097783a515dbf515578e35542f5675ce92caa158c95db64e68571ad5d",
-              "128":
-                  "03ac769f6d6d4ca6ef83549bf8535280ff70676f45045df782ac20e80f37f0012f",
-              "131072":
-                  "03c711b7a810fc4c8bb42f3ae1d2259cd29cde521fbfd1a96053b7828c8b34a22a",
-              "134217728":
-                  "027e651c25fbcfaf2dc5ef9f6a09286df5d19d07c7c894a2accd2a2a8602f7f6f6",
-              "16":
-                  "03de6848400b656115c502fcf6bc27266ee372b4e256cb337e10e5ee897380f80a",
-              "16384":
-                  "03e5ce94bb082f26cb0978f65dab72acababe8f6691a9cf88dbaede223a0221925",
-              "16777216":
-                  "03572b3fed165a371f54563fadef13f9bc8cfd7841ff200f049a3c57226bd0e0b2",
-              "2":
-                  "03633147c9a55a7d354ab15960675981e0c879d969643cea7da6889963afb90d3d",
-              "2048":
-                  "028644efab3ad590188508f7d3c462b57d592932c5a726b9311342003ec52a084b",
-              "2097152":
-                  "02df9890ef6ecd31146660485a1102979cf6365a80025636ba8c8c1a9a36a0ba89",
-              "2147483648":
-                  "02cc0f4252dc5f4672b863a261b3f7630bd65bd3201580cfff75de6634807c12b3",
-              "256":
-                  "03e4b4bb96562a4855a88814a8659eb7f7eab2df7639d7b646086d5dbe3ae0c7e2",
-              "262144":
-                  "0369d8da14ce6fcd33aa3aff9467b013aad9da5e12515bc6079bebf0da85daea5b",
-              "268435456":
-                  "03ca1e98639a08c2e3724711bbce00fd6a427c27a9b0b6cf7f327b44918b5c43c6",
-              "32":
-                  "030f589815a72b4c2fa4fe728e8b38a102228ef1eb490085d92d567d6ec8c97c09",
-              "32768":
-                  "0353fd1089a6ff7db8c15f82e4c767789e76b0995da1ede24e7243f33b8301d082",
-              "33554432":
-                  "0247abfe7eddd1f55e6c0f8e01c6160bde9b3fc98ee9413f192817a472e0abfcc8",
-              "4":
-                  "0393db23532a95b722da09168f39010561babd79c73e63313890ac6fd5e100e6ac",
-              "4096":
-                  "02718e4fca012601ebb320459fb57607ef9942f901683bf54ab6d6ec2eba2a523d",
-              "4194304":
-                  "020030f75e5a64e7e09150cba9e2572720504d37d438d00b22b16434c7676617e3",
-              "512":
-                  "032b95061460afaebdd0d9f3bad6c1d18dbb738b5daacf64a517e131d47133aad1",
-              "524288":
-                  "02d4ebcf9edec380d52b7190f77d44e6fd7fc195f0f60df656772c74775f2ef653",
-              "536870912":
-                  "02775c491ed9705b84fc0d1dd3abfec5e75fad5b1109240c67ae655b0024c06d1b",
-              "64":
-                  "03d3bab9f316f22c6ceebafb73d9506a9d43863c453a2d3bf7940a0b1e8bba0fb9",
-              "65536":
-                  "03344277ddad3a2cf49c21c5cac9ea620bb24f48fb534abd1539c4a5f3aa620749",
-              "67108864":
-                  "034824c572029074aa94de30fba1bfaa3e9f090da0d1166888dfd11285f1a7874d",
-              "8":
-                  "02ce8f0423a31496b3a405ce472a19f270dc526330d767beae8ec43a4812cbe43b",
-              "8192":
-                  "02e47c542ba5c3664a839e6c5e3968b69916ae9e9387b8eaf973897f4f4ff9de72",
-              "8388608":
-                  "02c7690d8e9032602cb29f4b0123bf8131dd58f42c0d4f457491b33594181a87c7",
+              "1": "02e67dd580169fb31cda6fe475581937a3a04bb0b422c624bfd6eeee1f6da6fa3c",
+              "1024": "028fb71ffae7afbb43d04a8992b4ea268b0d9aff0921d0abed85ccd2099821b80a",
+              "1048576": "03556358859d99dca7e6672bac4f12afcf88d0feee2c834800e917d0223b4e37a9",
+              "1073741824": "031f80815097783a515dbf515578e35542f5675ce92caa158c95db64e68571ad5d",
+              "128": "03ac769f6d6d4ca6ef83549bf8535280ff70676f45045df782ac20e80f37f0012f",
+              "131072": "03c711b7a810fc4c8bb42f3ae1d2259cd29cde521fbfd1a96053b7828c8b34a22a",
+              "134217728": "027e651c25fbcfaf2dc5ef9f6a09286df5d19d07c7c894a2accd2a2a8602f7f6f6",
+              "16": "03de6848400b656115c502fcf6bc27266ee372b4e256cb337e10e5ee897380f80a",
+              "16384": "03e5ce94bb082f26cb0978f65dab72acababe8f6691a9cf88dbaede223a0221925",
+              "16777216": "03572b3fed165a371f54563fadef13f9bc8cfd7841ff200f049a3c57226bd0e0b2",
+              "2": "03633147c9a55a7d354ab15960675981e0c879d969643cea7da6889963afb90d3d",
+              "2048": "028644efab3ad590188508f7d3c462b57d592932c5a726b9311342003ec52a084b",
+              "2097152": "02df9890ef6ecd31146660485a1102979cf6365a80025636ba8c8c1a9a36a0ba89",
+              "2147483648": "02cc0f4252dc5f4672b863a261b3f7630bd65bd3201580cfff75de6634807c12b3",
+              "256": "03e4b4bb96562a4855a88814a8659eb7f7eab2df7639d7b646086d5dbe3ae0c7e2",
+              "262144": "0369d8da14ce6fcd33aa3aff9467b013aad9da5e12515bc6079bebf0da85daea5b",
+              "268435456": "03ca1e98639a08c2e3724711bbce00fd6a427c27a9b0b6cf7f327b44918b5c43c6",
+              "32": "030f589815a72b4c2fa4fe728e8b38a102228ef1eb490085d92d567d6ec8c97c09",
+              "32768": "0353fd1089a6ff7db8c15f82e4c767789e76b0995da1ede24e7243f33b8301d082",
+              "33554432": "0247abfe7eddd1f55e6c0f8e01c6160bde9b3fc98ee9413f192817a472e0abfcc8",
+              "4": "0393db23532a95b722da09168f39010561babd79c73e63313890ac6fd5e100e6ac",
+              "4096": "02718e4fca012601ebb320459fb57607ef9942f901683bf54ab6d6ec2eba2a523d",
+              "4194304": "020030f75e5a64e7e09150cba9e2572720504d37d438d00b22b16434c7676617e3",
+              "512": "032b95061460afaebdd0d9f3bad6c1d18dbb738b5daacf64a517e131d47133aad1",
+              "524288": "02d4ebcf9edec380d52b7190f77d44e6fd7fc195f0f60df656772c74775f2ef653",
+              "536870912": "02775c491ed9705b84fc0d1dd3abfec5e75fad5b1109240c67ae655b0024c06d1b",
+              "64": "03d3bab9f316f22c6ceebafb73d9506a9d43863c453a2d3bf7940a0b1e8bba0fb9",
+              "65536": "03344277ddad3a2cf49c21c5cac9ea620bb24f48fb534abd1539c4a5f3aa620749",
+              "67108864": "034824c572029074aa94de30fba1bfaa3e9f090da0d1166888dfd11285f1a7874d",
+              "8": "02ce8f0423a31496b3a405ce472a19f270dc526330d767beae8ec43a4812cbe43b",
+              "8192": "02e47c542ba5c3664a839e6c5e3968b69916ae9e9387b8eaf973897f4f4ff9de72",
+              "8388608": "02c7690d8e9032602cb29f4b0123bf8131dd58f42c0d4f457491b33594181a87c7",
             },
           },
         ],
@@ -262,8 +198,7 @@ class MockCashuHttpClient extends http.BaseClient {
     _responses['POST:/v1/mint/quote/bolt11'] = http.Response(
       jsonEncode({
         "quote": "d00e6cbc-04c9-4661-8909-e47c19612bf0",
-        "request":
-            "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
+        "request": "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
         "amount": 5,
         "unit": "sat",
         "state": "UNPAID",
@@ -277,8 +212,7 @@ class MockCashuHttpClient extends http.BaseClient {
         http.Response(
           jsonEncode({
             "quote": "d00e6cbc-04c9-4661-8909-e47c19612bf0",
-            "request":
-                "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
+            "request": "lnbc50p1p5tctmqdqqpp5y7jyyyq3ezyu3p4c9dh6qpnjj6znuzrz35ernjjpkmw6lz7y2mxqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysl62hzvm9s5nf53gk22v5nqwf9nuy2uh32wn9rfx6grkjh6vr5jmy09mra5cna504azyhkd2ehdel9sm7fm72ns6ws2fk4m8cwc99hdgptq8hv4",
             "amount": 5,
             "unit": "sat",
             "state": "PAID",

--- a/packages/ndk/test/data_layer/cache_manager/mem_cache_manager_test.dart
+++ b/packages/ndk/test/data_layer/cache_manager/mem_cache_manager_test.dart
@@ -215,9 +215,8 @@ void main() {
       final mockRelaySet = MockRelaySet();
       when(mockRelaySet.name).thenReturn('testName');
       when(mockRelaySet.pubKey).thenReturn('testPubKey');
-      when(
-        mockRelaySet.id,
-      ).thenReturn(RelaySet.buildId('testName', 'testPubKey'));
+      when(mockRelaySet.id)
+          .thenReturn(RelaySet.buildId('testName', 'testPubKey'));
 
       await cacheManager.saveRelaySet(mockRelaySet);
       final result = await cacheManager.loadRelaySet('testName', 'testPubKey');
@@ -229,9 +228,8 @@ void main() {
       final mockRelaySet = MockRelaySet();
       when(mockRelaySet.name).thenReturn('testName');
       when(mockRelaySet.pubKey).thenReturn('testPubKey');
-      when(
-        mockRelaySet.id,
-      ).thenReturn(RelaySet.buildId('testName', 'testPubKey'));
+      when(mockRelaySet.id)
+          .thenReturn(RelaySet.buildId('testName', 'testPubKey'));
 
       await cacheManager.saveRelaySet(mockRelaySet);
       await cacheManager.removeRelaySet('testName', 'testPubKey');
@@ -245,14 +243,12 @@ void main() {
       final mockRelaySet2 = MockRelaySet();
       when(mockRelaySet1.name).thenReturn('testName1');
       when(mockRelaySet1.pubKey).thenReturn('testPubKey1');
-      when(
-        mockRelaySet1.id,
-      ).thenReturn(RelaySet.buildId('testName1', 'testPubKey1'));
+      when(mockRelaySet1.id)
+          .thenReturn(RelaySet.buildId('testName1', 'testPubKey1'));
       when(mockRelaySet2.name).thenReturn('testName2');
       when(mockRelaySet2.pubKey).thenReturn('testPubKey2');
-      when(
-        mockRelaySet2.id,
-      ).thenReturn(RelaySet.buildId('testName2', 'testPubKey2'));
+      when(mockRelaySet2.id)
+          .thenReturn(RelaySet.buildId('testName2', 'testPubKey2'));
 
       await cacheManager.saveRelaySet(mockRelaySet1);
       await cacheManager.saveRelaySet(mockRelaySet2);

--- a/packages/ndk/test/data_layer/cache_manager/mem_cache_manager_test.mocks.dart
+++ b/packages/ndk/test/data_layer/cache_manager/mem_cache_manager_test.mocks.dart
@@ -62,15 +62,10 @@ class MockUserRelayList extends _i1.Mock implements _i6.UserRelayList {
   }
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
   int get createdAt =>
@@ -78,20 +73,16 @@ class MockUserRelayList extends _i1.Mock implements _i6.UserRelayList {
           as int);
 
   @override
-  int get refreshedTimestamp =>
-      (super.noSuchMethod(
-            Invocation.getter(#refreshedTimestamp),
-            returnValue: 0,
-          )
-          as int);
+  int get refreshedTimestamp => (super.noSuchMethod(
+    Invocation.getter(#refreshedTimestamp),
+    returnValue: 0,
+  ) as int);
 
   @override
-  Map<String, _i8.ReadWriteMarker> get relays =>
-      (super.noSuchMethod(
-            Invocation.getter(#relays),
-            returnValue: <String, _i8.ReadWriteMarker>{},
-          )
-          as Map<String, _i8.ReadWriteMarker>);
+  Map<String, _i8.ReadWriteMarker> get relays => (super.noSuchMethod(
+    Invocation.getter(#relays),
+    returnValue: <String, _i8.ReadWriteMarker>{},
+  ) as Map<String, _i8.ReadWriteMarker>);
 
   @override
   Iterable<String> get urls =>
@@ -128,12 +119,10 @@ class MockUserRelayList extends _i1.Mock implements _i6.UserRelayList {
   );
 
   @override
-  _i2.Nip65 toNip65() =>
-      (super.noSuchMethod(
-            Invocation.method(#toNip65, []),
-            returnValue: _FakeNip65_0(this, Invocation.method(#toNip65, [])),
-          )
-          as _i2.Nip65);
+  _i2.Nip65 toNip65() => (super.noSuchMethod(
+    Invocation.method(#toNip65, []),
+    returnValue: _FakeNip65_0(this, Invocation.method(#toNip65, [])),
+  ) as _i2.Nip65);
 }
 
 /// A class which mocks [RelaySet].
@@ -145,12 +134,10 @@ class MockRelaySet extends _i1.Mock implements _i9.RelaySet {
   }
 
   @override
-  String get id =>
-      (super.noSuchMethod(
-            Invocation.getter(#id),
-            returnValue: _i7.dummyValue<String>(this, Invocation.getter(#id)),
-          )
-          as String);
+  String get id => (super.noSuchMethod(
+    Invocation.getter(#id),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#id)),
+  ) as String);
 
   @override
   Iterable<String> get urls =>
@@ -158,63 +145,46 @@ class MockRelaySet extends _i1.Mock implements _i9.RelaySet {
           as Iterable<String>);
 
   @override
-  String get name =>
-      (super.noSuchMethod(
-            Invocation.getter(#name),
-            returnValue: _i7.dummyValue<String>(this, Invocation.getter(#name)),
-          )
-          as String);
+  String get name => (super.noSuchMethod(
+    Invocation.getter(#name),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#name)),
+  ) as String);
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
-  int get relayMinCountPerPubkey =>
-      (super.noSuchMethod(
-            Invocation.getter(#relayMinCountPerPubkey),
-            returnValue: 0,
-          )
-          as int);
+  int get relayMinCountPerPubkey => (super.noSuchMethod(
+    Invocation.getter(#relayMinCountPerPubkey),
+    returnValue: 0,
+  ) as int);
 
   @override
-  _i10.RelayDirection get direction =>
-      (super.noSuchMethod(
-            Invocation.getter(#direction),
-            returnValue: _i10.RelayDirection.inbox,
-          )
-          as _i10.RelayDirection);
+  _i10.RelayDirection get direction => (super.noSuchMethod(
+    Invocation.getter(#direction),
+    returnValue: _i10.RelayDirection.inbox,
+  ) as _i10.RelayDirection);
 
   @override
-  Map<String, List<_i11.PubkeyMapping>> get relaysMap =>
-      (super.noSuchMethod(
-            Invocation.getter(#relaysMap),
-            returnValue: <String, List<_i11.PubkeyMapping>>{},
-          )
-          as Map<String, List<_i11.PubkeyMapping>>);
+  Map<String, List<_i11.PubkeyMapping>> get relaysMap => (super.noSuchMethod(
+    Invocation.getter(#relaysMap),
+    returnValue: <String, List<_i11.PubkeyMapping>>{},
+  ) as Map<String, List<_i11.PubkeyMapping>>);
 
   @override
-  bool get fallbackToBootstrapRelays =>
-      (super.noSuchMethod(
-            Invocation.getter(#fallbackToBootstrapRelays),
-            returnValue: false,
-          )
-          as bool);
+  bool get fallbackToBootstrapRelays => (super.noSuchMethod(
+    Invocation.getter(#fallbackToBootstrapRelays),
+    returnValue: false,
+  ) as bool);
 
   @override
-  List<_i9.NotCoveredPubKey> get notCoveredPubkeys =>
-      (super.noSuchMethod(
-            Invocation.getter(#notCoveredPubkeys),
-            returnValue: <_i9.NotCoveredPubKey>[],
-          )
-          as List<_i9.NotCoveredPubKey>);
+  List<_i9.NotCoveredPubKey> get notCoveredPubkeys => (super.noSuchMethod(
+    Invocation.getter(#notCoveredPubkeys),
+    returnValue: <_i9.NotCoveredPubKey>[],
+  ) as List<_i9.NotCoveredPubKey>);
 
   @override
   set name(String? value) => super.noSuchMethod(
@@ -286,15 +256,10 @@ class MockContactList extends _i1.Mock implements _i14.ContactList {
   }
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
   List<String> get contacts =>
@@ -302,12 +267,10 @@ class MockContactList extends _i1.Mock implements _i14.ContactList {
           as List<String>);
 
   @override
-  List<String> get contactRelays =>
-      (super.noSuchMethod(
-            Invocation.getter(#contactRelays),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> get contactRelays => (super.noSuchMethod(
+    Invocation.getter(#contactRelays),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
   List<String> get petnames =>
@@ -315,28 +278,22 @@ class MockContactList extends _i1.Mock implements _i14.ContactList {
           as List<String>);
 
   @override
-  List<String> get followedTags =>
-      (super.noSuchMethod(
-            Invocation.getter(#followedTags),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> get followedTags => (super.noSuchMethod(
+    Invocation.getter(#followedTags),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
-  List<String> get followedCommunities =>
-      (super.noSuchMethod(
-            Invocation.getter(#followedCommunities),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> get followedCommunities => (super.noSuchMethod(
+    Invocation.getter(#followedCommunities),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
-  List<String> get followedEvents =>
-      (super.noSuchMethod(
-            Invocation.getter(#followedEvents),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> get followedEvents => (super.noSuchMethod(
+    Invocation.getter(#followedEvents),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
   int get createdAt =>
@@ -409,31 +366,23 @@ class MockContactList extends _i1.Mock implements _i14.ContactList {
   );
 
   @override
-  List<List<String>> contactsToJson() =>
-      (super.noSuchMethod(
-            Invocation.method(#contactsToJson, []),
-            returnValue: <List<String>>[],
-          )
-          as List<List<String>>);
+  List<List<String>> contactsToJson() => (super.noSuchMethod(
+    Invocation.method(#contactsToJson, []),
+    returnValue: <List<String>>[],
+  ) as List<List<String>>);
 
   @override
   List<List<String>> tagListToJson(List<String>? list, String? tag) =>
       (super.noSuchMethod(
-            Invocation.method(#tagListToJson, [list, tag]),
-            returnValue: <List<String>>[],
-          )
-          as List<List<String>>);
+        Invocation.method(#tagListToJson, [list, tag]),
+        returnValue: <List<String>>[],
+      ) as List<List<String>>);
 
   @override
-  _i3.Nip01Event toEvent() =>
-      (super.noSuchMethod(
-            Invocation.method(#toEvent, []),
-            returnValue: _FakeNip01Event_1(
-              this,
-              Invocation.method(#toEvent, []),
-            ),
-          )
-          as _i3.Nip01Event);
+  _i3.Nip01Event toEvent() => (super.noSuchMethod(
+    Invocation.method(#toEvent, []),
+    returnValue: _FakeNip01Event_1(this, Invocation.method(#toEvent, [])),
+  ) as _i3.Nip01Event);
 }
 
 /// A class which mocks [Metadata].
@@ -445,23 +394,16 @@ class MockMetadata extends _i1.Mock implements _i4.Metadata {
   }
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
-  Map<String, dynamic> get content =>
-      (super.noSuchMethod(
-            Invocation.getter(#content),
-            returnValue: <String, dynamic>{},
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> get content => (super.noSuchMethod(
+    Invocation.getter(#content),
+    returnValue: <String, dynamic>{},
+  ) as Map<String, dynamic>);
 
   @override
   List<String> get sources =>
@@ -469,12 +411,10 @@ class MockMetadata extends _i1.Mock implements _i4.Metadata {
           as List<String>);
 
   @override
-  List<List<String>> get tags =>
-      (super.noSuchMethod(
-            Invocation.getter(#tags),
-            returnValue: <List<String>>[],
-          )
-          as List<List<String>>);
+  List<List<String>> get tags => (super.noSuchMethod(
+    Invocation.getter(#tags),
+    returnValue: <List<String>>[],
+  ) as List<List<String>>);
 
   @override
   set pubKey(String? value) => super.noSuchMethod(
@@ -567,23 +507,16 @@ class MockMetadata extends _i1.Mock implements _i4.Metadata {
   );
 
   @override
-  Map<String, dynamic> toJson() =>
-      (super.noSuchMethod(
-            Invocation.method(#toJson, []),
-            returnValue: <String, dynamic>{},
-          )
-          as Map<String, dynamic>);
+  Map<String, dynamic> toJson() => (super.noSuchMethod(
+    Invocation.method(#toJson, []),
+    returnValue: <String, dynamic>{},
+  ) as Map<String, dynamic>);
 
   @override
-  _i3.Nip01Event toEvent() =>
-      (super.noSuchMethod(
-            Invocation.method(#toEvent, []),
-            returnValue: _FakeNip01Event_1(
-              this,
-              Invocation.method(#toEvent, []),
-            ),
-          )
-          as _i3.Nip01Event);
+  _i3.Nip01Event toEvent() => (super.noSuchMethod(
+    Invocation.method(#toEvent, []),
+    returnValue: _FakeNip01Event_1(this, Invocation.method(#toEvent, [])),
+  ) as _i3.Nip01Event);
 
   @override
   void setCustomField(String? key, dynamic value) => super.noSuchMethod(
@@ -596,23 +529,16 @@ class MockMetadata extends _i1.Mock implements _i4.Metadata {
       super.noSuchMethod(Invocation.method(#getCustomField, [key]));
 
   @override
-  String getName() =>
-      (super.noSuchMethod(
-            Invocation.method(#getName, []),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.method(#getName, []),
-            ),
-          )
-          as String);
+  String getName() => (super.noSuchMethod(
+    Invocation.method(#getName, []),
+    returnValue: _i7.dummyValue<String>(this, Invocation.method(#getName, [])),
+  ) as String);
 
   @override
-  bool matchesSearch(String? str) =>
-      (super.noSuchMethod(
-            Invocation.method(#matchesSearch, [str]),
-            returnValue: false,
-          )
-          as bool);
+  bool matchesSearch(String? str) => (super.noSuchMethod(
+    Invocation.method(#matchesSearch, [str]),
+    returnValue: false,
+  ) as bool);
 
   @override
   _i4.Metadata copyWith({
@@ -631,47 +557,45 @@ class MockMetadata extends _i1.Mock implements _i4.Metadata {
     List<String>? sources,
     List<List<String>>? tags,
     Map<String, dynamic>? content,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#copyWith, [], {
-              #pubKey: pubKey,
-              #name: name,
-              #displayName: displayName,
-              #picture: picture,
-              #banner: banner,
-              #website: website,
-              #about: about,
-              #nip05: nip05,
-              #lud16: lud16,
-              #lud06: lud06,
-              #updatedAt: updatedAt,
-              #refreshedTimestamp: refreshedTimestamp,
-              #sources: sources,
-              #tags: tags,
-              #content: content,
-            }),
-            returnValue: _FakeMetadata_2(
-              this,
-              Invocation.method(#copyWith, [], {
-                #pubKey: pubKey,
-                #name: name,
-                #displayName: displayName,
-                #picture: picture,
-                #banner: banner,
-                #website: website,
-                #about: about,
-                #nip05: nip05,
-                #lud16: lud16,
-                #lud06: lud06,
-                #updatedAt: updatedAt,
-                #refreshedTimestamp: refreshedTimestamp,
-                #sources: sources,
-                #tags: tags,
-                #content: content,
-              }),
-            ),
-          )
-          as _i4.Metadata);
+  }) => (super.noSuchMethod(
+    Invocation.method(#copyWith, [], {
+      #pubKey: pubKey,
+      #name: name,
+      #displayName: displayName,
+      #picture: picture,
+      #banner: banner,
+      #website: website,
+      #about: about,
+      #nip05: nip05,
+      #lud16: lud16,
+      #lud06: lud06,
+      #updatedAt: updatedAt,
+      #refreshedTimestamp: refreshedTimestamp,
+      #sources: sources,
+      #tags: tags,
+      #content: content,
+    }),
+    returnValue: _FakeMetadata_2(
+      this,
+      Invocation.method(#copyWith, [], {
+        #pubKey: pubKey,
+        #name: name,
+        #displayName: displayName,
+        #picture: picture,
+        #banner: banner,
+        #website: website,
+        #about: about,
+        #nip05: nip05,
+        #lud16: lud16,
+        #lud06: lud06,
+        #updatedAt: updatedAt,
+        #refreshedTimestamp: refreshedTimestamp,
+        #sources: sources,
+        #tags: tags,
+        #content: content,
+      }),
+    ),
+  ) as _i4.Metadata);
 }
 
 /// A class which mocks [Nip01Event].
@@ -683,23 +607,16 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
   }
 
   @override
-  String get id =>
-      (super.noSuchMethod(
-            Invocation.getter(#id),
-            returnValue: _i7.dummyValue<String>(this, Invocation.getter(#id)),
-          )
-          as String);
+  String get id => (super.noSuchMethod(
+    Invocation.getter(#id),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#id)),
+  ) as String);
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
   int get createdAt =>
@@ -711,23 +628,16 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
       (super.noSuchMethod(Invocation.getter(#kind), returnValue: 0) as int);
 
   @override
-  List<List<String>> get tags =>
-      (super.noSuchMethod(
-            Invocation.getter(#tags),
-            returnValue: <List<String>>[],
-          )
-          as List<List<String>>);
+  List<List<String>> get tags => (super.noSuchMethod(
+    Invocation.getter(#tags),
+    returnValue: <List<String>>[],
+  ) as List<List<String>>);
 
   @override
-  String get content =>
-      (super.noSuchMethod(
-            Invocation.getter(#content),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#content),
-            ),
-          )
-          as String);
+  String get content => (super.noSuchMethod(
+    Invocation.getter(#content),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#content)),
+  ) as String);
 
   @override
   List<String> get sources =>
@@ -745,12 +655,10 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
           as List<String>);
 
   @override
-  List<String> get replyETags =>
-      (super.noSuchMethod(
-            Invocation.getter(#replyETags),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> get replyETags => (super.noSuchMethod(
+    Invocation.getter(#replyETags),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
   set id(String? value) => super.noSuchMethod(
@@ -775,43 +683,39 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
     String? sig,
     bool? validSig,
     List<String>? sources,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#copyWith, [], {
-              #id: id,
-              #pubKey: pubKey,
-              #createdAt: createdAt,
-              #kind: kind,
-              #tags: tags,
-              #content: content,
-              #sig: sig,
-              #validSig: validSig,
-              #sources: sources,
-            }),
-            returnValue: _FakeNip01Event_1(
-              this,
-              Invocation.method(#copyWith, [], {
-                #id: id,
-                #pubKey: pubKey,
-                #createdAt: createdAt,
-                #kind: kind,
-                #tags: tags,
-                #content: content,
-                #sig: sig,
-                #validSig: validSig,
-                #sources: sources,
-              }),
-            ),
-          )
-          as _i3.Nip01Event);
+  }) => (super.noSuchMethod(
+    Invocation.method(#copyWith, [], {
+      #id: id,
+      #pubKey: pubKey,
+      #createdAt: createdAt,
+      #kind: kind,
+      #tags: tags,
+      #content: content,
+      #sig: sig,
+      #validSig: validSig,
+      #sources: sources,
+    }),
+    returnValue: _FakeNip01Event_1(
+      this,
+      Invocation.method(#copyWith, [], {
+        #id: id,
+        #pubKey: pubKey,
+        #createdAt: createdAt,
+        #kind: kind,
+        #tags: tags,
+        #content: content,
+        #sig: sig,
+        #validSig: validSig,
+        #sources: sources,
+      }),
+    ),
+  ) as _i3.Nip01Event);
 
   @override
-  List<String> getTags(String? tag) =>
-      (super.noSuchMethod(
-            Invocation.method(#getTags, [tag]),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> getTags(String? tag) => (super.noSuchMethod(
+    Invocation.method(#getTags, [tag]),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
   String? getFirstTag(String? name) =>
@@ -827,26 +731,16 @@ class MockNip05 extends _i1.Mock implements _i5.Nip05 {
   }
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
-  String get nip05 =>
-      (super.noSuchMethod(
-            Invocation.getter(#nip05),
-            returnValue: _i7.dummyValue<String>(
-              this,
-              Invocation.getter(#nip05),
-            ),
-          )
-          as String);
+  String get nip05 => (super.noSuchMethod(
+    Invocation.getter(#nip05),
+    returnValue: _i7.dummyValue<String>(this, Invocation.getter(#nip05)),
+  ) as String);
 
   @override
   bool get valid =>
@@ -890,25 +784,23 @@ class MockNip05 extends _i1.Mock implements _i5.Nip05 {
     bool? valid,
     int? networkFetchTime,
     List<String>? relays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#copyWith, [], {
-              #pubKey: pubKey,
-              #nip05: nip05,
-              #valid: valid,
-              #networkFetchTime: networkFetchTime,
-              #relays: relays,
-            }),
-            returnValue: _FakeNip05_3(
-              this,
-              Invocation.method(#copyWith, [], {
-                #pubKey: pubKey,
-                #nip05: nip05,
-                #valid: valid,
-                #networkFetchTime: networkFetchTime,
-                #relays: relays,
-              }),
-            ),
-          )
-          as _i5.Nip05);
+  }) => (super.noSuchMethod(
+    Invocation.method(#copyWith, [], {
+      #pubKey: pubKey,
+      #nip05: nip05,
+      #valid: valid,
+      #networkFetchTime: networkFetchTime,
+      #relays: relays,
+    }),
+    returnValue: _FakeNip05_3(
+      this,
+      Invocation.method(#copyWith, [], {
+        #pubKey: pubKey,
+        #nip05: nip05,
+        #valid: valid,
+        #networkFetchTime: networkFetchTime,
+        #relays: relays,
+      }),
+    ),
+  ) as _i5.Nip05);
 }

--- a/packages/ndk/test/data_layer/cache_manager/sembast_cache_manager_test.dart
+++ b/packages/ndk/test/data_layer/cache_manager/sembast_cache_manager_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:ndk/data_layer/repositories/cache_manager/sembast_cache_manager.dart';
 import 'package:ndk/entities.dart';
 

--- a/packages/ndk/test/data_layer/nostr_transport/websocket_nostr_transport_test.dart
+++ b/packages/ndk/test/data_layer/nostr_transport/websocket_nostr_transport_test.dart
@@ -3,6 +3,7 @@ import 'package:ndk/data_layer/data_sources/websocket.dart';
 import 'package:ndk/data_layer/repositories/nostr_transport/websocket_nostr_transport.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
+
 import 'dart:async';
 
 // This will generate a MockWebsocketDS class
@@ -53,9 +54,8 @@ void main() {
     final result = transport.listen(onData, onError: onError, onDone: onDone);
 
     expect(result, equals(mockSubscription));
-    verify(
-      mockWebsocketDS.listen(onData, onError: onError, onDone: onDone),
-    ).called(1);
+    verify(mockWebsocketDS.listen(onData, onError: onError, onDone: onDone))
+        .called(1);
   });
 
   test('send should delegate to WebsocketDS send', () {

--- a/packages/ndk/test/data_layer/nostr_transport/websocket_nostr_transport_test.mocks.dart
+++ b/packages/ndk/test/data_layer/nostr_transport/websocket_nostr_transport_test.mocks.dart
@@ -41,50 +41,42 @@ class _FakeStreamSubscription_1<T> extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockWebsocketDS extends _i1.Mock implements _i4.WebsocketDS {
   @override
-  _i2.WebSocketChannel get webSocketChannel =>
-      (super.noSuchMethod(
-            Invocation.getter(#webSocketChannel),
-            returnValue: _FakeWebSocketChannel_0(
-              this,
-              Invocation.getter(#webSocketChannel),
-            ),
-            returnValueForMissingStub: _FakeWebSocketChannel_0(
-              this,
-              Invocation.getter(#webSocketChannel),
-            ),
-          )
-          as _i2.WebSocketChannel);
+  _i2.WebSocketChannel get webSocketChannel => (super.noSuchMethod(
+    Invocation.getter(#webSocketChannel),
+    returnValue: _FakeWebSocketChannel_0(
+      this,
+      Invocation.getter(#webSocketChannel),
+    ),
+    returnValueForMissingStub: _FakeWebSocketChannel_0(
+      this,
+      Invocation.getter(#webSocketChannel),
+    ),
+  ) as _i2.WebSocketChannel);
 
   @override
   _i3.StreamSubscription<dynamic> listen(
     void Function(dynamic)? onData, {
     Function? onError,
     void Function()? onDone,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #listen,
-              [onData],
-              {#onError: onError, #onDone: onDone},
-            ),
-            returnValue: _FakeStreamSubscription_1<dynamic>(
-              this,
-              Invocation.method(
-                #listen,
-                [onData],
-                {#onError: onError, #onDone: onDone},
-              ),
-            ),
-            returnValueForMissingStub: _FakeStreamSubscription_1<dynamic>(
-              this,
-              Invocation.method(
-                #listen,
-                [onData],
-                {#onError: onError, #onDone: onDone},
-              ),
-            ),
-          )
-          as _i3.StreamSubscription<dynamic>);
+  }) => (super.noSuchMethod(
+    Invocation.method(#listen, [onData], {#onError: onError, #onDone: onDone}),
+    returnValue: _FakeStreamSubscription_1<dynamic>(
+      this,
+      Invocation.method(
+        #listen,
+        [onData],
+        {#onError: onError, #onDone: onDone},
+      ),
+    ),
+    returnValueForMissingStub: _FakeStreamSubscription_1<dynamic>(
+      this,
+      Invocation.method(
+        #listen,
+        [onData],
+        {#onError: onError, #onDone: onDone},
+      ),
+    ),
+  ) as _i3.StreamSubscription<dynamic>);
 
   @override
   void send(dynamic data) => super.noSuchMethod(
@@ -93,29 +85,23 @@ class MockWebsocketDS extends _i1.Mock implements _i4.WebsocketDS {
   );
 
   @override
-  _i3.Future<void> ready() =>
-      (super.noSuchMethod(
-            Invocation.method(#ready, []),
-            returnValue: _i3.Future<void>.value(),
-            returnValueForMissingStub: _i3.Future<void>.value(),
-          )
-          as _i3.Future<void>);
+  _i3.Future<void> ready() => (super.noSuchMethod(
+    Invocation.method(#ready, []),
+    returnValue: _i3.Future<void>.value(),
+    returnValueForMissingStub: _i3.Future<void>.value(),
+  ) as _i3.Future<void>);
 
   @override
-  _i3.Future<void> close() =>
-      (super.noSuchMethod(
-            Invocation.method(#close, []),
-            returnValue: _i3.Future<void>.value(),
-            returnValueForMissingStub: _i3.Future<void>.value(),
-          )
-          as _i3.Future<void>);
+  _i3.Future<void> close() => (super.noSuchMethod(
+    Invocation.method(#close, []),
+    returnValue: _i3.Future<void>.value(),
+    returnValueForMissingStub: _i3.Future<void>.value(),
+  ) as _i3.Future<void>);
 
   @override
-  bool isOpen() =>
-      (super.noSuchMethod(
-            Invocation.method(#isOpen, []),
-            returnValue: false,
-            returnValueForMissingStub: false,
-          )
-          as bool);
+  bool isOpen() => (super.noSuchMethod(
+    Invocation.method(#isOpen, []),
+    returnValue: false,
+    returnValueForMissingStub: false,
+  ) as bool);
 }

--- a/packages/ndk/test/entities/blob_nip94_test.dart
+++ b/packages/ndk/test/entities/blob_nip94_test.dart
@@ -56,38 +56,33 @@ void main() async {
       },
     );
 
-    test(
-      'NIP92 - should handle malformed server response gracefully - dim 1920x1080',
-      () {
-        final Map<String, dynamic> malformedJson = {
-          "url": '',
-          "sha256": '',
-          "size": "512",
-          "type": "notype",
-          "nip94": {"dim": "1920x1080"},
-        };
+    test('NIP92 - should handle malformed server response gracefully - dim 1920x1080', () {
+      final Map<String, dynamic> malformedJson = {
+        "url": '',
+        "sha256": '',
+        "size": "512",
+        "type": "notype",
+        "nip94": {"dim": "1920x1080"},
+      };
 
-        final Map<String, dynamic> malformedJson2 = {
-          "url": '',
-          "sha256": '',
-          "size": "512",
-          "dim": 100,
-          "type": "notype",
-          "nip94": {"dim": 100},
-        };
+      final Map<String, dynamic> malformedJson2 = {
+        "url": '',
+        "sha256": '',
+        "size": "512",
+        "dim": 100,
+        "type": "notype",
+        "nip94": {"dim": 100},
+      };
 
-        final result = BlobDescriptor.fromJson(malformedJson);
-        final result2 = BlobDescriptor.fromJson(malformedJson2);
+      final result = BlobDescriptor.fromJson(malformedJson);
+      final result2 = BlobDescriptor.fromJson(malformedJson2);
 
-        expect(result.nip94!.dimenssions, equals("1920x1080"));
-        expect(result2.nip94!.dimenssions, equals("100"));
-      },
-    );
+      expect(result.nip94!.dimenssions, equals("1920x1080"));
+      expect(result2.nip94!.dimenssions, equals("100"));
+    });
 
-    test(
-      'NIP92 - should handle multiple repeated fields - image / thumb / fallback',
-      () {
-        final json = '''{
+    test('NIP92 - should handle multiple repeated fields - image / thumb / fallback', () {
+      final json = '''{
               "url": "https://nostr.download/aaaa.mp4",
               "duration": "24.293322",
               "bitrate": "2227033",
@@ -100,20 +95,16 @@ void main() async {
               "fallback": "https://nostr.download/bbbb.mp4"
           }''';
 
-        final obj = jsonDecode(json);
-        final result = BlobNip94.fromJson(obj);
-        expect(result.dimenssions, equals("590x1280"));
-        // replaced by second instance (BAD!!)
-        // https://github.com/hzrd149/blossom/pull/60
-        expect(
-          result.fallback!.first,
-          equals("https://nostr.download/bbbb.mp4"),
-        );
-        expect(
-          result.thumbnail!.first,
-          equals("https://nostr.download/thumb/aaaa.webp"),
-        );
-      },
-    );
+      final obj = jsonDecode(json);
+      final result = BlobNip94.fromJson(obj);
+      expect(result.dimenssions, equals("590x1280"));
+      // replaced by second instance (BAD!!)
+      // https://github.com/hzrd149/blossom/pull/60
+      expect(result.fallback!.first, equals("https://nostr.download/bbbb.mp4"));
+      expect(
+        result.thumbnail!.first,
+        equals("https://nostr.download/thumb/aaaa.webp"),
+      );
+    });
   });
 }

--- a/packages/ndk/test/mocks/mock_blossom_server.dart
+++ b/packages/ndk/test/mocks/mock_blossom_server.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 import 'package:ndk/shared/logger/logger.dart';
 

--- a/packages/ndk/test/mocks/mock_relay_replaceable_test.dart
+++ b/packages/ndk/test/mocks/mock_relay_replaceable_test.dart
@@ -18,180 +18,174 @@ void main() {
       await mockRelay.stopServer();
     });
 
-    test(
-      'replaceable events (kind 10002) should be replaced by newer version from same author',
-      () async {
-        final keyPair = Bip340.generatePrivateKey();
+    test('replaceable events (kind 10002) should be replaced by newer version from same author', () async {
+      final keyPair = Bip340.generatePrivateKey();
 
-        final ndkWriter = Ndk(
-          NdkConfig(
-            cache: MemCacheManager(),
-            eventVerifier: MockEventVerifier(),
-            bootstrapRelays: [mockRelay.url],
-          ),
-        );
+      final ndkWriter = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
 
-        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-        // Older version
-        final oldEvent = Nip01Event(
-          pubKey: keyPair.publicKey,
-          kind: 10002,
-          tags: [
-            ['r', 'wss://old.example.com'],
-          ],
-          content: '',
-          createdAt: now - 100,
-        );
-        final signedOld = Nip01Utils.signWithPrivateKey(
-          event: oldEvent,
-          privateKey: keyPair.privateKey!,
-        );
-        await ndkWriter.broadcast
-            .broadcast(nostrEvent: signedOld, specificRelays: [mockRelay.url])
-            .broadcastDoneFuture;
+      // Older version
+      final oldEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 10002,
+        tags: [
+          ['r', 'wss://old.example.com'],
+        ],
+        content: '',
+        createdAt: now - 100,
+      );
+      final signedOld = Nip01Utils.signWithPrivateKey(
+        event: oldEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast
+          .broadcast(nostrEvent: signedOld, specificRelays: [mockRelay.url])
+          .broadcastDoneFuture;
 
-        // Newer version (same author, same kind)
-        final newEvent = Nip01Event(
-          pubKey: keyPair.publicKey,
-          kind: 10002,
-          tags: [
-            ['r', 'wss://new.example.com'],
-          ],
-          content: '',
-          createdAt: now,
-        );
-        final signedNew = Nip01Utils.signWithPrivateKey(
-          event: newEvent,
-          privateKey: keyPair.privateKey!,
-        );
-        await ndkWriter.broadcast
-            .broadcast(nostrEvent: signedNew, specificRelays: [mockRelay.url])
-            .broadcastDoneFuture;
+      // Newer version (same author, same kind)
+      final newEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 10002,
+        tags: [
+          ['r', 'wss://new.example.com'],
+        ],
+        content: '',
+        createdAt: now,
+      );
+      final signedNew = Nip01Utils.signWithPrivateKey(
+        event: newEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast
+          .broadcast(nostrEvent: signedNew, specificRelays: [mockRelay.url])
+          .broadcastDoneFuture;
 
-        // Query from a fresh client to bypass any local cache
-        final ndkReader = Ndk(
-          NdkConfig(
-            cache: MemCacheManager(),
-            eventVerifier: MockEventVerifier(),
-            bootstrapRelays: [mockRelay.url],
-          ),
-        );
+      // Query from a fresh client to bypass any local cache
+      final ndkReader = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
 
-        final received = <Nip01Event>[];
-        final response = ndkReader.requests.query(
-          filter: Filter(kinds: [10002], authors: [keyPair.publicKey]),
-        );
-        await for (final event in response.stream) {
-          received.add(event);
-        }
+      final received = <Nip01Event>[];
+      final response = ndkReader.requests.query(
+        filter: Filter(kinds: [10002], authors: [keyPair.publicKey]),
+      );
+      await for (final event in response.stream) {
+        received.add(event);
+      }
 
-        expect(
-          received.length,
-          equals(1),
-          reason:
-              'NIP-01 replaceable events should keep only the latest (pubkey, kind); '
-              'mock currently returns every version ever sent.',
-        );
-        expect(
-          received.first.getFirstTag('r'),
-          equals('wss://new.example.com'),
-          reason: 'The retained event should be the newer one.',
-        );
+      expect(
+        received.length,
+        equals(1),
+        reason:
+            'NIP-01 replaceable events should keep only the latest (pubkey, kind); '
+            'mock currently returns every version ever sent.',
+      );
+      expect(
+        received.first.getFirstTag('r'),
+        equals('wss://new.example.com'),
+        reason: 'The retained event should be the newer one.',
+      );
 
-        await ndkWriter.destroy();
-        await ndkReader.destroy();
-      },
-    );
+      await ndkWriter.destroy();
+      await ndkReader.destroy();
+    });
 
-    test(
-      'addressable events (kind 30023) should be replaced by newer version with same d-tag',
-      () async {
-        final keyPair = Bip340.generatePrivateKey();
+    test('addressable events (kind 30023) should be replaced by newer version with same d-tag', () async {
+      final keyPair = Bip340.generatePrivateKey();
 
-        final ndkWriter = Ndk(
-          NdkConfig(
-            cache: MemCacheManager(),
-            eventVerifier: MockEventVerifier(),
-            bootstrapRelays: [mockRelay.url],
-          ),
-        );
+      final ndkWriter = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
 
-        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-        const dTag = 'my-article';
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      const dTag = 'my-article';
 
-        // Older version with d-tag
-        final oldEvent = Nip01Event(
-          pubKey: keyPair.publicKey,
-          kind: 30023,
-          tags: [
-            ['d', dTag],
-          ],
-          content: 'first draft',
-          createdAt: now - 100,
-        );
-        final signedOld = Nip01Utils.signWithPrivateKey(
-          event: oldEvent,
-          privateKey: keyPair.privateKey!,
-        );
-        await ndkWriter.broadcast
-            .broadcast(nostrEvent: signedOld, specificRelays: [mockRelay.url])
-            .broadcastDoneFuture;
+      // Older version with d-tag
+      final oldEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 30023,
+        tags: [
+          ['d', dTag],
+        ],
+        content: 'first draft',
+        createdAt: now - 100,
+      );
+      final signedOld = Nip01Utils.signWithPrivateKey(
+        event: oldEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast
+          .broadcast(nostrEvent: signedOld, specificRelays: [mockRelay.url])
+          .broadcastDoneFuture;
 
-        // Newer version with same d-tag
-        final newEvent = Nip01Event(
-          pubKey: keyPair.publicKey,
-          kind: 30023,
-          tags: [
-            ['d', dTag],
-          ],
-          content: 'final version',
-          createdAt: now,
-        );
-        final signedNew = Nip01Utils.signWithPrivateKey(
-          event: newEvent,
-          privateKey: keyPair.privateKey!,
-        );
-        await ndkWriter.broadcast
-            .broadcast(nostrEvent: signedNew, specificRelays: [mockRelay.url])
-            .broadcastDoneFuture;
+      // Newer version with same d-tag
+      final newEvent = Nip01Event(
+        pubKey: keyPair.publicKey,
+        kind: 30023,
+        tags: [
+          ['d', dTag],
+        ],
+        content: 'final version',
+        createdAt: now,
+      );
+      final signedNew = Nip01Utils.signWithPrivateKey(
+        event: newEvent,
+        privateKey: keyPair.privateKey!,
+      );
+      await ndkWriter.broadcast
+          .broadcast(nostrEvent: signedNew, specificRelays: [mockRelay.url])
+          .broadcastDoneFuture;
 
-        final ndkReader = Ndk(
-          NdkConfig(
-            cache: MemCacheManager(),
-            eventVerifier: MockEventVerifier(),
-            bootstrapRelays: [mockRelay.url],
-          ),
-        );
+      final ndkReader = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [mockRelay.url],
+        ),
+      );
 
-        final received = <Nip01Event>[];
-        final response = ndkReader.requests.query(
-          filter: Filter(
-            kinds: [30023],
-            authors: [keyPair.publicKey],
-            dTags: [dTag],
-          ),
-        );
-        await for (final event in response.stream) {
-          received.add(event);
-        }
+      final received = <Nip01Event>[];
+      final response = ndkReader.requests.query(
+        filter: Filter(
+          kinds: [30023],
+          authors: [keyPair.publicKey],
+          dTags: [dTag],
+        ),
+      );
+      await for (final event in response.stream) {
+        received.add(event);
+      }
 
-        expect(
-          received.length,
-          equals(1),
-          reason:
-              'NIP-01 addressable events should keep only the latest '
-              '(pubkey, kind, d-tag); mock currently returns every version sent.',
-        );
-        expect(
-          received.first.content,
-          equals('final version'),
-          reason: 'The retained event should be the newer one.',
-        );
+      expect(
+        received.length,
+        equals(1),
+        reason:
+            'NIP-01 addressable events should keep only the latest '
+            '(pubkey, kind, d-tag); mock currently returns every version sent.',
+      );
+      expect(
+        received.first.content,
+        equals('final version'),
+        reason: 'The retained event should be the newer one.',
+      );
 
-        await ndkWriter.destroy();
-        await ndkReader.destroy();
-      },
-    );
+      await ndkWriter.destroy();
+      await ndkReader.destroy();
+    });
   });
 }

--- a/packages/ndk/test/ndk_test.dart
+++ b/packages/ndk/test/ndk_test.dart
@@ -178,33 +178,30 @@ void main() async {
       await relay1.stopServer();
     });
 
-    test(
-      'emptyBootstrapRelaysConfig with non-list welcome message from explicit relay',
-      () async {
-        final welcomeMessage =
-            '{"welcome": {"motd": "test message"}, "type": "welcome"}';
-        MockRelay explicitRelay = MockRelay(
-          name: "explicitRelay",
-          explicitPort: 3963,
-          customWelcomeMessage: welcomeMessage,
-        );
-        await explicitRelay.startServer();
+    test('emptyBootstrapRelaysConfig with non-list welcome message from explicit relay', () async {
+      final welcomeMessage =
+          '{"welcome": {"motd": "test message"}, "type": "welcome"}';
+      MockRelay explicitRelay = MockRelay(
+        name: "explicitRelay",
+        explicitPort: 3963,
+        customWelcomeMessage: welcomeMessage,
+      );
+      await explicitRelay.startServer();
 
-        final ndk = Ndk.emptyBootstrapRelaysConfig();
+      final ndk = Ndk.emptyBootstrapRelaysConfig();
 
-        final query = ndk.requests.query(
-          filters: [
-            Filter(kinds: [0]),
-          ],
-          explicitRelays: [explicitRelay.url],
-        );
+      final query = ndk.requests.query(
+        filters: [
+          Filter(kinds: [0]),
+        ],
+        explicitRelays: [explicitRelay.url],
+      );
 
-        await query.future;
+      await query.future;
 
-        ndk.destroy();
-        await explicitRelay.stopServer();
-      },
-    );
+      ndk.destroy();
+      await explicitRelay.stopServer();
+    });
 
     test(
       'should handle null values in events from relays gracefully',

--- a/packages/ndk/test/nips/nip02_test.dart
+++ b/packages/ndk/test/nips/nip02_test.dart
@@ -11,8 +11,7 @@ void main() {
         createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
         pubKey: 'pubkeyUser1',
         kind: ContactList.kKind,
-        content:
-            "{\"wss://nos.lol\":{\"read\":true,\"write\":true},\"wss://relay.damus.io\":{\"read\":true,\"write\":true}}",
+        content: "{\"wss://nos.lol\":{\"read\":true,\"write\":true},\"wss://relay.damus.io\":{\"read\":true,\"write\":true}}",
         tags: [
           ['p', 'contact1'],
           ['p', 'contact2'],

--- a/packages/ndk/test/nips/nip05_test.mocks.mocks.dart
+++ b/packages/ndk/test/nips/nip05_test.mocks.mocks.dart
@@ -46,28 +46,26 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#head, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#head, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#head, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#get, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#get, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#get, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -75,25 +73,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #post,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #post,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #post,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #post,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -101,25 +97,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #put,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #put,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #put,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #put,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -127,25 +121,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #patch,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #patch,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #patch,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #patch,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -153,62 +145,53 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #delete,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #delete,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #delete,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #delete,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#read, [url], {#headers: headers}),
+        returnValue: _i3.Future<String>.value(
+          _i5.dummyValue<String>(
+            this,
             Invocation.method(#read, [url], {#headers: headers}),
-            returnValue: _i3.Future<String>.value(
-              _i5.dummyValue<String>(
-                this,
-                Invocation.method(#read, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<String>);
+          ),
+        ),
+      ) as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
     Uri? url, {
     Map<String, String>? headers,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#readBytes, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-          )
-          as _i3.Future<_i6.Uint8List>);
+  }) => (super.noSuchMethod(
+    Invocation.method(#readBytes, [url], {#headers: headers}),
+    returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+  ) as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-            Invocation.method(#send, [request]),
-            returnValue: _i3.Future<_i2.StreamedResponse>.value(
-              _FakeStreamedResponse_1(
-                this,
-                Invocation.method(#send, [request]),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.StreamedResponse>);
+        Invocation.method(#send, [request]),
+        returnValue: _i3.Future<_i2.StreamedResponse>.value(
+          _FakeStreamedResponse_1(this, Invocation.method(#send, [request])),
+        ),
+      ) as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(

--- a/packages/ndk/test/nips/nip13_test.dart
+++ b/packages/ndk/test/nips/nip13_test.dart
@@ -137,8 +137,7 @@ void main() {
         expect(
           actualDifficulty,
           equals(21),
-          reason:
-              'NIP-13 spec example should have 21 leading zero bits (000006 = 20 + 1 from "6")',
+          reason: 'NIP-13 spec example should have 21 leading zero bits (000006 = 20 + 1 from "6")',
         );
       });
 

--- a/packages/ndk/test/nips/nip19_event_getters_test.dart
+++ b/packages/ndk/test/nips/nip19_event_getters_test.dart
@@ -7,8 +7,7 @@ void main() {
     group('nevent getter', () {
       test('should encode regular event as nevent', () {
         final event = Nip01Event(
-          pubKey:
-              '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
+          pubKey: '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
           kind: 1,
           tags: [],
           content: 'Hello Nostr!',
@@ -30,8 +29,7 @@ void main() {
 
       test('should use event sources as relay hints', () {
         final eventInit = Nip01Event(
-          pubKey:
-              '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
+          pubKey: '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
           kind: 1,
           tags: [],
           content: 'Hello Nostr!',
@@ -51,8 +49,7 @@ void main() {
 
       test('should not include relays if sources is empty', () {
         final event = Nip01Event(
-          pubKey:
-              '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
+          pubKey: '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
           kind: 1,
           tags: [],
           content: 'Hello Nostr!',
@@ -70,8 +67,7 @@ void main() {
     group('naddr getter', () {
       test('should encode parameterized replaceable event as naddr', () {
         final event = Nip01Event(
-          pubKey:
-              '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+          pubKey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
           kind: 30023,
           tags: [
             ['d', 'my-article'],
@@ -95,8 +91,7 @@ void main() {
 
       test('should encode replaceable event (kind 0) as naddr', () {
         final event = Nip01Event(
-          pubKey:
-              '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+          pubKey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
           kind: 30001,
           tags: [
             ['d', 'bla'],
@@ -116,8 +111,7 @@ void main() {
 
       test('should return null for non-addressable event', () {
         final event = Nip01Event(
-          pubKey:
-              '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+          pubKey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
           kind: 1, // Regular text note, not addressable
           tags: [
             ['d', 'test'],
@@ -134,8 +128,7 @@ void main() {
 
       test('should return null for addressable event without d tag', () {
         final event = Nip01Event(
-          pubKey:
-              '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+          pubKey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
           kind: 30023,
           tags: [], // No d tag
           content: 'Article content',
@@ -150,8 +143,7 @@ void main() {
 
       test('should use event sources as relay hints', () {
         final event = Nip01Event(
-          pubKey:
-              '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+          pubKey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
           kind: 31990,
           tags: [
             ['d', '1685802317447'],

--- a/packages/ndk/test/nips/nip19_test.dart
+++ b/packages/ndk/test/nips/nip19_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:test/test.dart';
 import 'package:bech32/bech32.dart';
 import 'package:convert/convert.dart';
@@ -294,8 +295,7 @@ void main() {
       test('Naddr.toString should return formatted string', () {
         final naddr = Naddr(
           identifier: 'test-id',
-          pubkey:
-              '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+          pubkey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
           kind: 30023,
           relays: ['wss://relay.example.com'],
         );
@@ -314,10 +314,8 @@ void main() {
 
       test('Nevent.toString should return formatted string', () {
         final nevent = Nevent(
-          eventId:
-              'a12ff3d33a94fa408d71e2435e6382700647f0cd3c0c09d56ec2cc64d5164b43',
-          author:
-              '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
+          eventId: 'a12ff3d33a94fa408d71e2435e6382700647f0cd3c0c09d56ec2cc64d5164b43',
+          author: '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa',
           kind: 1,
           relays: ['wss://nos.lol/'],
         );
@@ -341,8 +339,7 @@ void main() {
 
       test('Nprofile.toString should return formatted string', () {
         final nprofile = Nprofile(
-          pubkey:
-              '30782a8323b7c98b172c5a2af7206bb8283c655be6ddce11133611a03d5f1177',
+          pubkey: '30782a8323b7c98b172c5a2af7206bb8283c655be6ddce11133611a03d5f1177',
           relays: ['wss://relay.example.com'],
         );
 
@@ -373,8 +370,7 @@ void main() {
         final longRelay = 'wss://${'a' * 300}.com';
         expect(
           () => Nip19.encodeNevent(
-            eventId:
-                'a12ff3d33a94fa408d71e2435e6382700647f0cd3c0c09d56ec2cc64d5164b43',
+            eventId: 'a12ff3d33a94fa408d71e2435e6382700647f0cd3c0c09d56ec2cc64d5164b43',
             relays: [longRelay],
           ),
           throwsA(isA<ArgumentError>()),
@@ -385,8 +381,7 @@ void main() {
         // Use valid hex but wrong length (30 bytes instead of 32)
         expect(
           () => Nip19.encodeNevent(
-            eventId:
-                'a12ff3d33a94fa408d71e2435e6382700647f0cd3c0c09d56ec2cc64d5164b43',
+            eventId: 'a12ff3d33a94fa408d71e2435e6382700647f0cd3c0c09d56ec2cc64d5164b43',
             author:
                 '76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29',
           ),
@@ -412,8 +407,7 @@ void main() {
         expect(
           () => Nip19.encodeNaddr(
             identifier: 'test',
-            pubkey:
-                '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
+            pubkey: '460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c',
             kind: 30023,
             relays: [longRelay],
           ),
@@ -436,8 +430,7 @@ void main() {
         final longRelay = 'wss://${'a' * 300}.com';
         expect(
           () => Nip19.encodeNprofile(
-            pubkey:
-                '30782a8323b7c98b172c5a2af7206bb8283c655be6ddce11133611a03d5f1177',
+            pubkey: '30782a8323b7c98b172c5a2af7206bb8283c655be6ddce11133611a03d5f1177',
             relays: [longRelay],
           ),
           throwsA(isA<ArgumentError>()),

--- a/packages/ndk/test/nips/nip44_test.dart
+++ b/packages/ndk/test/nips/nip44_test.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
+
 import 'package:ndk/shared/nips/nip44/nip44.dart';
 import 'package:ndk/shared/nips/nip44/utils.dart';
 import 'package:test/test.dart';
 import 'package:elliptic/elliptic.dart' as elliptic;
+
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 
 Uint8List hexToBytes(String hex) {

--- a/packages/ndk/test/nips/nip77_test.dart
+++ b/packages/ndk/test/nips/nip77_test.dart
@@ -175,8 +175,7 @@ void main() {
       final items = [
         NegentropyItem.fromHex(
           timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          idHex: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         ),
       ];
       final msg = NegentropyEncoder.createInitialMessage(
@@ -191,13 +190,11 @@ void main() {
       final items = [
         NegentropyItem.fromHex(
           timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          idHex: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         ),
         NegentropyItem.fromHex(
           timestamp: 2000,
-          idHex:
-              'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+          idHex: 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
         ),
       ];
       final msg = NegentropyEncoder.createInitialMessage(
@@ -213,18 +210,15 @@ void main() {
       final items = [
         NegentropyItem.fromHex(
           timestamp: 2000,
-          idHex:
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          idHex: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         ),
         NegentropyItem.fromHex(
           timestamp: 1000,
-          idHex:
-              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          idHex: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         ),
         NegentropyItem.fromHex(
           timestamp: 1000,
-          idHex:
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          idHex: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         ),
       ];
       // createInitialMessage sorts internally
@@ -300,8 +294,7 @@ void main() {
       final relayItems = [
         NegentropyItem.fromHex(
           timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          idHex: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         ),
       ];
 
@@ -322,8 +315,7 @@ void main() {
       final localItems = [
         NegentropyItem.fromHex(
           timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          idHex: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         ),
       ];
 

--- a/packages/ndk/test/relays/relay_manager_test.dart
+++ b/packages/ndk/test/relays/relay_manager_test.dart
@@ -160,149 +160,144 @@ void main() async {
       }
     });
 
-    test(
-      'CLOSED message bug - should not remove entire request from inFlightRequests',
-      () async {
-        // This test exposes a bug where receiving a CLOSED message from one relay
-        // removes the entire request from globalState.inFlightRequests, causing
-        // events from other relays to be lost since there's no request entry to handle them.
+    test('CLOSED message bug - should not remove entire request from inFlightRequests', () async {
+      // This test exposes a bug where receiving a CLOSED message from one relay
+      // removes the entire request from globalState.inFlightRequests, causing
+      // events from other relays to be lost since there's no request entry to handle them.
 
-        MockRelay relay1 = MockRelay(name: "relay 1", explicitPort: 5050);
-        MockRelay relay2 = MockRelay(name: "relay 2", explicitPort: 5051);
+      MockRelay relay1 = MockRelay(name: "relay 1", explicitPort: 5050);
+      MockRelay relay2 = MockRelay(name: "relay 2", explicitPort: 5051);
 
-        await relay1.startServer();
-        await relay2.startServer();
+      await relay1.startServer();
+      await relay2.startServer();
 
-        RelayManager manager = RelayManager(
-          globalState: GlobalState(),
-          bootstrapRelays: [],
-          nostrTransportFactory: webSocketNostrTransportFactory,
-        );
+      RelayManager manager = RelayManager(
+        globalState: GlobalState(),
+        bootstrapRelays: [],
+        nostrTransportFactory: webSocketNostrTransportFactory,
+      );
 
-        // Connect to both relays
-        await manager.connectRelay(
-          dirtyUrl: relay1.url,
-          connectionSource: ConnectionSource.seed,
-        );
-        await manager.connectRelay(
-          dirtyUrl: relay2.url,
-          connectionSource: ConnectionSource.seed,
-        );
+      // Connect to both relays
+      await manager.connectRelay(
+        dirtyUrl: relay1.url,
+        connectionSource: ConnectionSource.seed,
+      );
+      await manager.connectRelay(
+        dirtyUrl: relay2.url,
+        connectionSource: ConnectionSource.seed,
+      );
 
-        // Create test filters for the request
-        final testFilters = [
-          Filter(kinds: [1], limit: 10),
-        ];
-        final requestId = "test_request_123";
+      // Create test filters for the request
+      final testFilters = [
+        Filter(kinds: [1], limit: 10),
+      ];
+      final requestId = "test_request_123";
 
-        // Create a request state in globalState.inFlightRequests
-        final request = NdkRequest.query(
-          requestId,
-          name: "test_request",
-          filters: testFilters,
-          closeOnEOSE: false, // This is a subscription, not a one-time request
-          timeoutDuration: Duration(seconds: 30),
-        );
+      // Create a request state in globalState.inFlightRequests
+      final request = NdkRequest.query(
+        requestId,
+        name: "test_request",
+        filters: testFilters,
+        closeOnEOSE: false, // This is a subscription, not a one-time request
+        timeoutDuration: Duration(seconds: 30),
+      );
 
-        manager.globalState.inFlightRequests[requestId] = RequestState(request);
+      manager.globalState.inFlightRequests[requestId] = RequestState(request);
 
-        // Register the request with both relays
-        manager.registerRelayRequest(
-          reqId: requestId,
-          relayUrl: relay1.url,
-          filters: testFilters,
-        );
-        manager.registerRelayRequest(
-          reqId: requestId,
-          relayUrl: relay2.url,
-          filters: testFilters,
-        );
+      // Register the request with both relays
+      manager.registerRelayRequest(
+        reqId: requestId,
+        relayUrl: relay1.url,
+        filters: testFilters,
+      );
+      manager.registerRelayRequest(
+        reqId: requestId,
+        relayUrl: relay2.url,
+        filters: testFilters,
+      );
 
-        // Verify both relay requests are registered
-        expect(manager.globalState.inFlightRequests[requestId], isNotNull);
-        expect(
-          manager.globalState.inFlightRequests[requestId]!.requests[relay1.url],
-          isNotNull,
-        );
-        expect(
-          manager.globalState.inFlightRequests[requestId]!.requests[relay2.url],
-          isNotNull,
-        );
+      // Verify both relay requests are registered
+      expect(manager.globalState.inFlightRequests[requestId], isNotNull);
+      expect(
+        manager.globalState.inFlightRequests[requestId]!.requests[relay1.url],
+        isNotNull,
+      );
+      expect(
+        manager.globalState.inFlightRequests[requestId]!.requests[relay2.url],
+        isNotNull,
+      );
 
-        // Create a test event that relay2 will send
-        final testEvent = Nip01Event(
-          kind: 1,
-          pubKey: "test_pubkey",
-          content: "Test content from relay2",
-          tags: [],
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        );
+      // Create a test event that relay2 will send
+      final testEvent = Nip01Event(
+        kind: 1,
+        pubKey: "test_pubkey",
+        content: "Test content from relay2",
+        tags: [],
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
 
-        final List<Nip01Event> eventsReceived = [];
+      final List<Nip01Event> eventsReceived = [];
 
-        // Listen to the request stream to collect events
-        final streamSubscription = manager
-            .globalState
-            .inFlightRequests[requestId]!
-            .networkController
-            .stream
-            .listen((event) {
-              eventsReceived.add(event);
-            });
+      // Listen to the request stream to collect events
+      final streamSubscription = manager
+          .globalState
+          .inFlightRequests[requestId]!
+          .networkController
+          .stream
+          .listen((event) {
+            eventsReceived.add(event);
+          });
 
-        // Give a moment for stream setup
-        await Future.delayed(Duration(milliseconds: 50));
+      // Give a moment for stream setup
+      await Future.delayed(Duration(milliseconds: 50));
 
-        // Step 1: relay1 sends a CLOSED message
-        // This will trigger the bug - the entire request gets removed from inFlightRequests
-        relay1.sendClosed(requestId, message: "rate limited");
+      // Step 1: relay1 sends a CLOSED message
+      // This will trigger the bug - the entire request gets removed from inFlightRequests
+      relay1.sendClosed(requestId, message: "rate limited");
 
-        // Give a moment for the CLOSED message to be processed
-        await Future.delayed(Duration(milliseconds: 100));
+      // Give a moment for the CLOSED message to be processed
+      await Future.delayed(Duration(milliseconds: 100));
 
-        // CORRECT BEHAVIOR: The request should still exist in inFlightRequests
-        // because relay2 hasn't finished yet. Only relay1's entry should be removed
-        // from the requests map, not the entire request.
-        expect(
-          manager.globalState.inFlightRequests[requestId],
-          isNotNull,
-          reason:
-              "Request should still exist in inFlightRequests after CLOSED from relay1, since relay2 hasn't finished",
-        );
+      // CORRECT BEHAVIOR: The request should still exist in inFlightRequests
+      // because relay2 hasn't finished yet. Only relay1's entry should be removed
+      // from the requests map, not the entire request.
+      expect(
+        manager.globalState.inFlightRequests[requestId],
+        isNotNull,
+        reason: "Request should still exist in inFlightRequests after CLOSED from relay1, since relay2 hasn't finished",
+      );
 
-        // The request should still have relay2's entry, but relay1's should be removed or marked as closed
-        expect(
-          manager.globalState.inFlightRequests[requestId]!.requests[relay2.url],
-          isNotNull,
-          reason: "Relay2's request entry should still exist",
-        );
+      // The request should still have relay2's entry, but relay1's should be removed or marked as closed
+      expect(
+        manager.globalState.inFlightRequests[requestId]!.requests[relay2.url],
+        isNotNull,
+        reason: "Relay2's request entry should still exist",
+      );
 
-        // Step 2: relay2 tries to send an event
-        // This should work because the request entry should still exist
-        relay2.sendEvent(event: testEvent, subId: requestId);
+      // Step 2: relay2 tries to send an event
+      // This should work because the request entry should still exist
+      relay2.sendEvent(event: testEvent, subId: requestId);
 
-        // Give time for event processing
-        await Future.delayed(Duration(milliseconds: 100));
+      // Give time for event processing
+      await Future.delayed(Duration(milliseconds: 100));
 
-        // CORRECT BEHAVIOR: Events from relay2 should be received
-        expect(
-          eventsReceived.length,
-          equals(1),
-          reason:
-              "Event from relay2 should be received even after relay1 sent CLOSED message",
-        );
+      // CORRECT BEHAVIOR: Events from relay2 should be received
+      expect(
+        eventsReceived.length,
+        equals(1),
+        reason: "Event from relay2 should be received even after relay1 sent CLOSED message",
+      );
 
-        expect(
-          eventsReceived.first.content,
-          equals("Test content from relay2"),
-          reason: "The received event should be the one sent by relay2",
-        );
+      expect(
+        eventsReceived.first.content,
+        equals("Test content from relay2"),
+        reason: "The received event should be the one sent by relay2",
+      );
 
-        // Clean up
-        await streamSubscription.cancel();
-        await relay1.stopServer();
-        await relay2.stopServer();
-      },
-    );
+      // Clean up
+      await streamSubscription.cancel();
+      await relay1.stopServer();
+      await relay2.stopServer();
+    });
   });
 }

--- a/packages/ndk/test/relays/relay_sets_test.dart
+++ b/packages/ndk/test/relays/relay_sets_test.dart
@@ -361,101 +361,95 @@ void main() async {
     //   //expect(query, emitsInAnyOrder(key1TextNotes.values));
     // });
 
-    test(
-      "calculate best relays for relayMinCountPerPubKey=1 and check that it doesn't use redundant relays",
-      () async {
-        final ndk = Ndk(
-          NdkConfig(
-            eventVerifier: MockEventVerifier(),
-            cache: MemCacheManager(),
-            engine: NdkEngine.RELAY_SETS,
-            bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
-          ),
-        );
+    test("calculate best relays for relayMinCountPerPubKey=1 and check that it doesn't use redundant relays", () async {
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          engine: NdkEngine.RELAY_SETS,
+          bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
+        ),
+      );
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: key1.publicKey,
-          privkey: key1.privateKey!,
-        );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key1.publicKey,
+        privkey: key1.privateKey!,
+      );
 
-        // relayMinCountPerPubKey: 1
-        RelaySet relaySet = await ndk.relaySets.calculateRelaySet(
-          name: "feed",
-          ownerPubKey: "ownerPubKey",
-          pubKeys: [
-            key1.publicKey,
-            key2.publicKey,
-            key3.publicKey,
-            key4.publicKey,
-          ],
-          direction: RelayDirection.outbox,
-          relayMinCountPerPubKey: 1,
-          onProgress: (stepName, count, total) {
-            if (count % 100 == 0 || (total - count) < 10) {
-              print("[PROGRESS] $stepName: $count/$total");
-            }
-          },
-        );
-        print("BEST ${relaySet.relaysMap.length} RELAYS:");
-        relaySet.relaysMap.forEach((url, pubKeyMappings) {
-          print("  $url => has ${pubKeyMappings.length} follows");
-        });
+      // relayMinCountPerPubKey: 1
+      RelaySet relaySet = await ndk.relaySets.calculateRelaySet(
+        name: "feed",
+        ownerPubKey: "ownerPubKey",
+        pubKeys: [
+          key1.publicKey,
+          key2.publicKey,
+          key3.publicKey,
+          key4.publicKey,
+        ],
+        direction: RelayDirection.outbox,
+        relayMinCountPerPubKey: 1,
+        onProgress: (stepName, count, total) {
+          if (count % 100 == 0 || (total - count) < 10) {
+            print("[PROGRESS] $stepName: $count/$total");
+          }
+        },
+      );
+      print("BEST ${relaySet.relaysMap.length} RELAYS:");
+      relaySet.relaysMap.forEach((url, pubKeyMappings) {
+        print("  $url => has ${pubKeyMappings.length} follows");
+      });
 
-        expect(relaySet.urls.contains(relay1.url), true);
-        expect(relaySet.urls.contains(relay2.url), false);
-        expect(relaySet.urls.contains(relay3.url), false);
-        expect(relaySet.urls.contains(relay4.url), true);
-        expect(relaySet.notCoveredPubkeys.isEmpty, true);
-        await ndk.destroy();
-      },
-    );
+      expect(relaySet.urls.contains(relay1.url), true);
+      expect(relaySet.urls.contains(relay2.url), false);
+      expect(relaySet.urls.contains(relay3.url), false);
+      expect(relaySet.urls.contains(relay4.url), true);
+      expect(relaySet.notCoveredPubkeys.isEmpty, true);
+      await ndk.destroy();
+    });
 
-    test(
-      "calculate best relays for relayMinCountPerPubKey=2 and check that it doesn't use redundant relays",
-      () async {
-        final ndk = Ndk(
-          NdkConfig(
-            eventVerifier: MockEventVerifier(),
-            cache: MemCacheManager(),
-            engine: NdkEngine.RELAY_SETS,
-            bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
-          ),
-        );
+    test("calculate best relays for relayMinCountPerPubKey=2 and check that it doesn't use redundant relays", () async {
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          engine: NdkEngine.RELAY_SETS,
+          bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
+        ),
+      );
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: key1.publicKey,
-          privkey: key1.privateKey!,
-        );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key1.publicKey,
+        privkey: key1.privateKey!,
+      );
 
-        RelaySet relaySet = await ndk.relaySets.calculateRelaySet(
-          name: "feed",
-          ownerPubKey: "ownerPubKey",
-          pubKeys: [
-            key1.publicKey,
-            key2.publicKey,
-            key3.publicKey,
-            key4.publicKey,
-          ],
-          direction: RelayDirection.outbox,
-          relayMinCountPerPubKey: 2,
-          onProgress: (stepName, count, total) {
-            if (count % 100 == 0 || (total - count) < 10) {
-              print("[PROGRESS] $stepName: $count/$total");
-            }
-          },
-        );
-        print("BEST ${relaySet.relaysMap.length} RELAYS:");
-        relaySet.relaysMap.forEach((url, pubKeyMappings) {
-          print("  $url => has ${pubKeyMappings.length} follows");
-        });
+      RelaySet relaySet = await ndk.relaySets.calculateRelaySet(
+        name: "feed",
+        ownerPubKey: "ownerPubKey",
+        pubKeys: [
+          key1.publicKey,
+          key2.publicKey,
+          key3.publicKey,
+          key4.publicKey,
+        ],
+        direction: RelayDirection.outbox,
+        relayMinCountPerPubKey: 2,
+        onProgress: (stepName, count, total) {
+          if (count % 100 == 0 || (total - count) < 10) {
+            print("[PROGRESS] $stepName: $count/$total");
+          }
+        },
+      );
+      print("BEST ${relaySet.relaysMap.length} RELAYS:");
+      relaySet.relaysMap.forEach((url, pubKeyMappings) {
+        print("  $url => has ${pubKeyMappings.length} follows");
+      });
 
-        expect(relaySet.urls.contains(relay1.url), true);
-        expect(relaySet.urls.contains(relay2.url), true);
-        expect(relaySet.urls.contains(relay3.url), false);
-        expect(relaySet.urls.contains(relay4.url), true);
-        await ndk.destroy();
-      },
-    );
+      expect(relaySet.urls.contains(relay1.url), true);
+      expect(relaySet.urls.contains(relay2.url), true);
+      expect(relaySet.urls.contains(relay3.url), false);
+      expect(relaySet.urls.contains(relay4.url), true);
+      await ndk.destroy();
+    });
   });
   group("misc", () {
     // test('nwc info', () async {
@@ -715,17 +709,13 @@ void main() async {
       );
     }, timeout: const Timeout.factor(10));
 
-    test(
-      'Love is Bitcoin (3k follows) feed best relays',
-      () async {
-        await calculateBestRelaysForNpubContactsFeed(
-          "npub1kwcatqynqmry9d78a8cpe7d882wu3vmrgcmhvdsayhwqjf7mp25qpqf3xx",
-          iterations: 1,
-          relayMinCountPerPubKey: 2,
-        );
-      },
-      timeout: const Timeout.factor(10),
-    );
+    test('Love is Bitcoin (3k follows) feed best relays', () async {
+      await calculateBestRelaysForNpubContactsFeed(
+        "npub1kwcatqynqmry9d78a8cpe7d882wu3vmrgcmhvdsayhwqjf7mp25qpqf3xx",
+        iterations: 1,
+        relayMinCountPerPubKey: 2,
+      );
+    }, timeout: const Timeout.factor(10));
   });
   // test('testing not timing out on subscriptions', () async {
   //   RelayManager manager = RelayManager();

--- a/packages/ndk/test/relays/requests_test.dart
+++ b/packages/ndk/test/relays/requests_test.dart
@@ -288,58 +288,54 @@ void main() async {
       }
     });
 
-    test(
-      'Subscription processes events immediately without stream closing',
-      () async {
-        // This test would FAIL with the previous VerifyEventStream implementation
-        // because events would remain stuck in buffer until stream closes
-        MockRelay relay1 = MockRelay(name: "relay 1");
-        await relay1.startServer(textNotes: textNotes);
+    test('Subscription processes events immediately without stream closing', () async {
+      // This test would FAIL with the previous VerifyEventStream implementation
+      // because events would remain stuck in buffer until stream closes
+      MockRelay relay1 = MockRelay(name: "relay 1");
+      await relay1.startServer(textNotes: textNotes);
 
-        final ndk = Ndk(
-          NdkConfig(
-            eventVerifier: MockEventVerifier(),
-            cache: MemCacheManager(),
-            engine: NdkEngine.RELAY_SETS,
-            bootstrapRelays: [relay1.url],
-          ),
+      final ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          engine: NdkEngine.RELAY_SETS,
+          bootstrapRelays: [relay1.url],
+        ),
+      );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key1.publicKey,
+        privkey: key1.privateKey!,
+      );
+
+      final filter = Filter(
+        kinds: [Nip01Event.kTextNodeKind],
+        authors: [key1.publicKey],
+      );
+
+      // Use subscription instead of query - this creates a long-lived stream
+      final subscription = ndk.requests.subscription(filters: [filter]);
+
+      final receivedEvents = <Nip01Event>[];
+      final streamSubscription = subscription.stream.listen((event) {
+        receivedEvents.add(event);
+      });
+      try {
+        await waitForEventCount(receivedEvents, 1);
+
+        expect(
+          receivedEvents.length,
+          equals(1),
+          reason: 'Subscription should process events immediately without waiting for stream to close',
         );
-        ndk.accounts.loginPrivateKey(
-          pubkey: key1.publicKey,
-          privkey: key1.privateKey!,
-        );
-
-        final filter = Filter(
-          kinds: [Nip01Event.kTextNodeKind],
-          authors: [key1.publicKey],
-        );
-
-        // Use subscription instead of query - this creates a long-lived stream
-        final subscription = ndk.requests.subscription(filters: [filter]);
-
-        final receivedEvents = <Nip01Event>[];
-        final streamSubscription = subscription.stream.listen((event) {
-          receivedEvents.add(event);
-        });
-        try {
-          await waitForEventCount(receivedEvents, 1);
-
-          expect(
-            receivedEvents.length,
-            equals(1),
-            reason:
-                'Subscription should process events immediately without waiting for stream to close',
-          );
-          expect(receivedEvents[0].content, contains('key1'));
-        } finally {
-          await streamSubscription.cancel();
-          await ndk.requests.closeSubscription(subscription.requestId);
-          await ndk.destroy();
-          expect(ndk.relays.globalState.inFlightRequests.isEmpty, true);
-          await relay1.stopServer();
-        }
-      },
-    );
+        expect(receivedEvents[0].content, contains('key1'));
+      } finally {
+        await streamSubscription.cancel();
+        await ndk.requests.closeSubscription(subscription.requestId);
+        await ndk.destroy();
+        expect(ndk.relays.globalState.inFlightRequests.isEmpty, true);
+        await relay1.stopServer();
+      }
+    });
 
     test(
       'Subscription handles continuous events from non-closing stream',

--- a/packages/ndk/test/shared/bloom_filter/bloom_filter_prehash_test.dart
+++ b/packages/ndk/test/shared/bloom_filter/bloom_filter_prehash_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:typed_data';
+
 import 'package:ndk/entities.dart';
 import 'package:ndk/shared/bloom_filter/bloom_filter_prehash.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';

--- a/packages/ndk/test/shared/bloom_filter/bloom_filter_test.dart
+++ b/packages/ndk/test/shared/bloom_filter/bloom_filter_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:typed_data';
+
 import 'package:ndk/shared/bloom_filter/bloom_filter.dart';
 import 'package:test/test.dart';
 

--- a/packages/ndk/test/shared/event_filters/nip51_mute_event_filter_test.dart
+++ b/packages/ndk/test/shared/event_filters/nip51_mute_event_filter_test.dart
@@ -241,17 +241,14 @@ void main() {
       expect(trie.check("world"), isTrue);
     });
 
-    test(
-      'TrieTree: should find a word that is a prefix of another word if marked as done',
-      () {
-        final trie = filter.buildTrieTree([
-          "hell".codeUnits,
-          "hello".codeUnits,
-        ], null);
-        expect(trie.check("hell"), isTrue);
-        expect(trie.check("hello"), isTrue);
-      },
-    );
+    test('TrieTree: should find a word that is a prefix of another word if marked as done', () {
+      final trie = filter.buildTrieTree([
+        "hell".codeUnits,
+        "hello".codeUnits,
+      ], null);
+      expect(trie.check("hell"), isTrue);
+      expect(trie.check("hello"), isTrue);
+    });
 
     test('TrieTree: should handle empty string check', () {
       final trie = filter.buildTrieTree(["hello".codeUnits], null);

--- a/packages/ndk/test/shared/helpers/url_normalizer_test.dart
+++ b/packages/ndk/test/shared/helpers/url_normalizer_test.dart
@@ -113,24 +113,21 @@ void main() {
       );
     });
 
-    test(
-      'decodes percent-encoded unreserved characters (RFC 3986 Section 6.2.2.2)',
-      () {
-        // %41 = 'A', %7E = '~', %2D = '-'
-        expect(
-          cleanRelayUrl('wss://relay.damus.io/path%41'),
-          'wss://relay.damus.io/pathA',
-        );
-        expect(
-          cleanRelayUrl('wss://relay.damus.io/path%7E'),
-          'wss://relay.damus.io/path~',
-        );
-        expect(
-          cleanRelayUrl('wss://relay.damus.io/path%2D'),
-          'wss://relay.damus.io/path-',
-        );
-      },
-    );
+    test('decodes percent-encoded unreserved characters (RFC 3986 Section 6.2.2.2)', () {
+      // %41 = 'A', %7E = '~', %2D = '-'
+      expect(
+        cleanRelayUrl('wss://relay.damus.io/path%41'),
+        'wss://relay.damus.io/pathA',
+      );
+      expect(
+        cleanRelayUrl('wss://relay.damus.io/path%7E'),
+        'wss://relay.damus.io/path~',
+      );
+      expect(
+        cleanRelayUrl('wss://relay.damus.io/path%2D'),
+        'wss://relay.damus.io/path-',
+      );
+    });
 
     test(
       'uppercases hex digits in percent-encoding (RFC 3986 Section 6.2.2.2)',

--- a/packages/ndk/test/signers/nip46_event_signer_test.dart
+++ b/packages/ndk/test/signers/nip46_event_signer_test.dart
@@ -41,8 +41,7 @@ void main() {
       connection = BunkerConnection(
         privateKey:
             "7a8317f947fff0526749e9fe53f79def8eb0afd378c01058f37140cc8732fecc",
-        remotePubkey: MockRelay
-            .remoteSignerPublicKey, // Use the mock relay's remote signer public key
+        remotePubkey: MockRelay.remoteSignerPublicKey, // Use the mock relay's remote signer public key
         relays: [mockRelay.url], // Use the mock relay
       );
 

--- a/packages/ndk/test/usecases/broadcast_test.dart
+++ b/packages/ndk/test/usecases/broadcast_test.dart
@@ -654,83 +654,80 @@ void main() async {
       expect(kTags.length, 0);
     });
 
-    test(
-      'broadcastDeletion with eventAndAllVersions removes all versions from cache',
-      () async {
-        ndk.accounts.loginPrivateKey(
-          pubkey: key0.publicKey,
-          privkey: key0.privateKey!,
-        );
+    test('broadcastDeletion with eventAndAllVersions removes all versions from cache', () async {
+      ndk.accounts.loginPrivateKey(
+        pubkey: key0.publicKey,
+        privkey: key0.privateKey!,
+      );
 
-        const articleKind = 30023;
-        final dTag = "my-article-${DateTime.now().millisecondsSinceEpoch}";
+      const articleKind = 30023;
+      final dTag = "my-article-${DateTime.now().millisecondsSinceEpoch}";
 
-        // Create multiple versions of the same replaceable event
-        Nip01Event version1 = Nip01Event(
-          pubKey: key0.publicKey,
-          kind: articleKind,
-          tags: [
-            ["d", dTag],
-          ],
-          content: "version 1",
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 100,
-        );
+      // Create multiple versions of the same replaceable event
+      Nip01Event version1 = Nip01Event(
+        pubKey: key0.publicKey,
+        kind: articleKind,
+        tags: [
+          ["d", dTag],
+        ],
+        content: "version 1",
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 100,
+      );
 
-        Nip01Event version2 = Nip01Event(
-          pubKey: key0.publicKey,
-          kind: articleKind,
-          tags: [
-            ["d", dTag],
-          ],
-          content: "version 2",
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 50,
-        );
+      Nip01Event version2 = Nip01Event(
+        pubKey: key0.publicKey,
+        kind: articleKind,
+        tags: [
+          ["d", dTag],
+        ],
+        content: "version 2",
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 50,
+      );
 
-        Nip01Event version3 = Nip01Event(
-          pubKey: key0.publicKey,
-          kind: articleKind,
-          tags: [
-            ["d", dTag],
-          ],
-          content: "version 3",
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        );
+      Nip01Event version3 = Nip01Event(
+        pubKey: key0.publicKey,
+        kind: articleKind,
+        tags: [
+          ["d", dTag],
+        ],
+        content: "version 3",
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
 
-        // Save all versions to cache
-        await ndk.config.cache.saveEvent(version1);
-        await ndk.config.cache.saveEvent(version2);
-        await ndk.config.cache.saveEvent(version3);
+      // Save all versions to cache
+      await ndk.config.cache.saveEvent(version1);
+      await ndk.config.cache.saveEvent(version2);
+      await ndk.config.cache.saveEvent(version3);
 
-        // Verify only the canonical current version is visible in cache
-        List<Nip01Event> cachedBefore = await ndk.config.cache.loadEvents(
-          kinds: [articleKind],
-          pubKeys: [key0.publicKey],
-          tags: {
-            'd': [dTag],
-          },
-        );
-        expect(cachedBefore.length, 1);
-        expect(cachedBefore.first.content, 'version 3');
+      // Verify only the canonical current version is visible in cache
+      List<Nip01Event> cachedBefore = await ndk.config.cache.loadEvents(
+        kinds: [articleKind],
+        pubKeys: [key0.publicKey],
+        tags: {
+          'd': [dTag],
+        },
+      );
+      expect(cachedBefore.length, 1);
+      expect(cachedBefore.first.content, 'version 3');
 
-        // Delete using eventAndAllVersions
-        await ndk.broadcast
-            .broadcastDeletion(eventAndAllVersions: version3)
-            .broadcastDoneFuture;
+      // Delete using eventAndAllVersions
+      await ndk.broadcast
+          .broadcastDeletion(eventAndAllVersions: version3)
+          .broadcastDoneFuture;
 
-        // Wait for cache removal (fire and forget async operation)
-        await Future.delayed(const Duration(milliseconds: 100));
+      // Wait for cache removal (fire and forget async operation)
+      await Future.delayed(const Duration(milliseconds: 100));
 
-        // Verify ALL versions are removed from cache
-        List<Nip01Event> cachedAfter = await ndk.config.cache.loadEvents(
-          kinds: [articleKind],
-          pubKeys: [key0.publicKey],
-          tags: {
-            'd': [dTag],
-          },
-        );
-        expect(cachedAfter.length, 0);
-      },
-    );
+      // Verify ALL versions are removed from cache
+      List<Nip01Event> cachedAfter = await ndk.config.cache.loadEvents(
+        kinds: [articleKind],
+        pubKeys: [key0.publicKey],
+        tags: {
+          'd': [dTag],
+        },
+      );
+      expect(cachedAfter.length, 0);
+    });
 
     test(
       'broadcastDeletion with multiple events generates correct tags',

--- a/packages/ndk/test/usecases/dms/dms_test.dart
+++ b/packages/ndk/test/usecases/dms/dms_test.dart
@@ -125,47 +125,44 @@ void main() async {
       },
     );
 
-    test(
-      'sendMessage with additional tags keeps the p tag on the rumor',
-      () async {
-        await publishDmRelayList(alice, urls: [relay.url]);
-        await publishDmRelayList(bob, urls: [relay.url]);
+    test('sendMessage with additional tags keeps the p tag on the rumor', () async {
+      await publishDmRelayList(alice, urls: [relay.url]);
+      await publishDmRelayList(bob, urls: [relay.url]);
 
-        await ndk.dms.sendMessage(
-          recipientPubKey: bob.publicKey,
-          content: 'with subject',
-          additionalTags: const [
-            ['subject', 'greeting'],
-          ],
-        );
+      await ndk.dms.sendMessage(
+        recipientPubKey: bob.publicKey,
+        content: 'with subject',
+        additionalTags: const [
+          ['subject', 'greeting'],
+        ],
+      );
 
-        // Login as bob and load the conversation to verify the rumor carries the
-        // extra tag through the gift wrap.
-        ndk.accounts.logout();
-        ndk.accounts.loginPrivateKey(
-          pubkey: bob.publicKey,
-          privkey: bob.privateKey!,
-        );
-        await publishDmRelayList(bob, urls: [relay.url]);
+      // Login as bob and load the conversation to verify the rumor carries the
+      // extra tag through the gift wrap.
+      ndk.accounts.logout();
+      ndk.accounts.loginPrivateKey(
+        pubkey: bob.publicKey,
+        privkey: bob.privateKey!,
+      );
+      await publishDmRelayList(bob, urls: [relay.url]);
 
-        final conversations = await ndk.dms.loadConversations(
-          timeout: const Duration(seconds: 10),
-        );
-        expect(conversations, isNotEmpty);
+      final conversations = await ndk.dms.loadConversations(
+        timeout: const Duration(seconds: 10),
+      );
+      expect(conversations, isNotEmpty);
 
-        final aliceConv = conversations.firstWhere(
-          (c) => c.peerPubKey == alice.publicKey,
-        );
-        expect(aliceConv.messages, isNotEmpty);
-        final rumor = aliceConv.messages.first.rumor;
-        expect(
-          rumor.tags.any(
-            (t) => t.length >= 2 && t[0] == 'subject' && t[1] == 'greeting',
-          ),
-          isTrue,
-        );
-      },
-    );
+      final aliceConv = conversations.firstWhere(
+        (c) => c.peerPubKey == alice.publicKey,
+      );
+      expect(aliceConv.messages, isNotEmpty);
+      final rumor = aliceConv.messages.first.rumor;
+      expect(
+        rumor.tags.any(
+          (t) => t.length >= 2 && t[0] == 'subject' && t[1] == 'greeting',
+        ),
+        isTrue,
+      );
+    });
 
     test(
       'sender view keeps outgoing DMs with additional p tags for mentions',

--- a/packages/ndk/test/usecases/fetched_ranges/fetched_ranges_integration_test.dart
+++ b/packages/ndk/test/usecases/fetched_ranges/fetched_ranges_integration_test.dart
@@ -334,8 +334,7 @@ void main() async {
         expect(
           fetchedRanges.isEmpty,
           isTrue,
-          reason:
-              'FetchedRanges should NOT be recorded when relay returns CLOSED auth-required',
+          reason: 'FetchedRanges should NOT be recorded when relay returns CLOSED auth-required',
         );
 
         await relay1.stopServer();

--- a/packages/ndk/test/usecases/files/blossom_test.dart
+++ b/packages/ndk/test/usecases/files/blossom_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
+
 import 'package:http/http.dart' as http;
 
 import 'package:ndk/data_layer/data_sources/http_request.dart';
@@ -418,85 +419,79 @@ void main() {
       client: HttpRequestDS(http.Client()),
       fileIO: createFileIO(),
     );
-    test(
-      'getBlobStream should properly stream large files with range requests',
-      () async {
-        // First upload a test file to the mock server
-        final testData = Uint8List.fromList(
-          List.generate(5 * 1024 * 1024, (i) => i % 256),
-        ); // 5MB test file
+    test('getBlobStream should properly stream large files with range requests', () async {
+      // First upload a test file to the mock server
+      final testData = Uint8List.fromList(
+        List.generate(5 * 1024 * 1024, (i) => i % 256),
+      ); // 5MB test file
 
-        // Upload the test file
-        final uploadResponse = await client.uploadBlob(
-          data: testData,
-          serverUrls: ['http://localhost:${server.port}'],
-        );
+      // Upload the test file
+      final uploadResponse = await client.uploadBlob(
+        data: testData,
+        serverUrls: ['http://localhost:${server.port}'],
+      );
 
-        expect(uploadResponse.first.success, true);
-        final sha256 = uploadResponse.first.descriptor!.sha256;
+      expect(uploadResponse.first.success, true);
+      final sha256 = uploadResponse.first.descriptor!.sha256;
 
-        // Now test the streaming download
-        final stream = await blossomRepo.getBlobStream(
-          sha256: sha256,
-          serverUrls: ['http://localhost:${server.port}'],
-          chunkSize: 1024 * 1024, // 1MB chunks
-        );
+      // Now test the streaming download
+      final stream = await blossomRepo.getBlobStream(
+        sha256: sha256,
+        serverUrls: ['http://localhost:${server.port}'],
+        chunkSize: 1024 * 1024, // 1MB chunks
+      );
 
-        // Collect all chunks and verify the data
-        final chunks = <Uint8List>[];
-        int totalSize = 0;
+      // Collect all chunks and verify the data
+      final chunks = <Uint8List>[];
+      int totalSize = 0;
 
-        await for (final response in stream) {
-          chunks.add(response.data);
-          totalSize += response.data.length;
+      await for (final response in stream) {
+        chunks.add(response.data);
+        totalSize += response.data.length;
 
-          // Verify chunk metadata
-          expect(response.mimeType, isNotNull);
-          expect(response.contentLength, equals(testData.length));
-          //expect(response.contentRange, matches(RegExp(r'bytes \d+-\d+/\d+')));
-        }
+        // Verify chunk metadata
+        expect(response.mimeType, isNotNull);
+        expect(response.contentLength, equals(testData.length));
+        //expect(response.contentRange, matches(RegExp(r'bytes \d+-\d+/\d+')));
+      }
 
-        // Combine chunks and verify the complete file
-        final resultData = Uint8List(totalSize);
-        int offset = 0;
-        for (final chunk in chunks) {
-          resultData.setRange(offset, offset + chunk.length, chunk);
-          offset += chunk.length;
-        }
+      // Combine chunks and verify the complete file
+      final resultData = Uint8List(totalSize);
+      int offset = 0;
+      for (final chunk in chunks) {
+        resultData.setRange(offset, offset + chunk.length, chunk);
+        offset += chunk.length;
+      }
 
-        expect(resultData, equals(testData));
-        expect(totalSize, equals(testData.length));
-      },
-    );
+      expect(resultData, equals(testData));
+      expect(totalSize, equals(testData.length));
+    });
 
-    test(
-      'getBlobStream should fallback to regular download if range requests not supported',
-      () async {
-        // Upload a smaller test file
-        final testData = Uint8List.fromList(
-          List.generate(1024, (i) => i % 256),
-        ); // 1KB test file
+    test('getBlobStream should fallback to regular download if range requests not supported', () async {
+      // Upload a smaller test file
+      final testData = Uint8List.fromList(
+        List.generate(1024, (i) => i % 256),
+      ); // 1KB test file
 
-        final uploadResponse = await client.uploadBlob(
-          data: testData,
-          serverUrls: ['http://localhost:${server.port}'],
-        );
+      final uploadResponse = await client.uploadBlob(
+        data: testData,
+        serverUrls: ['http://localhost:${server.port}'],
+      );
 
-        expect(uploadResponse.first.success, true);
-        final sha256 = uploadResponse.first.descriptor!.sha256;
+      expect(uploadResponse.first.success, true);
+      final sha256 = uploadResponse.first.descriptor!.sha256;
 
-        // Test the streaming download
-        final stream = await blossomRepo.getBlobStream(
-          sha256: sha256,
-          serverUrls: ['http://localhost:${server.port}'],
-        );
+      // Test the streaming download
+      final stream = await blossomRepo.getBlobStream(
+        sha256: sha256,
+        serverUrls: ['http://localhost:${server.port}'],
+      );
 
-        // Should receive exactly one chunk with the complete file
-        final chunks = await stream.toList();
-        expect(chunks.length, equals(1));
-        expect(chunks.first.data, equals(testData));
-      },
-    );
+      // Should receive exactly one chunk with the complete file
+      final chunks = await stream.toList();
+      expect(chunks.length, equals(1));
+      expect(chunks.first.data, equals(testData));
+    });
 
     test('getBlobStream should handle server errors gracefully', () async {
       expect(
@@ -1033,53 +1028,50 @@ void main() {
       },
     );
 
-    test(
-      'uploadBlobFromFile mirrorAfterSuccess reports mirrorsTotal and mirrorsCompleted progression',
-      () async {
-        final testFile = File('${tempDir.path}/test_mirror_progress.txt');
-        await testFile.writeAsString('Mirror progress test');
+    test('uploadBlobFromFile mirrorAfterSuccess reports mirrorsTotal and mirrorsCompleted progression', () async {
+      final testFile = File('${tempDir.path}/test_mirror_progress.txt');
+      await testFile.writeAsString('Mirror progress test');
 
-        final events = <BlobUploadProgress>[];
-        await for (final progress in client.uploadBlobFromFile(
-          filePath: testFile.path,
-          serverUrls: [
-            'http://localhost:$primaryServerPort',
-            'http://localhost:$secondaryServerPort',
-          ],
-          strategy: UploadStrategy.mirrorAfterSuccess,
-        )) {
-          events.add(progress);
-        }
+      final events = <BlobUploadProgress>[];
+      await for (final progress in client.uploadBlobFromFile(
+        filePath: testFile.path,
+        serverUrls: [
+          'http://localhost:$primaryServerPort',
+          'http://localhost:$secondaryServerPort',
+        ],
+        strategy: UploadStrategy.mirrorAfterSuccess,
+      )) {
+        events.add(progress);
+      }
 
-        final mirrorEvents = events
-            .where(
-              (e) =>
-                  e.phase == UploadPhase.mirroring &&
-                  (e.mirrorsTotal > 0 || e.mirrorsCompleted > 0),
-            )
-            .toList();
+      final mirrorEvents = events
+          .where(
+            (e) =>
+                e.phase == UploadPhase.mirroring &&
+                (e.mirrorsTotal > 0 || e.mirrorsCompleted > 0),
+          )
+          .toList();
 
-        expect(mirrorEvents, isNotEmpty);
+      expect(mirrorEvents, isNotEmpty);
 
-        // With 2 servers and first success strategy, only 1 mirror should be needed.
-        expect(mirrorEvents.every((e) => e.mirrorsTotal == 1), isTrue);
+      // With 2 servers and first success strategy, only 1 mirror should be needed.
+      expect(mirrorEvents.every((e) => e.mirrorsTotal == 1), isTrue);
 
-        // Should emit start of mirroring and completion of mirroring.
-        expect(mirrorEvents.any((e) => e.mirrorsCompleted == 0), isTrue);
+      // Should emit start of mirroring and completion of mirroring.
+      expect(mirrorEvents.any((e) => e.mirrorsCompleted == 0), isTrue);
+      expect(
+        mirrorEvents.any((e) => e.mirrorsCompleted == e.mirrorsTotal),
+        isTrue,
+      );
+
+      // Progression should be monotonic.
+      for (var i = 1; i < mirrorEvents.length; i++) {
         expect(
-          mirrorEvents.any((e) => e.mirrorsCompleted == e.mirrorsTotal),
-          isTrue,
+          mirrorEvents[i].mirrorsCompleted,
+          greaterThanOrEqualTo(mirrorEvents[i - 1].mirrorsCompleted),
         );
-
-        // Progression should be monotonic.
-        for (var i = 1; i < mirrorEvents.length; i++) {
-          expect(
-            mirrorEvents[i].mirrorsCompleted,
-            greaterThanOrEqualTo(mirrorEvents[i - 1].mirrorsCompleted),
-          );
-        }
-      },
-    );
+      }
+    });
 
     test('downloadBlobToFile should handle server fallback', () async {
       // Upload to one server

--- a/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
+++ b/packages/ndk/test/usecases/gift_wrap/gift_wrap_test.dart
@@ -131,52 +131,49 @@ void main() {
       );
     });
 
-    test(
-      'NIP-17 DM gift wrap and seal timestamps should be randomized in the 2 days before the rumor createdAt',
-      () async {
-        const twoDaysInSeconds = 172800;
+    test('NIP-17 DM gift wrap and seal timestamps should be randomized in the 2 days before the rumor createdAt', () async {
+      const twoDaysInSeconds = 172800;
 
-        final rumor = Nip01Event(
-          pubKey: key1.publicKey,
-          content: 'Test NIP-17 direct message',
-          kind: 14,
-          tags: [
-            ['p', key2.publicKey],
-          ],
-        );
-        final baseCreatedAt = rumor.createdAt;
+      final rumor = Nip01Event(
+        pubKey: key1.publicKey,
+        content: 'Test NIP-17 direct message',
+        kind: 14,
+        tags: [
+          ['p', key2.publicKey],
+        ],
+      );
+      final baseCreatedAt = rumor.createdAt;
 
-        final giftWrap = await giftWrapService.toGiftWrap(
-          rumor: rumor,
-          recipientPubkey: key2.publicKey,
-        );
+      final giftWrap = await giftWrapService.toGiftWrap(
+        rumor: rumor,
+        recipientPubkey: key2.publicKey,
+      );
 
-        expect(
-          giftWrap.createdAt,
-          greaterThanOrEqualTo(baseCreatedAt - twoDaysInSeconds),
-        );
-        expect(giftWrap.createdAt, lessThan(baseCreatedAt));
+      expect(
+        giftWrap.createdAt,
+        greaterThanOrEqualTo(baseCreatedAt - twoDaysInSeconds),
+      );
+      expect(giftWrap.createdAt, lessThan(baseCreatedAt));
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: key2.publicKey,
-          privkey: key2.privateKey!,
-        );
+      ndk.accounts.loginPrivateKey(
+        pubkey: key2.publicKey,
+        privkey: key2.privateKey!,
+      );
 
-        final seal = await giftWrapService.unwrapEvent(wrappedEvent: giftWrap);
+      final seal = await giftWrapService.unwrapEvent(wrappedEvent: giftWrap);
 
-        expect(
-          seal.createdAt,
-          greaterThanOrEqualTo(baseCreatedAt - twoDaysInSeconds),
-        );
-        expect(seal.createdAt, lessThan(baseCreatedAt));
-        expect(seal.createdAt, isNot(equals(giftWrap.createdAt)));
+      expect(
+        seal.createdAt,
+        greaterThanOrEqualTo(baseCreatedAt - twoDaysInSeconds),
+      );
+      expect(seal.createdAt, lessThan(baseCreatedAt));
+      expect(seal.createdAt, isNot(equals(giftWrap.createdAt)));
 
-        final unwrappedRumor = await giftWrapService.fromGiftWrap(
-          giftWrap: giftWrap,
-        );
-        expect(unwrappedRumor.createdAt, equals(rumor.createdAt));
-      },
-    );
+      final unwrappedRumor = await giftWrapService.fromGiftWrap(
+        giftWrap: giftWrap,
+      );
+      expect(unwrappedRumor.createdAt, equals(rumor.createdAt));
+    });
 
     test(
       'Can use custom signer instead of logged-in account for wrap and unwrap',

--- a/packages/ndk/test/usecases/jit_engine/feed_test.dart
+++ b/packages/ndk/test/usecases/jit_engine/feed_test.dart
@@ -5,7 +5,9 @@ import 'package:ndk/ndk.dart';
 import 'package:ndk/shared/nips/nip01/helpers.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:test/test.dart';
+
 import 'dart:developer' as developer;
+
 import '../../mocks/mock_event_verifier.dart';
 
 void main() async {
@@ -181,15 +183,11 @@ void main() async {
       );
     }, timeout: const Timeout.factor(10));
 
-    test(
-      'Love is Bitcoin (3k follows) feed best relays',
-      () async {
-        await calculateBestRelaysForNpubContactsFeed(
-          "npub1kwcatqynqmry9d78a8cpe7d882wu3vmrgcmhvdsayhwqjf7mp25qpqf3xx",
-          relayMinCountPerPubKey: 2,
-        );
-      },
-      timeout: const Timeout.factor(10),
-    );
+    test('Love is Bitcoin (3k follows) feed best relays', () async {
+      await calculateBestRelaysForNpubContactsFeed(
+        "npub1kwcatqynqmry9d78a8cpe7d882wu3vmrgcmhvdsayhwqjf7mp25qpqf3xx",
+        relayMinCountPerPubKey: 2,
+      );
+    }, timeout: const Timeout.factor(10));
   });
 }

--- a/packages/ndk/test/usecases/jit_engine/relay_jit_connection_test.dart
+++ b/packages/ndk/test/usecases/jit_engine/relay_jit_connection_test.dart
@@ -11,6 +11,7 @@ import 'package:ndk/domain_layer/entities/nip_65.dart';
 import 'package:ndk/domain_layer/entities/read_write_marker.dart';
 
 import 'package:test/test.dart';
+
 import '../../mocks/mock_event_verifier.dart';
 import '../../mocks/mock_relay.dart';
 

--- a/packages/ndk/test/usecases/lists/lists_test.dart
+++ b/packages/ndk/test/usecases/lists/lists_test.dart
@@ -519,67 +519,61 @@ void main() async {
       expect(parsedSet.elements.first.private, true);
     });
 
-    test(
-      'fromEvent preserves metadata (title/description/image) alongside private elements',
-      () async {
-        // Regression test for: when a set has encrypted private elements AND
-        // public metadata tags, parsing with a full signer must retain both.
-        // Previously, parseSetTags was called only on the decrypted content
-        // (which never contains title/description/image), so metadata was silently
-        // dropped for any set that had private content.
-        final original = Nip51Set(
-          pubKey: key1.publicKey,
-          kind: Nip51List.kRelaySet,
-          name: "metadata-set",
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          title: "My Relay Set",
-          description: "A set with both private relays and metadata",
-          image: "https://example.com/image.png",
-          elements: [
-            Nip51ListElement(
-              tag: Nip51List.kRelay,
-              value: "wss://private-relay.com",
-              private: true,
-            ),
-            Nip51ListElement(
-              tag: Nip51List.kRelay,
-              value: "wss://public-relay.com",
-              private: false,
-            ),
-          ],
-        );
-
-        // Serialize: private relay goes into encrypted content, metadata stays
-        // as public tags on the event.
-        final event = await original.toEvent(signer1);
-        final signedEvent = await signer1.sign(event);
-
-        // Deserialize with a full signer (can decrypt).
-        final parsed = await Nip51Set.fromEvent(signedEvent, signer1);
-
-        expect(parsed, isNotNull);
-        // Metadata must survive even though private content was decrypted.
-        expect(parsed!.title, "My Relay Set");
-        expect(
-          parsed.description,
-          "A set with both private relays and metadata",
-        );
-        expect(parsed.image, "https://example.com/image.png");
-        // Both private and public elements must be present.
-        expect(parsed.elements.length, 2);
-        expect(
-          parsed.elements.any(
-            (e) => e.value == "wss://private-relay.com" && e.private,
+    test('fromEvent preserves metadata (title/description/image) alongside private elements', () async {
+      // Regression test for: when a set has encrypted private elements AND
+      // public metadata tags, parsing with a full signer must retain both.
+      // Previously, parseSetTags was called only on the decrypted content
+      // (which never contains title/description/image), so metadata was silently
+      // dropped for any set that had private content.
+      final original = Nip51Set(
+        pubKey: key1.publicKey,
+        kind: Nip51List.kRelaySet,
+        name: "metadata-set",
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        title: "My Relay Set",
+        description: "A set with both private relays and metadata",
+        image: "https://example.com/image.png",
+        elements: [
+          Nip51ListElement(
+            tag: Nip51List.kRelay,
+            value: "wss://private-relay.com",
+            private: true,
           ),
-          isTrue,
-        );
-        expect(
-          parsed.elements.any(
-            (e) => e.value == "wss://public-relay.com" && !e.private,
+          Nip51ListElement(
+            tag: Nip51List.kRelay,
+            value: "wss://public-relay.com",
+            private: false,
           ),
-          isTrue,
-        );
-      },
-    );
+        ],
+      );
+
+      // Serialize: private relay goes into encrypted content, metadata stays
+      // as public tags on the event.
+      final event = await original.toEvent(signer1);
+      final signedEvent = await signer1.sign(event);
+
+      // Deserialize with a full signer (can decrypt).
+      final parsed = await Nip51Set.fromEvent(signedEvent, signer1);
+
+      expect(parsed, isNotNull);
+      // Metadata must survive even though private content was decrypted.
+      expect(parsed!.title, "My Relay Set");
+      expect(parsed.description, "A set with both private relays and metadata");
+      expect(parsed.image, "https://example.com/image.png");
+      // Both private and public elements must be present.
+      expect(parsed.elements.length, 2);
+      expect(
+        parsed.elements.any(
+          (e) => e.value == "wss://private-relay.com" && e.private,
+        ),
+        isTrue,
+      );
+      expect(
+        parsed.elements.any(
+          (e) => e.value == "wss://public-relay.com" && !e.private,
+        ),
+        isTrue,
+      );
+    });
   });
 }

--- a/packages/ndk/test/usecases/lnurl/lnurl_test.dart
+++ b/packages/ndk/test/usecases/lnurl/lnurl_test.dart
@@ -38,9 +38,8 @@ void main() {
       };
 
       // Mock the client.get method
-      when(
-        client.get(Uri.parse(link), headers: {"Accept": "application/json"}),
-      ).thenAnswer((_) async => http.Response(jsonEncode(response), 200));
+      when(client.get(Uri.parse(link), headers: {"Accept": "application/json"}))
+          .thenAnswer((_) async => http.Response(jsonEncode(response), 200));
 
       var lnurlResponse = await lnurl.getLnurlResponse(link);
       expect(lnurlResponse, isNotNull);
@@ -53,9 +52,8 @@ void main() {
       final Lnurl lnurl = Lnurl(transport: transport);
 
       final link = 'https://invalid.com';
-      when(
-        client.get(Uri.parse(link), headers: {"Accept": "application/json"}),
-      ).thenAnswer((_) async => http.Response('not found', 404));
+      when(client.get(Uri.parse(link), headers: {"Accept": "application/json"}))
+          .thenAnswer((_) async => http.Response('not found', 404));
 
       var lnurlResponse = await lnurl.getLnurlResponse(link);
       expect(lnurlResponse, isNull);

--- a/packages/ndk/test/usecases/lnurl/lnurl_test.mocks.dart
+++ b/packages/ndk/test/usecases/lnurl/lnurl_test.mocks.dart
@@ -48,28 +48,26 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#head, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#head, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#head, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#get, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#get, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#get, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -77,25 +75,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #post,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #post,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #post,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #post,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -103,25 +99,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #put,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #put,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #put,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #put,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -129,25 +123,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #patch,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #patch,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #patch,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #patch,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -155,62 +147,53 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #delete,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #delete,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #delete,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #delete,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#read, [url], {#headers: headers}),
+        returnValue: _i3.Future<String>.value(
+          _i5.dummyValue<String>(
+            this,
             Invocation.method(#read, [url], {#headers: headers}),
-            returnValue: _i3.Future<String>.value(
-              _i5.dummyValue<String>(
-                this,
-                Invocation.method(#read, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<String>);
+          ),
+        ),
+      ) as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
     Uri? url, {
     Map<String, String>? headers,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#readBytes, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-          )
-          as _i3.Future<_i6.Uint8List>);
+  }) => (super.noSuchMethod(
+    Invocation.method(#readBytes, [url], {#headers: headers}),
+    returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+  ) as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-            Invocation.method(#send, [request]),
-            returnValue: _i3.Future<_i2.StreamedResponse>.value(
-              _FakeStreamedResponse_1(
-                this,
-                Invocation.method(#send, [request]),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.StreamedResponse>);
+        Invocation.method(#send, [request]),
+        returnValue: _i3.Future<_i2.StreamedResponse>.value(
+          _FakeStreamedResponse_1(this, Invocation.method(#send, [request])),
+        ),
+      ) as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(

--- a/packages/ndk/test/usecases/local_first/local_first_subscription_test.dart
+++ b/packages/ndk/test/usecases/local_first/local_first_subscription_test.dart
@@ -26,267 +26,256 @@ void main() {
       await tempDir.delete(recursive: true);
     });
 
-    test(
-      'cache-backed subscription emits cached event first and later continues with live relay updates',
-      () async {
-        final relay = MockRelay(name: 'subscription-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final cachedEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Nip01Event.kTextNodeKind,
-            tags: const [],
-            content: 'cached event',
-            createdAt: 1_700_000_080,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final liveEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Nip01Event.kTextNodeKind,
-            tags: const [],
-            content: 'live event',
-            createdAt: 1_700_000_081,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        await relay.startServer(textNotes: {remoteAuthor: cachedEvent});
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-        await ndk.relays.seedRelaysConnected;
+    test('cache-backed subscription emits cached event first and later continues with live relay updates', () async {
+      final relay = MockRelay(name: 'subscription-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final cachedEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Nip01Event.kTextNodeKind,
+          tags: const [],
+          content: 'cached event',
+          createdAt: 1_700_000_080,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final liveEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Nip01Event.kTextNodeKind,
+          tags: const [],
+          content: 'live event',
+          createdAt: 1_700_000_081,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      await relay.startServer(textNotes: {remoteAuthor: cachedEvent});
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+      await ndk.relays.seedRelaysConnected;
 
-        final initiallyCached = await ndk.requests
-            .query(
-              filter: Filter(ids: [cachedEvent.id]),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 4),
-            )
-            .future;
-        expect(initiallyCached.map((e) => e.id), contains(cachedEvent.id));
+      final initiallyCached = await ndk.requests
+          .query(
+            filter: Filter(ids: [cachedEvent.id]),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 4),
+          )
+          .future;
+      expect(initiallyCached.map((e) => e.id), contains(cachedEvent.id));
 
-        final receivedEvents = <Nip01Event>[];
-        final cachedSeen = Completer<void>();
-        final liveSeen = Completer<void>();
-        final subscription = ndk.requests.subscription(
-          filter: Filter(
-            authors: [remoteAuthor.publicKey],
-            kinds: [Nip01Event.kTextNodeKind],
-          ),
-          cacheRead: true,
-          cacheWrite: true,
-          explicitRelays: [relay.url],
-        );
-        final sub = subscription.stream.listen((event) {
-          receivedEvents.add(event);
-          if (event.id == cachedEvent.id && !cachedSeen.isCompleted) {
-            cachedSeen.complete();
-          }
-          if (event.id == liveEvent.id && !liveSeen.isCompleted) {
-            liveSeen.complete();
-          }
-        });
-        addTearDown(sub.cancel);
+      final receivedEvents = <Nip01Event>[];
+      final cachedSeen = Completer<void>();
+      final liveSeen = Completer<void>();
+      final subscription = ndk.requests.subscription(
+        filter: Filter(
+          authors: [remoteAuthor.publicKey],
+          kinds: [Nip01Event.kTextNodeKind],
+        ),
+        cacheRead: true,
+        cacheWrite: true,
+        explicitRelays: [relay.url],
+      );
+      final sub = subscription.stream.listen((event) {
+        receivedEvents.add(event);
+        if (event.id == cachedEvent.id && !cachedSeen.isCompleted) {
+          cachedSeen.complete();
+        }
+        if (event.id == liveEvent.id && !liveSeen.isCompleted) {
+          liveSeen.complete();
+        }
+      });
+      addTearDown(sub.cancel);
 
-        await cachedSeen.future.timeout(const Duration(seconds: 2));
+      await cachedSeen.future.timeout(const Duration(seconds: 2));
 
-        await _publishFixtureEventToRelay(relay.url, liveEvent);
-        await liveSeen.future.timeout(const Duration(seconds: 2));
+      await _publishFixtureEventToRelay(relay.url, liveEvent);
+      await liveSeen.future.timeout(const Duration(seconds: 2));
 
-        expect(receivedEvents.map((e) => e.id), contains(cachedEvent.id));
-        expect(receivedEvents.map((e) => e.id), contains(liveEvent.id));
+      expect(receivedEvents.map((e) => e.id), contains(cachedEvent.id));
+      expect(receivedEvents.map((e) => e.id), contains(liveEvent.id));
 
-        await relay.stopServer();
-      },
-    );
+      await relay.stopServer();
+    });
 
-    test(
-      'cache-backed subscription does not emit tombstoned foreign events or resurrect them later',
-      () async {
-        final relay = MockRelay(name: 'subscription-delete-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final targetEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Nip01Event.kTextNodeKind,
-            tags: const [],
-            content: 'deleted target',
-            createdAt: 1_700_000_090,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final deletionEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Deletion.kKind,
-            tags: [
-              ['e', targetEvent.id],
-              ['k', targetEvent.kind.toString()],
-            ],
-            content: 'delete target',
-            createdAt: 1_700_000_091,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        await relay.startServer(textNotes: {remoteAuthor: targetEvent});
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-        await ndk.relays.seedRelaysConnected;
+    test('cache-backed subscription does not emit tombstoned foreign events or resurrect them later', () async {
+      final relay = MockRelay(name: 'subscription-delete-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final targetEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Nip01Event.kTextNodeKind,
+          tags: const [],
+          content: 'deleted target',
+          createdAt: 1_700_000_090,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final deletionEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Deletion.kKind,
+          tags: [
+            ['e', targetEvent.id],
+            ['k', targetEvent.kind.toString()],
+          ],
+          content: 'delete target',
+          createdAt: 1_700_000_091,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      await relay.startServer(textNotes: {remoteAuthor: targetEvent});
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+      await ndk.relays.seedRelaysConnected;
 
-        final cachedTarget = await ndk.requests
-            .query(
-              filter: Filter(ids: [targetEvent.id]),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(cachedTarget.map((e) => e.id), contains(targetEvent.id));
+      final cachedTarget = await ndk.requests
+          .query(
+            filter: Filter(ids: [targetEvent.id]),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(cachedTarget.map((e) => e.id), contains(targetEvent.id));
 
-        await _publishFixtureEventToRelay(relay.url, deletionEvent);
-        final syncedDeletion = await ndk.requests
-            .query(
-              filter: Filter(ids: [deletionEvent.id], kinds: [Deletion.kKind]),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(syncedDeletion.map((e) => e.id), contains(deletionEvent.id));
+      await _publishFixtureEventToRelay(relay.url, deletionEvent);
+      final syncedDeletion = await ndk.requests
+          .query(
+            filter: Filter(ids: [deletionEvent.id], kinds: [Deletion.kKind]),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(syncedDeletion.map((e) => e.id), contains(deletionEvent.id));
 
-        final emittedEvents = <Nip01Event>[];
-        final subscription = ndk.requests.subscription(
-          filter: Filter(ids: [targetEvent.id]),
-          cacheRead: true,
-          cacheWrite: true,
-          explicitRelays: [relay.url],
-        );
-        final sub = subscription.stream.listen(emittedEvents.add);
-        addTearDown(sub.cancel);
+      final emittedEvents = <Nip01Event>[];
+      final subscription = ndk.requests.subscription(
+        filter: Filter(ids: [targetEvent.id]),
+        cacheRead: true,
+        cacheWrite: true,
+        explicitRelays: [relay.url],
+      );
+      final sub = subscription.stream.listen(emittedEvents.add);
+      addTearDown(sub.cancel);
 
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        expect(emittedEvents, isEmpty);
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      expect(emittedEvents, isEmpty);
 
-        await _publishFixtureEventToRelay(relay.url, targetEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 500));
+      await _publishFixtureEventToRelay(relay.url, targetEvent);
+      await Future<void>.delayed(const Duration(milliseconds: 500));
 
-        expect(
-          emittedEvents.map((e) => e.id),
-          isNot(contains(targetEvent.id)),
-          reason:
-              'A tombstoned foreign target should stay suppressed on the public reactive stream even if replayed later.',
-        );
+      expect(
+        emittedEvents.map((e) => e.id),
+        isNot(contains(targetEvent.id)),
+        reason: 'A tombstoned foreign target should stay suppressed on the public reactive stream even if replayed later.',
+      );
 
-        await relay.stopServer();
-      },
-    );
+      await relay.stopServer();
+    });
 
-    test(
-      'cache-backed subscription emits cached replaceable winner then newer live replacement but not stale late event',
-      () async {
-        final relay = MockRelay(name: 'subscription-replaceable-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final writerNdk = Ndk(
-          NdkConfig(
-            cache: MemCacheManager(),
-            eventVerifier: MockEventVerifier(),
-            bootstrapRelays: [relay.url],
-          ),
-        );
-        addTearDown(writerNdk.destroy);
-        final cachedVersion = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Metadata.kKind,
-            tags: const [],
-            content: jsonEncode({'name': 'version-1'}),
-            createdAt: 1_700_000_100,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final newerVersion = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Metadata.kKind,
-            tags: const [],
-            content: jsonEncode({'name': 'version-2'}),
-            createdAt: 1_700_000_101,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final staleVersion = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Metadata.kKind,
-            tags: const [],
-            content: jsonEncode({'name': 'version-0'}),
-            createdAt: 1_700_000_099,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        await relay.startServer(
-          metadatas: {remoteAuthor.publicKey: cachedVersion},
-        );
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-        await ndk.relays.seedRelaysConnected;
+    test('cache-backed subscription emits cached replaceable winner then newer live replacement but not stale late event', () async {
+      final relay = MockRelay(name: 'subscription-replaceable-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final writerNdk = Ndk(
+        NdkConfig(
+          cache: MemCacheManager(),
+          eventVerifier: MockEventVerifier(),
+          bootstrapRelays: [relay.url],
+        ),
+      );
+      addTearDown(writerNdk.destroy);
+      final cachedVersion = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Metadata.kKind,
+          tags: const [],
+          content: jsonEncode({'name': 'version-1'}),
+          createdAt: 1_700_000_100,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final newerVersion = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Metadata.kKind,
+          tags: const [],
+          content: jsonEncode({'name': 'version-2'}),
+          createdAt: 1_700_000_101,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final staleVersion = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Metadata.kKind,
+          tags: const [],
+          content: jsonEncode({'name': 'version-0'}),
+          createdAt: 1_700_000_099,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      await relay.startServer(
+        metadatas: {remoteAuthor.publicKey: cachedVersion},
+      );
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+      await ndk.relays.seedRelaysConnected;
 
-        final cachedLoad = await ndk.requests
-            .query(
-              filter: Filter(
-                authors: [remoteAuthor.publicKey],
-                kinds: [Metadata.kKind],
-              ),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(cachedLoad.map((e) => e.id), contains(cachedVersion.id));
-        await Future<void>.delayed(const Duration(milliseconds: 200));
+      final cachedLoad = await ndk.requests
+          .query(
+            filter: Filter(
+              authors: [remoteAuthor.publicKey],
+              kinds: [Metadata.kKind],
+            ),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(cachedLoad.map((e) => e.id), contains(cachedVersion.id));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
 
-        final receivedContents = <String>[];
-        final cachedSeen = Completer<void>();
-        final newerSeen = Completer<void>();
-        final subscription = ndk.requests.subscription(
-          filter: Filter(
-            authors: [remoteAuthor.publicKey],
-            kinds: [Metadata.kKind],
-          ),
-          cacheRead: true,
-          cacheWrite: true,
-          explicitRelays: [relay.url],
-        );
-        final sub = subscription.stream.listen((event) {
-          receivedContents.add(event.content);
-          if (event.id == cachedVersion.id && !cachedSeen.isCompleted) {
-            cachedSeen.complete();
-          }
-          if (event.id == newerVersion.id && !newerSeen.isCompleted) {
-            newerSeen.complete();
-          }
-        });
-        addTearDown(sub.cancel);
+      final receivedContents = <String>[];
+      final cachedSeen = Completer<void>();
+      final newerSeen = Completer<void>();
+      final subscription = ndk.requests.subscription(
+        filter: Filter(
+          authors: [remoteAuthor.publicKey],
+          kinds: [Metadata.kKind],
+        ),
+        cacheRead: true,
+        cacheWrite: true,
+        explicitRelays: [relay.url],
+      );
+      final sub = subscription.stream.listen((event) {
+        receivedContents.add(event.content);
+        if (event.id == cachedVersion.id && !cachedSeen.isCompleted) {
+          cachedSeen.complete();
+        }
+        if (event.id == newerVersion.id && !newerSeen.isCompleted) {
+          newerSeen.complete();
+        }
+      });
+      addTearDown(sub.cancel);
 
-        await cachedSeen.future.timeout(const Duration(seconds: 2));
-        await Future<void>.delayed(const Duration(milliseconds: 200));
+      await cachedSeen.future.timeout(const Duration(seconds: 2));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
 
-        await writerNdk.broadcast
-            .broadcast(nostrEvent: newerVersion, specificRelays: [relay.url])
-            .broadcastDoneFuture;
-        await newerSeen.future.timeout(const Duration(seconds: 2));
+      await writerNdk.broadcast
+          .broadcast(nostrEvent: newerVersion, specificRelays: [relay.url])
+          .broadcastDoneFuture;
+      await newerSeen.future.timeout(const Duration(seconds: 2));
 
-        await writerNdk.broadcast
-            .broadcast(nostrEvent: staleVersion, specificRelays: [relay.url])
-            .broadcastDoneFuture;
-        await Future<void>.delayed(const Duration(milliseconds: 500));
+      await writerNdk.broadcast
+          .broadcast(nostrEvent: staleVersion, specificRelays: [relay.url])
+          .broadcastDoneFuture;
+      await Future<void>.delayed(const Duration(milliseconds: 500));
 
-        expect(receivedContents, contains(jsonEncode({'name': 'version-1'})));
-        expect(receivedContents, contains(jsonEncode({'name': 'version-2'})));
-        expect(
-          receivedContents,
-          isNot(contains(jsonEncode({'name': 'version-0'}))),
-          reason:
-              'A stale replaceable event that arrives after a newer winner should not be emitted on the local-first reactive stream.',
-        );
+      expect(receivedContents, contains(jsonEncode({'name': 'version-1'})));
+      expect(receivedContents, contains(jsonEncode({'name': 'version-2'})));
+      expect(
+        receivedContents,
+        isNot(contains(jsonEncode({'name': 'version-0'}))),
+        reason: 'A stale replaceable event that arrives after a newer winner should not be emitted on the local-first reactive stream.',
+      );
 
-        await relay.stopServer();
-      },
-    );
+      await relay.stopServer();
+    });
   });
 }
 

--- a/packages/ndk/test/usecases/local_first/local_first_test.dart
+++ b/packages/ndk/test/usecases/local_first/local_first_test.dart
@@ -29,990 +29,762 @@ void main() {
       await tempDir.delete(recursive: true);
     });
 
-    test(
-      'offline publish is locally readable and eventually reaches relay when relay comes online',
-      () async {
-        final relay = MockRelay(name: 'local-first-relay');
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [relay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
+    test('offline publish is locally readable and eventually reaches relay when relay comes online', () async {
+      final relay = MockRelay(name: 'local-first-relay');
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [relay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
 
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'offline-first public api note',
+        createdAt: 1_700_000_000,
+      );
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .broadcastDoneFuture;
+
+      final localWhileOffline = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+
+      expect(localWhileOffline.map((e) => e.id), contains(event.id));
+
+      await relay.startServer();
+      await _waitForRelayConnected(
+        ndk: ndk,
+        relayUrl: relay.url,
+        timeout: const Duration(seconds: 20),
+      );
+
+      final relayAfterReconnect = await _waitForRelayEvents(
+        relay: relay,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 15),
+      );
+
+      expect(
+        relayAfterReconnect.map((e) => e.id),
+        contains(event.id),
+        reason: 'Local-first should auto-deliver the unpublished event after the relay becomes reachable.',
+      );
+
+      await relay.stopServer();
+    });
+
+    test('partial success keeps local visibility and should later deliver only to relays that were offline', () async {
+      final relayOnline = MockRelay(name: 'relay-online');
+      final relayOffline = MockRelay(name: 'relay-offline');
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [relayOnline.url, relayOffline.url],
+      );
+
+      await relayOnline.startServer();
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
+
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'partial success note',
+        createdAt: 1_700_000_010,
+      );
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relayOnline.url, relayOffline.url],
+            timeout: const Duration(milliseconds: 300),
+          )
+          .broadcastDoneFuture;
+
+      final localVisible = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(localVisible.map((e) => e.id), contains(event.id));
+
+      final onlineRelayEvents = await _waitForRelayEvents(
+        relay: relayOnline,
+        filter: Filter(ids: [event.id]),
+      );
+      expect(onlineRelayEvents.map((e) => e.id), contains(event.id));
+
+      await relayOffline.startServer();
+
+      final offlineRelayEventually = await _waitForRelayEvents(
+        relay: relayOffline,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 8),
+      );
+
+      expect(
+        offlineRelayEventually.map((e) => e.id),
+        contains(event.id),
+        reason: 'After one relay succeeded and another was offline, local-first delivery should later flush only the missing relay.',
+      );
+
+      await relayOnline.stopServer();
+      await relayOffline.stopServer();
+    });
+
+    test('offline reaction to a cached root is locally visible and should later reach the relay', () async {
+      final relay = MockRelay(name: 'reaction-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final rootEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
           kind: Nip01Event.kTextNodeKind,
           tags: const [],
-          content: 'offline-first public api note',
-          createdAt: 1_700_000_000,
-        );
+          content: 'root event',
+          createdAt: 1_700_000_020,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
 
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: event,
-              specificRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .broadcastDoneFuture;
+      await relay.startServer(textNotes: {remoteAuthor: rootEvent});
 
-        final localWhileOffline = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
 
-        expect(localWhileOffline.map((e) => e.id), contains(event.id));
+      final cachedRoot = await ndk.requests
+          .query(
+            filter: Filter(ids: [rootEvent.id]),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(cachedRoot.map((e) => e.id), contains(rootEvent.id));
 
-        await relay.startServer();
-        await _waitForRelayConnected(
-          ndk: ndk,
-          relayUrl: relay.url,
-          timeout: const Duration(seconds: 20),
-        );
+      await relay.stopServer();
 
-        final relayAfterReconnect = await _waitForRelayEvents(
-          relay: relay,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 15),
-        );
+      await ndk.broadcast
+          .broadcastReaction(
+            eventId: rootEvent.id,
+            customRelays: [relay.url],
+            reaction: '♡',
+          )
+          .broadcastDoneFuture;
 
-        expect(
-          relayAfterReconnect.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'Local-first should auto-deliver the unpublished event after the relay becomes reachable.',
-        );
+      final localReaction = await ndk.requests
+          .query(
+            filter: Filter(
+              authors: [authorKey.publicKey],
+              kinds: [Reaction.kKind],
+            ),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
 
-        await relay.stopServer();
-      },
-    );
+      expect(localReaction.map((e) => e.content), contains('♡'));
 
-    test(
-      'partial success keeps local visibility and should later deliver only to relays that were offline',
-      () async {
-        final relayOnline = MockRelay(name: 'relay-online');
-        final relayOffline = MockRelay(name: 'relay-offline');
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [relayOnline.url, relayOffline.url],
-        );
+      await relay.startServer(textNotes: {remoteAuthor: rootEvent});
 
-        await relayOnline.startServer();
+      final relayReaction = await _waitForRelayEvents(
+        relay: relay,
+        filter: Filter(authors: [authorKey.publicKey], kinds: [Reaction.kKind]),
+        timeout: const Duration(seconds: 8),
+      );
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
+      expect(
+        relayReaction.map((e) => e.content),
+        contains('♡'),
+        reason: 'A reaction created while offline should be immediately visible locally and later delivered when the relay becomes reachable again.',
+      );
 
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
+      await relay.stopServer();
+    });
+
+    test('offline replaceable supersession shows latest locally and should later deliver only the newest version', () async {
+      final relay = MockRelay(name: 'replaceable-relay');
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
+
+      final version1 = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: 30023,
+        tags: const [
+          ['d', 'article-1'],
+        ],
+        content: 'version 1',
+        createdAt: 1_700_000_030,
+      );
+
+      final version2 = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: 30023,
+        tags: const [
+          ['d', 'article-1'],
+        ],
+        content: 'version 2',
+        createdAt: 1_700_000_031,
+      );
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: version1,
+            specificRelays: [relay.url],
+            timeout: const Duration(milliseconds: 300),
+          )
+          .broadcastDoneFuture;
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: version2,
+            specificRelays: [relay.url],
+            timeout: const Duration(milliseconds: 300),
+          )
+          .broadcastDoneFuture;
+
+      final localCurrent = await ndk.requests
+          .query(
+            filter: Filter(
+              authors: [authorKey.publicKey],
+              kinds: [30023],
+              tags: {
+                'd': ['article-1'],
+              },
+            ),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+
+      expect(localCurrent.length, 1);
+      expect(localCurrent.single.content, 'version 2');
+
+      await relay.startServer();
+      await _waitForRelayConnected(
+        ndk: ndk,
+        relayUrl: relay.url,
+        timeout: const Duration(seconds: 20),
+      );
+
+      final relayCurrent = await _waitForRelayEvents(
+        relay: relay,
+        filter: Filter(
+          authors: [authorKey.publicKey],
+          kinds: [30023],
+          tags: {
+            'd': ['article-1'],
+          },
+        ),
+        timeout: const Duration(seconds: 8),
+      );
+
+      expect(
+        relayCurrent.map((e) => e.content),
+        contains('version 2'),
+        reason: 'When multiple offline versions of a replaceable event exist, local-first delivery should later flush only the newest visible version.',
+      );
+      expect(
+        relayCurrent.where((e) => e.content == 'version 1'),
+        isEmpty,
+        reason: 'Superseded replaceable versions should not later be delivered after the current one replaced them locally.',
+      );
+      expect(
+        relay.receivedEvents.where((e) => e.content == 'version 1'),
+        isEmpty,
+        reason: 'Superseded replaceable versions should be skipped by local-first flush instead of being sent and relying on relay-side conflict resolution.',
+      );
+      expect(
+        relay.receivedEvents.where((e) => e.content == 'version 2').length,
+        1,
+        reason: 'Only the current replaceable version should be delivered during delayed flush.',
+      );
+
+      await relay.stopServer();
+    });
+
+    test('offline publish survives ndk restart and is later delivered after relay comes online', () async {
+      final relay = MockRelay(name: 'restart-relay');
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
+
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'restart persistence note',
+        createdAt: 1_700_000_035,
+      );
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            timeout: const Duration(milliseconds: 300),
+          )
+          .broadcastDoneFuture;
+
+      final localBeforeRestart = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(localBeforeRestart.map((e) => e.id), contains(event.id));
+
+      await ndk.destroy();
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
+
+      final localAfterRestart = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(localAfterRestart.map((e) => e.id), contains(event.id));
+
+      await relay.startServer();
+      await _waitForRelayConnected(
+        ndk: ndk,
+        relayUrl: relay.url,
+        timeout: const Duration(seconds: 20),
+      );
+
+      final relayAfterReconnect = await _waitForRelayEvents(
+        relay: relay,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 8),
+      );
+
+      expect(
+        relayAfterReconnect.map((e) => e.id),
+        contains(event.id),
+        reason: 'A locally queued event should survive process restart and still be delivered once the relay becomes reachable.',
+      );
+
+      await relay.stopServer();
+    });
+
+    test('incoming deletion hides a previously cached foreign event from app queries', () async {
+      final relay = MockRelay(name: 'incoming-deletion-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final rootEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
           kind: Nip01Event.kTextNodeKind,
           tags: const [],
-          content: 'partial success note',
-          createdAt: 1_700_000_010,
-        );
-
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: event,
-              specificRelays: [relayOnline.url, relayOffline.url],
-              timeout: const Duration(milliseconds: 300),
-            )
-            .broadcastDoneFuture;
-
-        final localVisible = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-        expect(localVisible.map((e) => e.id), contains(event.id));
-
-        final onlineRelayEvents = await _waitForRelayEvents(
-          relay: relayOnline,
-          filter: Filter(ids: [event.id]),
-        );
-        expect(onlineRelayEvents.map((e) => e.id), contains(event.id));
-
-        await relayOffline.startServer();
-
-        final offlineRelayEventually = await _waitForRelayEvents(
-          relay: relayOffline,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 8),
-        );
-
-        expect(
-          offlineRelayEventually.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'After one relay succeeded and another was offline, local-first delivery should later flush only the missing relay.',
-        );
-
-        await relayOnline.stopServer();
-        await relayOffline.stopServer();
-      },
-    );
-
-    test(
-      'offline reaction to a cached root is locally visible and should later reach the relay',
-      () async {
-        final relay = MockRelay(name: 'reaction-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final rootEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Nip01Event.kTextNodeKind,
-            tags: const [],
-            content: 'root event',
-            createdAt: 1_700_000_020,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-
-        await relay.startServer(textNotes: {remoteAuthor: rootEvent});
-
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
-
-        final cachedRoot = await ndk.requests
-            .query(
-              filter: Filter(ids: [rootEvent.id]),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(cachedRoot.map((e) => e.id), contains(rootEvent.id));
-
-        await relay.stopServer();
-
-        await ndk.broadcast
-            .broadcastReaction(
-              eventId: rootEvent.id,
-              customRelays: [relay.url],
-              reaction: '♡',
-            )
-            .broadcastDoneFuture;
-
-        final localReaction = await ndk.requests
-            .query(
-              filter: Filter(
-                authors: [authorKey.publicKey],
-                kinds: [Reaction.kKind],
-              ),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-
-        expect(localReaction.map((e) => e.content), contains('♡'));
-
-        await relay.startServer(textNotes: {remoteAuthor: rootEvent});
-
-        final relayReaction = await _waitForRelayEvents(
-          relay: relay,
-          filter: Filter(
-            authors: [authorKey.publicKey],
-            kinds: [Reaction.kKind],
-          ),
-          timeout: const Duration(seconds: 8),
-        );
-
-        expect(
-          relayReaction.map((e) => e.content),
-          contains('♡'),
-          reason:
-              'A reaction created while offline should be immediately visible locally and later delivered when the relay becomes reachable again.',
-        );
-
-        await relay.stopServer();
-      },
-    );
-
-    test(
-      'offline replaceable supersession shows latest locally and should later deliver only the newest version',
-      () async {
-        final relay = MockRelay(name: 'replaceable-relay');
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
-
-        final version1 = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: 30023,
-          tags: const [
-            ['d', 'article-1'],
+          content: 'event later deleted',
+          createdAt: 1_700_000_050,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final deletionEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Deletion.kKind,
+          tags: [
+            ['e', rootEvent.id],
+            ['k', rootEvent.kind.toString()],
           ],
-          content: 'version 1',
-          createdAt: 1_700_000_030,
-        );
+          content: 'delete root event',
+          createdAt: 1_700_000_051,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
 
-        final version2 = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: 30023,
-          tags: const [
-            ['d', 'article-1'],
+      await relay.startServer(textNotes: {remoteAuthor: rootEvent});
+
+      final cachedRoot = await ndk.requests
+          .query(
+            filter: Filter(ids: [rootEvent.id]),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(cachedRoot.map((e) => e.id), contains(rootEvent.id));
+
+      await _publishFixtureEventToRelay(relay.url, deletionEvent);
+
+      final fetchedDeletion = await ndk.requests
+          .query(
+            filter: Filter(
+              authors: [remoteAuthor.publicKey],
+              kinds: [Deletion.kKind],
+              ids: [deletionEvent.id],
+            ),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(fetchedDeletion.map((e) => e.id), contains(deletionEvent.id));
+
+      final localAfterDeletion = await ndk.requests
+          .query(
+            filter: Filter(ids: [rootEvent.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+
+      expect(
+        localAfterDeletion.map((e) => e.id),
+        isNot(contains(rootEvent.id)),
+        reason: 'After a valid remote deletion is seen, app-level local-first reads should stop returning the deleted foreign event.',
+      );
+
+      await relay.stopServer();
+    });
+
+    test('deletion received before target should keep the later foreign target suppressed locally', () async {
+      final relay = MockRelay(name: 'deletion-first-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final rootEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Nip01Event.kTextNodeKind,
+          tags: const [],
+          content: 'event that should stay tombstoned',
+          createdAt: 1_700_000_060,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final deletionEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Deletion.kKind,
+          tags: [
+            ['e', rootEvent.id],
+            ['k', rootEvent.kind.toString()],
           ],
-          content: 'version 2',
-          createdAt: 1_700_000_031,
-        );
+          content: 'delete before target arrives',
+          createdAt: 1_700_000_061,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
 
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: version1,
-              specificRelays: [relay.url],
-              timeout: const Duration(milliseconds: 300),
-            )
-            .broadcastDoneFuture;
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: version2,
-              specificRelays: [relay.url],
-              timeout: const Duration(milliseconds: 300),
-            )
-            .broadcastDoneFuture;
+      await relay.startServer();
 
-        final localCurrent = await ndk.requests
-            .query(
-              filter: Filter(
-                authors: [authorKey.publicKey],
-                kinds: [30023],
-                tags: {
-                  'd': ['article-1'],
-                },
-              ),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
+      await _publishFixtureEventToRelay(relay.url, deletionEvent);
 
-        expect(localCurrent.length, 1);
-        expect(localCurrent.single.content, 'version 2');
+      final fetchedDeletion = await ndk.requests
+          .query(
+            filter: Filter(
+              authors: [remoteAuthor.publicKey],
+              kinds: [Deletion.kKind],
+              ids: [deletionEvent.id],
+            ),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(fetchedDeletion.map((e) => e.id), contains(deletionEvent.id));
 
-        await relay.startServer();
-        await _waitForRelayConnected(
-          ndk: ndk,
-          relayUrl: relay.url,
-          timeout: const Duration(seconds: 20),
-        );
+      await _publishFixtureEventToRelay(relay.url, rootEvent);
 
-        final relayCurrent = await _waitForRelayEvents(
-          relay: relay,
-          filter: Filter(
-            authors: [authorKey.publicKey],
-            kinds: [30023],
-            tags: {
-              'd': ['article-1'],
-            },
-          ),
-          timeout: const Duration(seconds: 8),
-        );
+      final targetFetch = await ndk.requests
+          .query(
+            filter: Filter(ids: [rootEvent.id]),
+            explicitRelays: [relay.url],
+            timeout: const Duration(seconds: 1),
+          )
+          .future;
+      expect(
+        targetFetch.map((e) => e.id),
+        isNot(contains(rootEvent.id)),
+        reason: 'Once a tombstone is known locally, a later fetch of that foreign target should already be suppressed at the public query layer.',
+      );
 
-        expect(
-          relayCurrent.map((e) => e.content),
-          contains('version 2'),
-          reason:
-              'When multiple offline versions of a replaceable event exist, local-first delivery should later flush only the newest visible version.',
-        );
-        expect(
-          relayCurrent.where((e) => e.content == 'version 1'),
-          isEmpty,
-          reason:
-              'Superseded replaceable versions should not later be delivered after the current one replaced them locally.',
-        );
-        expect(
-          relay.receivedEvents.where((e) => e.content == 'version 1'),
-          isEmpty,
-          reason:
-              'Superseded replaceable versions should be skipped by local-first flush instead of being sent and relying on relay-side conflict resolution.',
-        );
-        expect(
-          relay.receivedEvents.where((e) => e.content == 'version 2').length,
-          1,
-          reason:
-              'Only the current replaceable version should be delivered during delayed flush.',
-        );
+      final localAfterLateTarget = await ndk.requests
+          .query(
+            filter: Filter(ids: [rootEvent.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
 
-        await relay.stopServer();
-      },
-    );
+      expect(
+        localAfterLateTarget.map((e) => e.id),
+        isNot(contains(rootEvent.id)),
+        reason: 'If the deletion arrived first, later sync of the deleted foreign target should remain suppressed instead of resurrecting locally.',
+      );
 
-    test(
-      'offline publish survives ndk restart and is later delivered after relay comes online',
-      () async {
-        final relay = MockRelay(name: 'restart-relay');
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
+      await relay.stopServer();
+    });
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
-
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: Nip01Event.kTextNodeKind,
+    test('relay refresh replaces stale cached metadata with the newest remote version', () async {
+      final relay = MockRelay(name: 'metadata-convergence-relay');
+      final remoteAuthor = Bip340.generatePrivateKey();
+      final oldMetadataEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Metadata.kKind,
           tags: const [],
-          content: 'restart persistence note',
-          createdAt: 1_700_000_035,
-        );
-
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: event,
-              specificRelays: [relay.url],
-              timeout: const Duration(milliseconds: 300),
-            )
-            .broadcastDoneFuture;
-
-        final localBeforeRestart = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-        expect(localBeforeRestart.map((e) => e.id), contains(event.id));
-
-        await ndk.destroy();
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
-
-        final localAfterRestart = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-        expect(localAfterRestart.map((e) => e.id), contains(event.id));
-
-        await relay.startServer();
-        await _waitForRelayConnected(
-          ndk: ndk,
-          relayUrl: relay.url,
-          timeout: const Duration(seconds: 20),
-        );
-
-        final relayAfterReconnect = await _waitForRelayEvents(
-          relay: relay,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 8),
-        );
-
-        expect(
-          relayAfterReconnect.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'A locally queued event should survive process restart and still be delivered once the relay becomes reachable.',
-        );
-
-        await relay.stopServer();
-      },
-    );
-
-    test(
-      'incoming deletion hides a previously cached foreign event from app queries',
-      () async {
-        final relay = MockRelay(name: 'incoming-deletion-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final rootEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Nip01Event.kTextNodeKind,
-            tags: const [],
-            content: 'event later deleted',
-            createdAt: 1_700_000_050,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final deletionEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Deletion.kKind,
-            tags: [
-              ['e', rootEvent.id],
-              ['k', rootEvent.kind.toString()],
-            ],
-            content: 'delete root event',
-            createdAt: 1_700_000_051,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-
-        await relay.startServer(textNotes: {remoteAuthor: rootEvent});
-
-        final cachedRoot = await ndk.requests
-            .query(
-              filter: Filter(ids: [rootEvent.id]),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(cachedRoot.map((e) => e.id), contains(rootEvent.id));
-
-        await _publishFixtureEventToRelay(relay.url, deletionEvent);
-
-        final fetchedDeletion = await ndk.requests
-            .query(
-              filter: Filter(
-                authors: [remoteAuthor.publicKey],
-                kinds: [Deletion.kKind],
-                ids: [deletionEvent.id],
-              ),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(fetchedDeletion.map((e) => e.id), contains(deletionEvent.id));
-
-        final localAfterDeletion = await ndk.requests
-            .query(
-              filter: Filter(ids: [rootEvent.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-
-        expect(
-          localAfterDeletion.map((e) => e.id),
-          isNot(contains(rootEvent.id)),
-          reason:
-              'After a valid remote deletion is seen, app-level local-first reads should stop returning the deleted foreign event.',
-        );
-
-        await relay.stopServer();
-      },
-    );
-
-    test(
-      'deletion received before target should keep the later foreign target suppressed locally',
-      () async {
-        final relay = MockRelay(name: 'deletion-first-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final rootEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Nip01Event.kTextNodeKind,
-            tags: const [],
-            content: 'event that should stay tombstoned',
-            createdAt: 1_700_000_060,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final deletionEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Deletion.kKind,
-            tags: [
-              ['e', rootEvent.id],
-              ['k', rootEvent.kind.toString()],
-            ],
-            content: 'delete before target arrives',
-            createdAt: 1_700_000_061,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-
-        await relay.startServer();
-
-        await _publishFixtureEventToRelay(relay.url, deletionEvent);
-
-        final fetchedDeletion = await ndk.requests
-            .query(
-              filter: Filter(
-                authors: [remoteAuthor.publicKey],
-                kinds: [Deletion.kKind],
-                ids: [deletionEvent.id],
-              ),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(fetchedDeletion.map((e) => e.id), contains(deletionEvent.id));
-
-        await _publishFixtureEventToRelay(relay.url, rootEvent);
-
-        final targetFetch = await ndk.requests
-            .query(
-              filter: Filter(ids: [rootEvent.id]),
-              explicitRelays: [relay.url],
-              timeout: const Duration(seconds: 1),
-            )
-            .future;
-        expect(
-          targetFetch.map((e) => e.id),
-          isNot(contains(rootEvent.id)),
-          reason:
-              'Once a tombstone is known locally, a later fetch of that foreign target should already be suppressed at the public query layer.',
-        );
-
-        final localAfterLateTarget = await ndk.requests
-            .query(
-              filter: Filter(ids: [rootEvent.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-
-        expect(
-          localAfterLateTarget.map((e) => e.id),
-          isNot(contains(rootEvent.id)),
-          reason:
-              'If the deletion arrived first, later sync of the deleted foreign target should remain suppressed instead of resurrecting locally.',
-        );
-
-        await relay.stopServer();
-      },
-    );
-
-    test(
-      'relay refresh replaces stale cached metadata with the newest remote version',
-      () async {
-        final relay = MockRelay(name: 'metadata-convergence-relay');
-        final remoteAuthor = Bip340.generatePrivateKey();
-        final oldMetadataEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Metadata.kKind,
-            tags: const [],
-            content: jsonEncode({'name': 'old-name'}),
-            createdAt: 1_700_000_070,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        final newMetadataEvent = Nip01Utils.signWithPrivateKey(
-          event: Nip01Event(
-            pubKey: remoteAuthor.publicKey,
-            kind: Metadata.kKind,
-            tags: const [],
-            content: jsonEncode({'name': 'new-name'}),
-            createdAt: 1_700_000_071,
-          ),
-          privateKey: remoteAuthor.privateKey!,
-        );
-        ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
-
-        await relay.startServer(
-          metadatas: {remoteAuthor.publicKey: oldMetadataEvent},
-        );
-
-        final cachedOldMetadata = await ndk.metadata.loadMetadata(
-          remoteAuthor.publicKey,
-          forceRefresh: true,
-          idleTimeout: const Duration(seconds: 1),
-        );
-        expect(cachedOldMetadata?.name, 'old-name');
-
-        await relay.stopServer();
-        await relay.startServer(
-          metadatas: {remoteAuthor.publicKey: newMetadataEvent},
-        );
-
-        final refreshedMetadata = await ndk.metadata.loadMetadata(
-          remoteAuthor.publicKey,
-          forceRefresh: true,
-          idleTimeout: const Duration(seconds: 1),
-        );
-        expect(
-          refreshedMetadata?.name,
-          'new-name',
-          reason:
-              'A newer replaceable metadata event from the relay should overwrite the stale cached materialized view.',
-        );
-
-        final localCurrentMetadata = await ndk.metadata.loadMetadata(
-          remoteAuthor.publicKey,
-        );
-        expect(localCurrentMetadata?.name, 'new-name');
-
-        await relay.stopServer();
-      },
-    );
-
-    test(
-      'connected relay rejecting first should keep local visibility and later succeed via periodic retry',
-      () async {
-        final relay = MockRelay(
-          name: 'retry-relay',
-          rejectFirstEventPublishes: 1,
-          rejectEventMessage: 'rate-limited: retry later',
-        );
-        await relay.startServer();
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [relay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
-
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
-
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: Nip01Event.kTextNodeKind,
+          content: jsonEncode({'name': 'old-name'}),
+          createdAt: 1_700_000_070,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      final newMetadataEvent = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: remoteAuthor.publicKey,
+          kind: Metadata.kKind,
           tags: const [],
-          content: 'connected retry note',
-          createdAt: 1_700_000_040,
-        );
+          content: jsonEncode({'name': 'new-name'}),
+          createdAt: 1_700_000_071,
+        ),
+        privateKey: remoteAuthor.privateKey!,
+      );
+      ndk = await _createNdk(tempDir.path, bootstrapRelays: [relay.url]);
 
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: event,
-              specificRelays: [relay.url],
-              timeout: const Duration(milliseconds: 500),
-            )
-            .broadcastDoneFuture;
+      await relay.startServer(
+        metadatas: {remoteAuthor.publicKey: oldMetadataEvent},
+      );
 
-        final localVisible = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-        expect(localVisible.map((e) => e.id), contains(event.id));
+      final cachedOldMetadata = await ndk.metadata.loadMetadata(
+        remoteAuthor.publicKey,
+        forceRefresh: true,
+        idleTimeout: const Duration(seconds: 1),
+      );
+      expect(cachedOldMetadata?.name, 'old-name');
 
-        expect(
-          relay.receivedEvents.where((e) => e.id == event.id).length,
-          1,
-          reason:
-              'The first connected publish attempt should reach the relay and be rejected without disconnecting.',
-        );
-        expect(
-          relay.matchingEvents(Filter(ids: [event.id])),
-          isEmpty,
-          reason:
-              'Rejected events should not be visible on the relay before the retry succeeds.',
-        );
+      await relay.stopServer();
+      await relay.startServer(
+        metadatas: {remoteAuthor.publicKey: newMetadataEvent},
+      );
 
-        final eventuallyStored = await _waitForRelayEvents(
-          relay: relay,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 8),
-        );
+      final refreshedMetadata = await ndk.metadata.loadMetadata(
+        remoteAuthor.publicKey,
+        forceRefresh: true,
+        idleTimeout: const Duration(seconds: 1),
+      );
+      expect(
+        refreshedMetadata?.name,
+        'new-name',
+        reason: 'A newer replaceable metadata event from the relay should overwrite the stale cached materialized view.',
+      );
 
-        expect(
-          eventuallyStored.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'A connected relay that first rejects with a transient error should later receive the event through the periodic due-retry path.',
-        );
-        expect(
-          relay.receivedEvents.where((e) => e.id == event.id).length,
-          2,
-          reason:
-              'The retry path should produce a second publish attempt after the initial transient rejection.',
-        );
+      final localCurrentMetadata = await ndk.metadata.loadMetadata(
+        remoteAuthor.publicKey,
+      );
+      expect(localCurrentMetadata?.name, 'new-name');
 
-        await relay.stopServer();
-      },
-    );
+      await relay.stopServer();
+    });
 
-    test(
-      'connected relay returning permanent failure should keep local visibility without periodic retry spam',
-      () async {
-        final relay = MockRelay(
-          name: 'permanent-failure-relay',
-          rejectFirstEventPublishes: 99,
-          rejectEventMessage: 'policy violation: forbidden kind',
-        );
-        await relay.startServer();
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [relay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
+    test('connected relay rejecting first should keep local visibility and later succeed via periodic retry', () async {
+      final relay = MockRelay(
+        name: 'retry-relay',
+        rejectFirstEventPublishes: 1,
+        rejectEventMessage: 'rate-limited: retry later',
+      );
+      await relay.startServer();
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [relay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
 
-        ndk.accounts.loginPrivateKey(
-          pubkey: authorKey.publicKey,
-          privkey: authorKey.privateKey!,
-        );
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
 
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'permanent failure note',
-          createdAt: 1_700_000_041,
-        );
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'connected retry note',
+        createdAt: 1_700_000_040,
+      );
 
-        await ndk.broadcast
-            .broadcast(
-              nostrEvent: event,
-              specificRelays: [relay.url],
-              timeout: const Duration(milliseconds: 500),
-            )
-            .broadcastDoneFuture;
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            timeout: const Duration(milliseconds: 500),
+          )
+          .broadcastDoneFuture;
 
-        final localVisible = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-        expect(localVisible.map((e) => e.id), contains(event.id));
+      final localVisible = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(localVisible.map((e) => e.id), contains(event.id));
 
-        expect(
-          relay.receivedEvents.where((e) => e.id == event.id).length,
-          1,
-          reason:
-              'The initial publish attempt should still reach the connected relay before being rejected permanently.',
-        );
+      expect(
+        relay.receivedEvents.where((e) => e.id == event.id).length,
+        1,
+        reason: 'The first connected publish attempt should reach the relay and be rejected without disconnecting.',
+      );
+      expect(
+        relay.matchingEvents(Filter(ids: [event.id])),
+        isEmpty,
+        reason: 'Rejected events should not be visible on the relay before the retry succeeds.',
+      );
 
-        await Future<void>.delayed(const Duration(seconds: 4));
+      final eventuallyStored = await _waitForRelayEvents(
+        relay: relay,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 8),
+      );
 
-        expect(
-          relay.matchingEvents(Filter(ids: [event.id])),
-          isEmpty,
-          reason:
-              'A permanently rejected event should never appear on the relay if the relay keeps refusing it.',
-        );
-        expect(
-          relay.receivedEvents.where((e) => e.id == event.id).length,
-          1,
-          reason:
-              'Permanent failures should not be retried by the periodic retry pump.',
-        );
+      expect(
+        eventuallyStored.map((e) => e.id),
+        contains(event.id),
+        reason: 'A connected relay that first rejects with a transient error should later receive the event through the periodic due-retry path.',
+      );
+      expect(
+        relay.receivedEvents.where((e) => e.id == event.id).length,
+        2,
+        reason: 'The retry path should produce a second publish attempt after the initial transient rejection.',
+      );
 
-        await relay.stopServer();
-      },
-    );
+      await relay.stopServer();
+    });
 
-    test(
-      'network-backed interactive signer queues locally while signer transport relay is offline and publishes once that relay connects',
-      () async {
-        final publishRelay = MockRelay(name: 'signer-publish-relay');
-        final signerRelay = MockRelay(name: 'signer-transport-relay');
-        final signer = _ControllableInteractiveSigner(
-          keyPair: authorKey,
-          available: false,
-          requiresSignerNetwork: true,
-          transportRelayUrls: () => [signerRelay.url],
-        );
+    test('connected relay returning permanent failure should keep local visibility without periodic retry spam', () async {
+      final relay = MockRelay(
+        name: 'permanent-failure-relay',
+        rejectFirstEventPublishes: 99,
+        rejectEventMessage: 'policy violation: forbidden kind',
+      );
+      await relay.startServer();
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [relay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
 
-        await publishRelay.startServer();
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [publishRelay.url, signerRelay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
-        ndk.accounts.loginExternalSigner(signer: signer);
+      ndk.accounts.loginPrivateKey(
+        pubkey: authorKey.publicKey,
+        privkey: authorKey.privateKey!,
+      );
 
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'network signer offline then online',
-          createdAt: 1_700_000_080,
-        );
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'permanent failure note',
+        createdAt: 1_700_000_041,
+      );
 
-        try {
-          await ndk.broadcast
-              .broadcast(
-                nostrEvent: event,
-                specificRelays: [publishRelay.url],
-                timeout: const Duration(milliseconds: 300),
-              )
-              .broadcastDoneFuture;
-        } catch (_) {}
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            timeout: const Duration(milliseconds: 500),
+          )
+          .broadcastDoneFuture;
 
-        final localWhileSignerOffline = await _waitForCachedEvents(
-          ndk: ndk,
-          filter: Filter(ids: [event.id]),
-        );
-        expect(localWhileSignerOffline.map((e) => e.id), contains(event.id));
+      final localVisible = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(localVisible.map((e) => e.id), contains(event.id));
 
-        await Future<void>.delayed(const Duration(seconds: 2));
-        expect(
-          publishRelay.receivedEvents.where((e) => e.id == event.id),
-          isEmpty,
-          reason:
-              'While the network-backed signer transport relay is unavailable, local-first should keep the event queued without publishing to target relays.',
-        );
+      expect(
+        relay.receivedEvents.where((e) => e.id == event.id).length,
+        1,
+        reason: 'The initial publish attempt should still reach the connected relay before being rejected permanently.',
+      );
 
-        signer.available = true;
-        await signerRelay.startServer();
-        await ndk.connectivity.tryReconnect();
-        await _waitForRelayConnected(
-          ndk: ndk,
-          relayUrl: signerRelay.url,
-          timeout: const Duration(seconds: 10),
-        );
+      await Future<void>.delayed(const Duration(seconds: 4));
 
-        final relayAfterSignerTransportOnline = await _waitForRelayEvents(
-          relay: publishRelay,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 10),
-        );
+      expect(
+        relay.matchingEvents(Filter(ids: [event.id])),
+        isEmpty,
+        reason: 'A permanently rejected event should never appear on the relay if the relay keeps refusing it.',
+      );
+      expect(
+        relay.receivedEvents.where((e) => e.id == event.id).length,
+        1,
+        reason: 'Permanent failures should not be retried by the periodic retry pump.',
+      );
 
-        expect(
-          relayAfterSignerTransportOnline.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'When the signer transport relay comes online, local-first should retry signing and then immediately publish to connected delivery relays.',
-        );
+      await relay.stopServer();
+    });
 
-        await publishRelay.stopServer();
-        await signerRelay.stopServer();
-      },
-    );
+    test('network-backed interactive signer queues locally while signer transport relay is offline and publishes once that relay connects', () async {
+      final publishRelay = MockRelay(name: 'signer-publish-relay');
+      final signerRelay = MockRelay(name: 'signer-transport-relay');
+      final signer = _ControllableInteractiveSigner(
+        keyPair: authorKey,
+        available: false,
+        requiresSignerNetwork: true,
+        transportRelayUrls: () => [signerRelay.url],
+      );
 
-    test(
-      'interactive signer queue survives restart and later signs plus publishes when signer becomes available',
-      () async {
-        final relay = MockRelay(name: 'interactive-restart-relay');
-        final failingSigner = _ControllableInteractiveSigner(
-          keyPair: authorKey,
-          available: false,
-          requiresSignerNetwork: false,
-        );
+      await publishRelay.startServer();
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [publishRelay.url, signerRelay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
+      ndk.accounts.loginExternalSigner(signer: signer);
 
-        await relay.startServer();
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [relay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
-        ndk.accounts.loginExternalSigner(signer: failingSigner);
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'network signer offline then online',
+        createdAt: 1_700_000_080,
+      );
 
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'interactive signer restart persistence',
-          createdAt: 1_700_000_081,
-        );
-
-        try {
-          await ndk.broadcast
-              .broadcast(
-                nostrEvent: event,
-                specificRelays: [relay.url],
-                timeout: const Duration(milliseconds: 300),
-              )
-              .broadcastDoneFuture;
-        } catch (_) {}
-
-        final localBeforeRestart = await _waitForCachedEvents(
-          ndk: ndk,
-          filter: Filter(ids: [event.id]),
-        );
-        expect(localBeforeRestart.map((e) => e.id), contains(event.id));
-        expect(
-          relay.receivedEvents.where((e) => e.id == event.id),
-          isEmpty,
-          reason:
-              'If interactive signing cannot complete yet, the event should remain local without being published.',
-        );
-
-        await ndk.destroy();
-
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [relay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
-        ndk.accounts.loginExternalSigner(
-          signer: _ControllableInteractiveSigner(
-            keyPair: authorKey,
-            available: true,
-            requiresSignerNetwork: false,
-          ),
-        );
-
-        final localAfterRestart = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
-              timeout: const Duration(milliseconds: 300),
-            )
-            .future;
-        expect(localAfterRestart.map((e) => e.id), contains(event.id));
-
-        final relayAfterRestart = await _waitForRelayEvents(
-          relay: relay,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 10),
-        );
-
-        expect(
-          relayAfterRestart.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'Unsigned interactive-signing work should survive restart and later complete once a compatible signer becomes available again.',
-        );
-
-        await relay.stopServer();
-      },
-    );
-
-    test(
-      'successful network signing while publish relay is offline should still deliver later when the target relay reconnects',
-      () async {
-        final publishRelay = MockRelay(name: 'signed-then-publish-later-relay');
-        final signerRelay = MockRelay(name: 'signer-online-relay');
-        final signer = _ControllableInteractiveSigner(
-          keyPair: authorKey,
-          available: true,
-          requiresSignerNetwork: true,
-          transportRelayUrls: () => [signerRelay.url],
-        );
-
-        await signerRelay.startServer();
-        ndk = await _createNdk(
-          tempDir.path,
-          bootstrapRelays: [publishRelay.url, signerRelay.url],
-          pendingDeliveryRetryInterval: const Duration(seconds: 1),
-        );
-        ndk.accounts.loginExternalSigner(signer: signer);
-
-        await _waitForRelayConnected(
-          ndk: ndk,
-          relayUrl: signerRelay.url,
-          timeout: const Duration(seconds: 10),
-        );
-
-        final event = Nip01Event(
-          pubKey: authorKey.publicKey,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'signed now publish later',
-          createdAt: 1_700_000_082,
-        );
-
+      try {
         await ndk.broadcast
             .broadcast(
               nostrEvent: event,
@@ -1020,52 +792,213 @@ void main() {
               timeout: const Duration(milliseconds: 300),
             )
             .broadcastDoneFuture;
+      } catch (_) {}
 
-        final localSignedWhilePublishOffline = await ndk.requests
-            .query(
-              filter: Filter(ids: [event.id]),
-              cacheRead: true,
-              cacheWrite: false,
+      final localWhileSignerOffline = await _waitForCachedEvents(
+        ndk: ndk,
+        filter: Filter(ids: [event.id]),
+      );
+      expect(localWhileSignerOffline.map((e) => e.id), contains(event.id));
+
+      await Future<void>.delayed(const Duration(seconds: 2));
+      expect(
+        publishRelay.receivedEvents.where((e) => e.id == event.id),
+        isEmpty,
+        reason: 'While the network-backed signer transport relay is unavailable, local-first should keep the event queued without publishing to target relays.',
+      );
+
+      signer.available = true;
+      await signerRelay.startServer();
+      await ndk.connectivity.tryReconnect();
+      await _waitForRelayConnected(
+        ndk: ndk,
+        relayUrl: signerRelay.url,
+        timeout: const Duration(seconds: 10),
+      );
+
+      final relayAfterSignerTransportOnline = await _waitForRelayEvents(
+        relay: publishRelay,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(
+        relayAfterSignerTransportOnline.map((e) => e.id),
+        contains(event.id),
+        reason: 'When the signer transport relay comes online, local-first should retry signing and then immediately publish to connected delivery relays.',
+      );
+
+      await publishRelay.stopServer();
+      await signerRelay.stopServer();
+    });
+
+    test('interactive signer queue survives restart and later signs plus publishes when signer becomes available', () async {
+      final relay = MockRelay(name: 'interactive-restart-relay');
+      final failingSigner = _ControllableInteractiveSigner(
+        keyPair: authorKey,
+        available: false,
+        requiresSignerNetwork: false,
+      );
+
+      await relay.startServer();
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [relay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
+      ndk.accounts.loginExternalSigner(signer: failingSigner);
+
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'interactive signer restart persistence',
+        createdAt: 1_700_000_081,
+      );
+
+      try {
+        await ndk.broadcast
+            .broadcast(
+              nostrEvent: event,
+              specificRelays: [relay.url],
               timeout: const Duration(milliseconds: 300),
             )
-            .future;
-        expect(
-          localSignedWhilePublishOffline.map((e) => e.id),
-          contains(event.id),
-        );
+            .broadcastDoneFuture;
+      } catch (_) {}
 
-        await Future<void>.delayed(const Duration(seconds: 2));
-        expect(
-          publishRelay.receivedEvents.where((e) => e.id == event.id),
-          isEmpty,
-          reason:
-              'Even if signing succeeds immediately, target relay delivery should stay queued while the publish relay is still offline.',
-        );
+      final localBeforeRestart = await _waitForCachedEvents(
+        ndk: ndk,
+        filter: Filter(ids: [event.id]),
+      );
+      expect(localBeforeRestart.map((e) => e.id), contains(event.id));
+      expect(
+        relay.receivedEvents.where((e) => e.id == event.id),
+        isEmpty,
+        reason: 'If interactive signing cannot complete yet, the event should remain local without being published.',
+      );
 
-        await publishRelay.startServer();
-        await _waitForRelayConnected(
-          ndk: ndk,
-          relayUrl: publishRelay.url,
-          timeout: const Duration(seconds: 15),
-        );
+      await ndk.destroy();
 
-        final relayAfterPublishReconnect = await _waitForRelayEvents(
-          relay: publishRelay,
-          filter: Filter(ids: [event.id]),
-          timeout: const Duration(seconds: 10),
-        );
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [relay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
+      ndk.accounts.loginExternalSigner(
+        signer: _ControllableInteractiveSigner(
+          keyPair: authorKey,
+          available: true,
+          requiresSignerNetwork: false,
+        ),
+      );
 
-        expect(
-          relayAfterPublishReconnect.map((e) => e.id),
-          contains(event.id),
-          reason:
-              'After signing succeeded while the publish relay was offline, the queued signed event should later be delivered once that relay reconnects.',
-        );
+      final localAfterRestart = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(localAfterRestart.map((e) => e.id), contains(event.id));
 
-        await publishRelay.stopServer();
-        await signerRelay.stopServer();
-      },
-    );
+      final relayAfterRestart = await _waitForRelayEvents(
+        relay: relay,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(
+        relayAfterRestart.map((e) => e.id),
+        contains(event.id),
+        reason: 'Unsigned interactive-signing work should survive restart and later complete once a compatible signer becomes available again.',
+      );
+
+      await relay.stopServer();
+    });
+
+    test('successful network signing while publish relay is offline should still deliver later when the target relay reconnects', () async {
+      final publishRelay = MockRelay(name: 'signed-then-publish-later-relay');
+      final signerRelay = MockRelay(name: 'signer-online-relay');
+      final signer = _ControllableInteractiveSigner(
+        keyPair: authorKey,
+        available: true,
+        requiresSignerNetwork: true,
+        transportRelayUrls: () => [signerRelay.url],
+      );
+
+      await signerRelay.startServer();
+      ndk = await _createNdk(
+        tempDir.path,
+        bootstrapRelays: [publishRelay.url, signerRelay.url],
+        pendingDeliveryRetryInterval: const Duration(seconds: 1),
+      );
+      ndk.accounts.loginExternalSigner(signer: signer);
+
+      await _waitForRelayConnected(
+        ndk: ndk,
+        relayUrl: signerRelay.url,
+        timeout: const Duration(seconds: 10),
+      );
+
+      final event = Nip01Event(
+        pubKey: authorKey.publicKey,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'signed now publish later',
+        createdAt: 1_700_000_082,
+      );
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [publishRelay.url],
+            timeout: const Duration(milliseconds: 300),
+          )
+          .broadcastDoneFuture;
+
+      final localSignedWhilePublishOffline = await ndk.requests
+          .query(
+            filter: Filter(ids: [event.id]),
+            cacheRead: true,
+            cacheWrite: false,
+            timeout: const Duration(milliseconds: 300),
+          )
+          .future;
+      expect(
+        localSignedWhilePublishOffline.map((e) => e.id),
+        contains(event.id),
+      );
+
+      await Future<void>.delayed(const Duration(seconds: 2));
+      expect(
+        publishRelay.receivedEvents.where((e) => e.id == event.id),
+        isEmpty,
+        reason: 'Even if signing succeeds immediately, target relay delivery should stay queued while the publish relay is still offline.',
+      );
+
+      await publishRelay.startServer();
+      await _waitForRelayConnected(
+        ndk: ndk,
+        relayUrl: publishRelay.url,
+        timeout: const Duration(seconds: 15),
+      );
+
+      final relayAfterPublishReconnect = await _waitForRelayEvents(
+        relay: publishRelay,
+        filter: Filter(ids: [event.id]),
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(
+        relayAfterPublishReconnect.map((e) => e.id),
+        contains(event.id),
+        reason: 'After signing succeeded while the publish relay was offline, the queued signed event should later be delivered once that relay reconnects.',
+      );
+
+      await publishRelay.stopServer();
+      await signerRelay.stopServer();
+    });
   });
 }
 

--- a/packages/ndk/test/usecases/nip05/nip05_network.test.mocks.dart
+++ b/packages/ndk/test/usecases/nip05/nip05_network.test.mocks.dart
@@ -46,28 +46,26 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#head, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#head, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#head, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#get, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#get, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#get, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -75,25 +73,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #post,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #post,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #post,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #post,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -101,25 +97,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #put,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #put,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #put,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #put,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -127,25 +121,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #patch,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #patch,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #patch,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #patch,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -153,62 +145,53 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #delete,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #delete,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #delete,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #delete,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#read, [url], {#headers: headers}),
+        returnValue: _i3.Future<String>.value(
+          _i5.dummyValue<String>(
+            this,
             Invocation.method(#read, [url], {#headers: headers}),
-            returnValue: _i3.Future<String>.value(
-              _i5.dummyValue<String>(
-                this,
-                Invocation.method(#read, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<String>);
+          ),
+        ),
+      ) as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
     Uri? url, {
     Map<String, String>? headers,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#readBytes, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-          )
-          as _i3.Future<_i6.Uint8List>);
+  }) => (super.noSuchMethod(
+    Invocation.method(#readBytes, [url], {#headers: headers}),
+    returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+  ) as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-            Invocation.method(#send, [request]),
-            returnValue: _i3.Future<_i2.StreamedResponse>.value(
-              _FakeStreamedResponse_1(
-                this,
-                Invocation.method(#send, [request]),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.StreamedResponse>);
+        Invocation.method(#send, [request]),
+        returnValue: _i3.Future<_i2.StreamedResponse>.value(
+          _FakeStreamedResponse_1(this, Invocation.method(#send, [request])),
+        ),
+      ) as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(

--- a/packages/ndk/test/usecases/nip05/nip05_network_test.mocks.dart
+++ b/packages/ndk/test/usecases/nip05/nip05_network_test.mocks.dart
@@ -48,28 +48,26 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#head, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#head, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#head, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#get, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#get, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#get, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -77,25 +75,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #post,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #post,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #post,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #post,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -103,25 +99,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #put,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #put,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #put,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #put,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -129,25 +123,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #patch,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #patch,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #patch,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #patch,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -155,62 +147,53 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #delete,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #delete,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #delete,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #delete,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#read, [url], {#headers: headers}),
+        returnValue: _i3.Future<String>.value(
+          _i5.dummyValue<String>(
+            this,
             Invocation.method(#read, [url], {#headers: headers}),
-            returnValue: _i3.Future<String>.value(
-              _i5.dummyValue<String>(
-                this,
-                Invocation.method(#read, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<String>);
+          ),
+        ),
+      ) as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
     Uri? url, {
     Map<String, String>? headers,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#readBytes, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-          )
-          as _i3.Future<_i6.Uint8List>);
+  }) => (super.noSuchMethod(
+    Invocation.method(#readBytes, [url], {#headers: headers}),
+    returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+  ) as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-            Invocation.method(#send, [request]),
-            returnValue: _i3.Future<_i2.StreamedResponse>.value(
-              _FakeStreamedResponse_1(
-                this,
-                Invocation.method(#send, [request]),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.StreamedResponse>);
+        Invocation.method(#send, [request]),
+        returnValue: _i3.Future<_i2.StreamedResponse>.value(
+          _FakeStreamedResponse_1(this, Invocation.method(#send, [request])),
+        ),
+      ) as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(

--- a/packages/ndk/test/usecases/nwc/nostr_wallet_connect_uri_test.dart
+++ b/packages/ndk/test/usecases/nwc/nostr_wallet_connect_uri_test.dart
@@ -34,25 +34,22 @@ void main() {
       );
       expect(nostrUri.secret, equals('secret123'));
     });
-    test(
-      'should parse a connection URI with multiple individual relay parameters',
-      () {
-        final uri =
-            'nostr+walletconnect://pubkey123?relay=wss://relay1.example.com&relay=wss://relay2.example.com&relay=wss://relay3.example.com&secret=secret123';
-        final nostrUri = NostrWalletConnectUri.parseConnectionUri(uri);
+    test('should parse a connection URI with multiple individual relay parameters', () {
+      final uri =
+          'nostr+walletconnect://pubkey123?relay=wss://relay1.example.com&relay=wss://relay2.example.com&relay=wss://relay3.example.com&secret=secret123';
+      final nostrUri = NostrWalletConnectUri.parseConnectionUri(uri);
 
-        expect(nostrUri.walletPubkey, equals('pubkey123'));
-        expect(
-          nostrUri.relays,
-          equals([
-            'wss://relay1.example.com',
-            'wss://relay2.example.com',
-            'wss://relay3.example.com',
-          ]),
-        );
-        expect(nostrUri.secret, equals('secret123'));
-      },
-    );
+      expect(nostrUri.walletPubkey, equals('pubkey123'));
+      expect(
+        nostrUri.relays,
+        equals([
+          'wss://relay1.example.com',
+          'wss://relay2.example.com',
+          'wss://relay3.example.com',
+        ]),
+      );
+      expect(nostrUri.secret, equals('secret123'));
+    });
 
     test('should parse a connection URI with mixed relay parameters', () {
       final uri =
@@ -257,20 +254,14 @@ void main() {
       expect(parsedUri, equals(originalUri));
     });
 
-    test(
-      'should parse a connection URI with comma-separated relays in the relay parameter',
-      () {
-        final uri =
-            'nostr+walletconnect://pubkey123?relay=wss://relay1.com,wss://relay2.com&secret=secret123';
-        final nostrUri = NostrWalletConnectUri.parseConnectionUri(uri);
+    test('should parse a connection URI with comma-separated relays in the relay parameter', () {
+      final uri =
+          'nostr+walletconnect://pubkey123?relay=wss://relay1.com,wss://relay2.com&secret=secret123';
+      final nostrUri = NostrWalletConnectUri.parseConnectionUri(uri);
 
-        expect(nostrUri.walletPubkey, equals('pubkey123'));
-        expect(
-          nostrUri.relays,
-          equals(['wss://relay1.com', 'wss://relay2.com']),
-        );
-        expect(nostrUri.secret, equals('secret123'));
-      },
-    );
+      expect(nostrUri.walletPubkey, equals('pubkey123'));
+      expect(nostrUri.relays, equals(['wss://relay1.com', 'wss://relay2.com']));
+      expect(nostrUri.secret, equals('secret123'));
+    });
   });
 }

--- a/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
+++ b/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
@@ -168,34 +168,31 @@ void main() {
       );
     });
 
-    test(
-      'periodic retry forces reconnect for disconnected relays with due targets',
-      () async {
-        final now = Nip01Event.secondsSinceEpoch();
-        await cacheManager.saveRelayDeliveryTarget(
-          RelayDeliveryTarget(
-            eventId: event.id,
-            relayUrl: 'wss://relay.example',
-            reason: RelayDeliveryReason.explicit,
-            state: RelayDeliveryState.pending,
-            attemptCount: 0,
-            lastAttemptAt: now - 60,
-            nextRetryAt: now - 1,
-          ),
-        );
+    test('periodic retry forces reconnect for disconnected relays with due targets', () async {
+      final now = Nip01Event.secondsSinceEpoch();
+      await cacheManager.saveRelayDeliveryTarget(
+        RelayDeliveryTarget(
+          eventId: event.id,
+          relayUrl: 'wss://relay.example',
+          reason: RelayDeliveryReason.explicit,
+          state: RelayDeliveryState.pending,
+          attemptCount: 0,
+          lastAttemptAt: now - 60,
+          nextRetryAt: now - 1,
+        ),
+      );
 
-        await pendingDelivery.retryDueDeliveries(
-          connectedRelayUrls: () => const <String>[],
-          reconnectRelay: (relayUrl) async {
-            reconnectAttempts.add(relayUrl);
-            return true;
-          },
-        );
+      await pendingDelivery.retryDueDeliveries(
+        connectedRelayUrls: () => const <String>[],
+        reconnectRelay: (relayUrl) async {
+          reconnectAttempts.add(relayUrl);
+          return true;
+        },
+      );
 
-        expect(reconnectAttempts, ['wss://relay.example']);
-        expect(broadcast.broadcastedEvents.map((e) => e.id), [event.id]);
-      },
-    );
+      expect(reconnectAttempts, ['wss://relay.example']);
+      expect(broadcast.broadcastedEvents.map((e) => e.id), [event.id]);
+    });
 
     test(
       'purges ephemeral event and sidecars once delivery is complete',
@@ -227,14 +224,16 @@ void main() {
           ),
         );
 
-        await pendingDelivery
-            .persistSpecificRelayBroadcastResult(ephemeralEvent, [
-              RelayBroadcastResponse(
-                relayUrl: 'wss://relay.example',
-                okReceived: true,
-                broadcastSuccessful: true,
-              ),
-            ]);
+        await pendingDelivery.persistSpecificRelayBroadcastResult(
+          ephemeralEvent,
+          [
+            RelayBroadcastResponse(
+              relayUrl: 'wss://relay.example',
+              okReceived: true,
+              broadcastSuccessful: true,
+            ),
+          ],
+        );
 
         expect(await cacheManager.loadEvent(ephemeralEvent.id), isNull);
         expect(
@@ -250,56 +249,55 @@ void main() {
       },
     );
 
-    test(
-      'keeps ephemeral event cached while delivery is not yet terminal',
-      () async {
-        final ephemeralEvent = Nip01Event(
-          id: 'ephemeral-auth',
-          pubKey: 'pubkey',
-          createdAt: 1700000000,
-          kind: 21000,
-          tags: const [],
-          content: 'ephemeral awaiting auth',
-          sig: 'sig',
-        );
-        await cacheManager.saveEvent(ephemeralEvent);
-        await cacheManager.saveEventDeliveryRecord(
-          EventDeliveryRecord(
-            eventId: ephemeralEvent.id,
-            status: EventDeliveryStatus.pending,
-            createdAt: ephemeralEvent.createdAt,
-            updatedAt: ephemeralEvent.createdAt,
-          ),
-        );
-        await cacheManager.saveRelayDeliveryTarget(
-          RelayDeliveryTarget(
-            eventId: ephemeralEvent.id,
+    test('keeps ephemeral event cached while delivery is not yet terminal', () async {
+      final ephemeralEvent = Nip01Event(
+        id: 'ephemeral-auth',
+        pubKey: 'pubkey',
+        createdAt: 1700000000,
+        kind: 21000,
+        tags: const [],
+        content: 'ephemeral awaiting auth',
+        sig: 'sig',
+      );
+      await cacheManager.saveEvent(ephemeralEvent);
+      await cacheManager.saveEventDeliveryRecord(
+        EventDeliveryRecord(
+          eventId: ephemeralEvent.id,
+          status: EventDeliveryStatus.pending,
+          createdAt: ephemeralEvent.createdAt,
+          updatedAt: ephemeralEvent.createdAt,
+        ),
+      );
+      await cacheManager.saveRelayDeliveryTarget(
+        RelayDeliveryTarget(
+          eventId: ephemeralEvent.id,
+          relayUrl: 'wss://relay.example',
+          reason: RelayDeliveryReason.explicit,
+          state: RelayDeliveryState.pending,
+        ),
+      );
+
+      // auth-required is a non-terminal outcome (status -> needsAction), so the
+      // event and its delivery state must survive for a later auth-gated retry.
+      await pendingDelivery.persistSpecificRelayBroadcastResult(
+        ephemeralEvent,
+        [
+          RelayBroadcastResponse(
             relayUrl: 'wss://relay.example',
-            reason: RelayDeliveryReason.explicit,
-            state: RelayDeliveryState.pending,
+            okReceived: false,
+            broadcastSuccessful: false,
+            msg: 'auth-required: need to authenticate',
           ),
-        );
+        ],
+      );
 
-        // auth-required is a non-terminal outcome (status -> needsAction), so the
-        // event and its delivery state must survive for a later auth-gated retry.
-        await pendingDelivery
-            .persistSpecificRelayBroadcastResult(ephemeralEvent, [
-              RelayBroadcastResponse(
-                relayUrl: 'wss://relay.example',
-                okReceived: false,
-                broadcastSuccessful: false,
-                msg: 'auth-required: need to authenticate',
-              ),
-            ]);
-
-        expect(await cacheManager.loadEvent(ephemeralEvent.id), isNotNull);
-        final record = await cacheManager.loadEventDeliveryRecord(
-          ephemeralEvent.id,
-        );
-        expect(record, isNotNull);
-        expect(record!.status, EventDeliveryStatus.needsAction);
-      },
-    );
+      expect(await cacheManager.loadEvent(ephemeralEvent.id), isNotNull);
+      final record = await cacheManager.loadEventDeliveryRecord(
+        ephemeralEvent.id,
+      );
+      expect(record, isNotNull);
+      expect(record!.status, EventDeliveryStatus.needsAction);
+    });
 
     test('signs remote-signer events before broadcasting', () async {
       final unsignedEvent = Nip01Event(
@@ -348,33 +346,30 @@ void main() {
       expect(broadcast.broadcastedEvents.single.sig, 'remote-sig');
     });
 
-    test(
-      'replays pending delivery from serialized record when event row is missing',
-      () async {
-        final serializedRecord = EventDeliveryRecord(
-          eventId: event.id,
-          status: EventDeliveryStatus.pending,
-          createdAt: event.createdAt,
-          updatedAt: event.createdAt,
-          serializedEventJson: Nip01EventModel.fromEntity(event).toJsonString(),
-        );
-        await cacheManager.saveEventDeliveryRecord(serializedRecord);
-        await cacheManager.saveRelayDeliveryTarget(
-          const RelayDeliveryTarget(
-            eventId: 'event-1',
-            relayUrl: 'wss://relay.example',
-            reason: RelayDeliveryReason.explicit,
-          ),
-        );
-        cacheManager.events.remove(event.id);
+    test('replays pending delivery from serialized record when event row is missing', () async {
+      final serializedRecord = EventDeliveryRecord(
+        eventId: event.id,
+        status: EventDeliveryStatus.pending,
+        createdAt: event.createdAt,
+        updatedAt: event.createdAt,
+        serializedEventJson: Nip01EventModel.fromEntity(event).toJsonString(),
+      );
+      await cacheManager.saveEventDeliveryRecord(serializedRecord);
+      await cacheManager.saveRelayDeliveryTarget(
+        const RelayDeliveryTarget(
+          eventId: 'event-1',
+          relayUrl: 'wss://relay.example',
+          reason: RelayDeliveryReason.explicit,
+        ),
+      );
+      cacheManager.events.remove(event.id);
 
-        await pendingDelivery.flushForRelay('wss://relay.example');
+      await pendingDelivery.flushForRelay('wss://relay.example');
 
-        expect(broadcast.broadcastedEvents.map((e) => e.id), [event.id]);
-        final restoredEvent = await cacheManager.loadEvent(event.id);
-        expect(restoredEvent?.content, event.content);
-      },
-    );
+      expect(broadcast.broadcastedEvents.map((e) => e.id), [event.id]);
+      final restoredEvent = await cacheManager.loadEvent(event.id);
+      expect(restoredEvent?.content, event.content);
+    });
 
     test(
       'rejected remote signing becomes needsAction and does not broadcast',
@@ -431,85 +426,80 @@ void main() {
       },
     );
 
-    test(
-      'timed out signing attempt does not block a later retry forever if the original future never completes',
-      () async {
-        await pendingDelivery.stop();
-        pendingDelivery = PendingBroadcastDelivery(
-          cacheManager: cacheManager,
-          broadcastSender: broadcast,
-          accounts: accounts,
-          signAttemptTimeout: const Duration(milliseconds: 20),
-        );
+    test('timed out signing attempt does not block a later retry forever if the original future never completes', () async {
+      await pendingDelivery.stop();
+      pendingDelivery = PendingBroadcastDelivery(
+        cacheManager: cacheManager,
+        broadcastSender: broadcast,
+        accounts: accounts,
+        signAttemptTimeout: const Duration(milliseconds: 20),
+      );
 
-        final hangingCompleter = Completer<Nip01Event>();
-        var signAttempts = 0;
-        final unsignedEvent = Nip01Event(
-          id: 'event-remote-timeout-stall',
-          pubKey: 'remote-timeout-stall-pubkey',
-          createdAt: 1700000250,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'first sign hangs forever',
-        );
-        final signer = _RemoteTestSigner(
-          pubKey: unsignedEvent.pubKey,
-          onSign: (event) {
-            signAttempts += 1;
-            if (signAttempts == 1) {
-              return hangingCompleter.future;
-            }
-            return Future.value(event.copyWith(sig: 'signed-after-retry'));
-          },
-        );
-        accounts.loginExternalSigner(signer: signer);
+      final hangingCompleter = Completer<Nip01Event>();
+      var signAttempts = 0;
+      final unsignedEvent = Nip01Event(
+        id: 'event-remote-timeout-stall',
+        pubKey: 'remote-timeout-stall-pubkey',
+        createdAt: 1700000250,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'first sign hangs forever',
+      );
+      final signer = _RemoteTestSigner(
+        pubKey: unsignedEvent.pubKey,
+        onSign: (event) {
+          signAttempts += 1;
+          if (signAttempts == 1) {
+            return hangingCompleter.future;
+          }
+          return Future.value(event.copyWith(sig: 'signed-after-retry'));
+        },
+      );
+      accounts.loginExternalSigner(signer: signer);
 
-        await cacheManager.saveEvent(unsignedEvent);
-        await cacheManager.saveEventDeliveryRecord(
-          EventDeliveryRecord(
-            eventId: unsignedEvent.id,
-            status: EventDeliveryStatus.pending,
-            signingState: EventSigningState.pending,
-            createdAt: unsignedEvent.createdAt,
-            updatedAt: unsignedEvent.createdAt,
-            requiresInteractiveSigning: true,
-          ),
-        );
-        await cacheManager.saveRelayDeliveryTarget(
-          const RelayDeliveryTarget(
-            eventId: 'event-remote-timeout-stall',
-            relayUrl: 'wss://relay.example',
-            reason: RelayDeliveryReason.explicit,
-          ),
-        );
+      await cacheManager.saveEvent(unsignedEvent);
+      await cacheManager.saveEventDeliveryRecord(
+        EventDeliveryRecord(
+          eventId: unsignedEvent.id,
+          status: EventDeliveryStatus.pending,
+          signingState: EventSigningState.pending,
+          createdAt: unsignedEvent.createdAt,
+          updatedAt: unsignedEvent.createdAt,
+          requiresInteractiveSigning: true,
+        ),
+      );
+      await cacheManager.saveRelayDeliveryTarget(
+        const RelayDeliveryTarget(
+          eventId: 'event-remote-timeout-stall',
+          relayUrl: 'wss://relay.example',
+          reason: RelayDeliveryReason.explicit,
+        ),
+      );
 
-        await pendingDelivery.flushForRelay('wss://relay.example');
+      await pendingDelivery.flushForRelay('wss://relay.example');
 
-        final afterTimeoutRecord = await cacheManager.loadEventDeliveryRecord(
-          unsignedEvent.id,
-        );
-        expect(
-          afterTimeoutRecord?.signingState,
-          EventSigningState.transientFailure,
-        );
-        expect(signer.signCallCount, 1);
-        expect(broadcast.broadcastedEvents, isEmpty);
+      final afterTimeoutRecord = await cacheManager.loadEventDeliveryRecord(
+        unsignedEvent.id,
+      );
+      expect(
+        afterTimeoutRecord?.signingState,
+        EventSigningState.transientFailure,
+      );
+      expect(signer.signCallCount, 1);
+      expect(broadcast.broadcastedEvents, isEmpty);
 
-        await pendingDelivery.flushForRelay('wss://relay.example');
+      await pendingDelivery.flushForRelay('wss://relay.example');
 
-        final savedEvent = await cacheManager.loadEvent(unsignedEvent.id);
-        final savedRecord = await cacheManager.loadEventDeliveryRecord(
-          unsignedEvent.id,
-        );
+      final savedEvent = await cacheManager.loadEvent(unsignedEvent.id);
+      final savedRecord = await cacheManager.loadEventDeliveryRecord(
+        unsignedEvent.id,
+      );
 
-        expect(signer.signCallCount, 2);
-        expect(savedEvent?.sig, 'signed-after-retry');
-        expect(savedRecord?.signingState, EventSigningState.signed);
-        expect(broadcast.broadcastedEvents.map((e) => e.id), [
-          unsignedEvent.id,
-        ]);
-      },
-    );
+      expect(signer.signCallCount, 2);
+      expect(savedEvent?.sig, 'signed-after-retry');
+      expect(savedRecord?.signingState, EventSigningState.signed);
+      expect(broadcast.broadcastedEvents.map((e) => e.id), [unsignedEvent.id]);
+    });
 
     test(
       'skips network signer attempt while signer transport relays are offline',
@@ -571,71 +561,66 @@ void main() {
       },
     );
 
-    test(
-      'transport relay opening retries network signing and immediately flushes connected targets',
-      () async {
-        pendingDelivery.startPeriodicRetry(
-          connectedRelayUrls: () => const <String>{
-            'wss://bunker-relay.example',
-            'wss://target-relay.example',
-          },
-          reconnectRelay: (_) async => false,
-          retryInterval: const Duration(hours: 1),
-        );
-
-        final unsignedEvent = Nip01Event(
-          id: 'event-bunker-online',
-          pubKey: 'bunker-online-pubkey',
-          createdAt: 1700000400,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'online bunker',
-        );
-        final signer = _RemoteTestSigner(
-          pubKey: unsignedEvent.pubKey,
-          requiresSignerNetwork: true,
-          transportRelayUrls: const ['wss://bunker-relay.example'],
-          onSign: (event) async => event.copyWith(sig: 'bunker-sig'),
-        );
-        accounts.loginExternalSigner(signer: signer);
-
-        await cacheManager.saveEvent(unsignedEvent);
-        await cacheManager.saveEventDeliveryRecord(
-          EventDeliveryRecord(
-            eventId: unsignedEvent.id,
-            status: EventDeliveryStatus.pending,
-            signingState: EventSigningState.pending,
-            createdAt: unsignedEvent.createdAt,
-            updatedAt: unsignedEvent.createdAt,
-            requiresInteractiveSigning: true,
-          ),
-        );
-        await cacheManager.saveRelayDeliveryTarget(
-          const RelayDeliveryTarget(
-            eventId: 'event-bunker-online',
-            relayUrl: 'wss://target-relay.example',
-            reason: RelayDeliveryReason.explicit,
-          ),
-        );
-
-        await pendingDelivery.retryInteractiveSigningForTransportRelay(
+    test('transport relay opening retries network signing and immediately flushes connected targets', () async {
+      pendingDelivery.startPeriodicRetry(
+        connectedRelayUrls: () => const <String>{
           'wss://bunker-relay.example',
-        );
+          'wss://target-relay.example',
+        },
+        reconnectRelay: (_) async => false,
+        retryInterval: const Duration(hours: 1),
+      );
 
-        final savedEvent = await cacheManager.loadEvent(unsignedEvent.id);
-        final savedRecord = await cacheManager.loadEventDeliveryRecord(
-          unsignedEvent.id,
-        );
+      final unsignedEvent = Nip01Event(
+        id: 'event-bunker-online',
+        pubKey: 'bunker-online-pubkey',
+        createdAt: 1700000400,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'online bunker',
+      );
+      final signer = _RemoteTestSigner(
+        pubKey: unsignedEvent.pubKey,
+        requiresSignerNetwork: true,
+        transportRelayUrls: const ['wss://bunker-relay.example'],
+        onSign: (event) async => event.copyWith(sig: 'bunker-sig'),
+      );
+      accounts.loginExternalSigner(signer: signer);
 
-        expect(signer.signCallCount, 1);
-        expect(savedEvent?.sig, 'bunker-sig');
-        expect(savedRecord?.signingState, EventSigningState.signed);
-        expect(broadcast.broadcastedEvents.map((e) => e.id), [
-          unsignedEvent.id,
-        ]);
-        expect(broadcast.broadcastedEvents.single.sig, 'bunker-sig');
-      },
-    );
+      await cacheManager.saveEvent(unsignedEvent);
+      await cacheManager.saveEventDeliveryRecord(
+        EventDeliveryRecord(
+          eventId: unsignedEvent.id,
+          status: EventDeliveryStatus.pending,
+          signingState: EventSigningState.pending,
+          createdAt: unsignedEvent.createdAt,
+          updatedAt: unsignedEvent.createdAt,
+          requiresInteractiveSigning: true,
+        ),
+      );
+      await cacheManager.saveRelayDeliveryTarget(
+        const RelayDeliveryTarget(
+          eventId: 'event-bunker-online',
+          relayUrl: 'wss://target-relay.example',
+          reason: RelayDeliveryReason.explicit,
+        ),
+      );
+
+      await pendingDelivery.retryInteractiveSigningForTransportRelay(
+        'wss://bunker-relay.example',
+      );
+
+      final savedEvent = await cacheManager.loadEvent(unsignedEvent.id);
+      final savedRecord = await cacheManager.loadEventDeliveryRecord(
+        unsignedEvent.id,
+      );
+
+      expect(signer.signCallCount, 1);
+      expect(savedEvent?.sig, 'bunker-sig');
+      expect(savedRecord?.signingState, EventSigningState.signed);
+      expect(broadcast.broadcastedEvents.map((e) => e.id), [unsignedEvent.id]);
+      expect(broadcast.broadcastedEvents.single.sig, 'bunker-sig');
+    });
 
     test(
       'non-matching transport relay opening does not retry network signer',
@@ -756,55 +741,52 @@ void main() {
       },
     );
 
-    test(
-      'non-network interactive signer transient failure uses faster retry backoff',
-      () async {
-        final unsignedEvent = Nip01Event(
-          id: 'event-local-backoff',
-          pubKey: 'local-backoff-pubkey',
-          createdAt: 1700000700,
-          kind: Nip01Event.kTextNodeKind,
-          tags: const [],
-          content: 'backoff local',
-        );
-        final signer = _RemoteTestSigner(
-          pubKey: unsignedEvent.pubKey,
-          requiresSignerNetwork: false,
-          onSign: (_) => Future.error(Exception('temporary local failure')),
-        );
-        accounts.loginExternalSigner(signer: signer);
+    test('non-network interactive signer transient failure uses faster retry backoff', () async {
+      final unsignedEvent = Nip01Event(
+        id: 'event-local-backoff',
+        pubKey: 'local-backoff-pubkey',
+        createdAt: 1700000700,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'backoff local',
+      );
+      final signer = _RemoteTestSigner(
+        pubKey: unsignedEvent.pubKey,
+        requiresSignerNetwork: false,
+        onSign: (_) => Future.error(Exception('temporary local failure')),
+      );
+      accounts.loginExternalSigner(signer: signer);
 
-        await cacheManager.saveEvent(unsignedEvent);
-        await cacheManager.saveEventDeliveryRecord(
-          EventDeliveryRecord(
-            eventId: unsignedEvent.id,
-            status: EventDeliveryStatus.pending,
-            signingState: EventSigningState.pending,
-            createdAt: unsignedEvent.createdAt,
-            updatedAt: unsignedEvent.createdAt,
-            requiresInteractiveSigning: true,
-          ),
-        );
-        await cacheManager.saveRelayDeliveryTarget(
-          const RelayDeliveryTarget(
-            eventId: 'event-local-backoff',
-            relayUrl: 'wss://target-relay.example',
-            reason: RelayDeliveryReason.explicit,
-          ),
-        );
+      await cacheManager.saveEvent(unsignedEvent);
+      await cacheManager.saveEventDeliveryRecord(
+        EventDeliveryRecord(
+          eventId: unsignedEvent.id,
+          status: EventDeliveryStatus.pending,
+          signingState: EventSigningState.pending,
+          createdAt: unsignedEvent.createdAt,
+          updatedAt: unsignedEvent.createdAt,
+          requiresInteractiveSigning: true,
+        ),
+      );
+      await cacheManager.saveRelayDeliveryTarget(
+        const RelayDeliveryTarget(
+          eventId: 'event-local-backoff',
+          relayUrl: 'wss://target-relay.example',
+          reason: RelayDeliveryReason.explicit,
+        ),
+      );
 
-        await pendingDelivery.flushForRelay('wss://target-relay.example');
+      await pendingDelivery.flushForRelay('wss://target-relay.example');
 
-        final savedRecord = await cacheManager.loadEventDeliveryRecord(
-          unsignedEvent.id,
-        );
+      final savedRecord = await cacheManager.loadEventDeliveryRecord(
+        unsignedEvent.id,
+      );
 
-        expect(savedRecord?.signingState, EventSigningState.transientFailure);
-        expect(savedRecord, isNotNull);
-        expect(savedRecord!.nextSignRetryAt, isNotNull);
-        expect(savedRecord.nextSignRetryAt! - savedRecord.updatedAt, 5);
-      },
-    );
+      expect(savedRecord?.signingState, EventSigningState.transientFailure);
+      expect(savedRecord, isNotNull);
+      expect(savedRecord!.nextSignRetryAt, isNotNull);
+      expect(savedRecord.nextSignRetryAt! - savedRecord.updatedAt, 5);
+    });
   });
 }
 

--- a/packages/ndk/test/usecases/zaps/zap_receipt_test.mocks.dart
+++ b/packages/ndk/test/usecases/zaps/zap_receipt_test.mocks.dart
@@ -36,23 +36,16 @@ class MockNip01Event extends _i1.Mock implements _i2.Nip01Event {
   }
 
   @override
-  String get id =>
-      (super.noSuchMethod(
-            Invocation.getter(#id),
-            returnValue: _i3.dummyValue<String>(this, Invocation.getter(#id)),
-          )
-          as String);
+  String get id => (super.noSuchMethod(
+    Invocation.getter(#id),
+    returnValue: _i3.dummyValue<String>(this, Invocation.getter(#id)),
+  ) as String);
 
   @override
-  String get pubKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#pubKey),
-            returnValue: _i3.dummyValue<String>(
-              this,
-              Invocation.getter(#pubKey),
-            ),
-          )
-          as String);
+  String get pubKey => (super.noSuchMethod(
+    Invocation.getter(#pubKey),
+    returnValue: _i3.dummyValue<String>(this, Invocation.getter(#pubKey)),
+  ) as String);
 
   @override
   int get createdAt =>
@@ -64,23 +57,16 @@ class MockNip01Event extends _i1.Mock implements _i2.Nip01Event {
       (super.noSuchMethod(Invocation.getter(#kind), returnValue: 0) as int);
 
   @override
-  List<List<String>> get tags =>
-      (super.noSuchMethod(
-            Invocation.getter(#tags),
-            returnValue: <List<String>>[],
-          )
-          as List<List<String>>);
+  List<List<String>> get tags => (super.noSuchMethod(
+    Invocation.getter(#tags),
+    returnValue: <List<String>>[],
+  ) as List<List<String>>);
 
   @override
-  String get content =>
-      (super.noSuchMethod(
-            Invocation.getter(#content),
-            returnValue: _i3.dummyValue<String>(
-              this,
-              Invocation.getter(#content),
-            ),
-          )
-          as String);
+  String get content => (super.noSuchMethod(
+    Invocation.getter(#content),
+    returnValue: _i3.dummyValue<String>(this, Invocation.getter(#content)),
+  ) as String);
 
   @override
   List<String> get sources =>
@@ -98,12 +84,10 @@ class MockNip01Event extends _i1.Mock implements _i2.Nip01Event {
           as List<String>);
 
   @override
-  List<String> get replyETags =>
-      (super.noSuchMethod(
-            Invocation.getter(#replyETags),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> get replyETags => (super.noSuchMethod(
+    Invocation.getter(#replyETags),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
   set id(String? value) => super.noSuchMethod(
@@ -128,43 +112,39 @@ class MockNip01Event extends _i1.Mock implements _i2.Nip01Event {
     String? sig,
     bool? validSig,
     List<String>? sources,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#copyWith, [], {
-              #id: id,
-              #pubKey: pubKey,
-              #createdAt: createdAt,
-              #kind: kind,
-              #tags: tags,
-              #content: content,
-              #sig: sig,
-              #validSig: validSig,
-              #sources: sources,
-            }),
-            returnValue: _FakeNip01Event_0(
-              this,
-              Invocation.method(#copyWith, [], {
-                #id: id,
-                #pubKey: pubKey,
-                #createdAt: createdAt,
-                #kind: kind,
-                #tags: tags,
-                #content: content,
-                #sig: sig,
-                #validSig: validSig,
-                #sources: sources,
-              }),
-            ),
-          )
-          as _i2.Nip01Event);
+  }) => (super.noSuchMethod(
+    Invocation.method(#copyWith, [], {
+      #id: id,
+      #pubKey: pubKey,
+      #createdAt: createdAt,
+      #kind: kind,
+      #tags: tags,
+      #content: content,
+      #sig: sig,
+      #validSig: validSig,
+      #sources: sources,
+    }),
+    returnValue: _FakeNip01Event_0(
+      this,
+      Invocation.method(#copyWith, [], {
+        #id: id,
+        #pubKey: pubKey,
+        #createdAt: createdAt,
+        #kind: kind,
+        #tags: tags,
+        #content: content,
+        #sig: sig,
+        #validSig: validSig,
+        #sources: sources,
+      }),
+    ),
+  ) as _i2.Nip01Event);
 
   @override
-  List<String> getTags(String? tag) =>
-      (super.noSuchMethod(
-            Invocation.method(#getTags, [tag]),
-            returnValue: <String>[],
-          )
-          as List<String>);
+  List<String> getTags(String? tag) => (super.noSuchMethod(
+    Invocation.method(#getTags, [tag]),
+    returnValue: <String>[],
+  ) as List<String>);
 
   @override
   String? getFirstTag(String? name) =>

--- a/packages/ndk/test/usecases/zaps/zaps_test.dart
+++ b/packages/ndk/test/usecases/zaps/zaps_test.dart
@@ -38,9 +38,8 @@ void main() {
       final link = 'https://domain.com/.well-known/lnurlp/name';
 
       // Mock the client.get method
-      when(
-        client.get(Uri.parse(link), headers: {"Accept": "application/json"}),
-      ).thenAnswer((_) async => http.Response(jsonEncode(response), 200));
+      when(client.get(Uri.parse(link), headers: {"Accept": "application/json"}))
+          .thenAnswer((_) async => http.Response(jsonEncode(response), 200));
 
       when(
         client.get(

--- a/packages/ndk/test/usecases/zaps/zaps_test.mocks.dart
+++ b/packages/ndk/test/usecases/zaps/zaps_test.mocks.dart
@@ -48,28 +48,26 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#head, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#head, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#head, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#get, [url], {#headers: headers}),
+        returnValue: _i3.Future<_i2.Response>.value(
+          _FakeResponse_0(
+            this,
             Invocation.method(#get, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(#get, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+          ),
+        ),
+      ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> post(
@@ -77,25 +75,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #post,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #post,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #post,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #post,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> put(
@@ -103,25 +99,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #put,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #put,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #put,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #put,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> patch(
@@ -129,25 +123,23 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #patch,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #patch,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #patch,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #patch,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<_i2.Response> delete(
@@ -155,62 +147,53 @@ class MockClient extends _i1.Mock implements _i2.Client {
     Map<String, String>? headers,
     Object? body,
     _i4.Encoding? encoding,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #delete,
-              [url],
-              {#headers: headers, #body: body, #encoding: encoding},
-            ),
-            returnValue: _i3.Future<_i2.Response>.value(
-              _FakeResponse_0(
-                this,
-                Invocation.method(
-                  #delete,
-                  [url],
-                  {#headers: headers, #body: body, #encoding: encoding},
-                ),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.Response>);
+  }) => (super.noSuchMethod(
+    Invocation.method(
+      #delete,
+      [url],
+      {#headers: headers, #body: body, #encoding: encoding},
+    ),
+    returnValue: _i3.Future<_i2.Response>.value(
+      _FakeResponse_0(
+        this,
+        Invocation.method(
+          #delete,
+          [url],
+          {#headers: headers, #body: body, #encoding: encoding},
+        ),
+      ),
+    ),
+  ) as _i3.Future<_i2.Response>);
 
   @override
   _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
+        Invocation.method(#read, [url], {#headers: headers}),
+        returnValue: _i3.Future<String>.value(
+          _i5.dummyValue<String>(
+            this,
             Invocation.method(#read, [url], {#headers: headers}),
-            returnValue: _i3.Future<String>.value(
-              _i5.dummyValue<String>(
-                this,
-                Invocation.method(#read, [url], {#headers: headers}),
-              ),
-            ),
-          )
-          as _i3.Future<String>);
+          ),
+        ),
+      ) as _i3.Future<String>);
 
   @override
   _i3.Future<_i6.Uint8List> readBytes(
     Uri? url, {
     Map<String, String>? headers,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#readBytes, [url], {#headers: headers}),
-            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
-          )
-          as _i3.Future<_i6.Uint8List>);
+  }) => (super.noSuchMethod(
+    Invocation.method(#readBytes, [url], {#headers: headers}),
+    returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
+  ) as _i3.Future<_i6.Uint8List>);
 
   @override
   _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
-            Invocation.method(#send, [request]),
-            returnValue: _i3.Future<_i2.StreamedResponse>.value(
-              _FakeStreamedResponse_1(
-                this,
-                Invocation.method(#send, [request]),
-              ),
-            ),
-          )
-          as _i3.Future<_i2.StreamedResponse>);
+        Invocation.method(#send, [request]),
+        returnValue: _i3.Future<_i2.StreamedResponse>.value(
+          _FakeStreamedResponse_1(this, Invocation.method(#send, [request])),
+        ),
+      ) as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(

--- a/packages/ndk/test/verifiers/event_id_verification_test.dart
+++ b/packages/ndk/test/verifiers/event_id_verification_test.dart
@@ -11,8 +11,7 @@ void main() {
       "kind": 1,
       "tags": [],
       "content": "content",
-      "sig":
-          "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607",
+      "sig": "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607",
     });
 
     expect(await Bip340EventVerifier().verify(event), isTrue);
@@ -27,8 +26,7 @@ void main() {
       "kind": 1,
       "tags": [],
       "content": "content",
-      "sig":
-          "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607",
+      "sig": "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607",
     });
 
     expect(await Bip340EventVerifier().verify(event), isFalse);
@@ -43,8 +41,7 @@ void main() {
       "kind": 1,
       "tags": [],
       "content": "content",
-      "sig":
-          "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607",
+      "sig": "eff0ae7d37d9739baa920fee76792974bfc0b27219a20c728dd143d8188395abb35ff6b09acbf0049a60f5c73b0a2a154f014bc02e08902c78f07f5c422ae607",
     });
 
     expect(await Bip340EventVerifier().verify(event), isFalse);

--- a/packages/ndk/test/verifiers/verify_event_stream_test.dart
+++ b/packages/ndk/test/verifiers/verify_event_stream_test.dart
@@ -240,39 +240,36 @@ void main() {
       await controller.close();
     });
 
-    test(
-      'should process events from non-closing stream with fewer events than maxConcurrent',
-      () async {
-        final controller = StreamController<Nip01Event>();
-        final resultList = <Nip01Event>[];
+    test('should process events from non-closing stream with fewer events than maxConcurrent', () async {
+      final controller = StreamController<Nip01Event>();
+      final resultList = <Nip01Event>[];
 
-        final verifyStream = VerifyEventStream(
-          unverifiedStreamInput: controller.stream,
-          eventVerifier: mockVerifier,
-          maxConcurrent: 10,
-        );
+      final verifyStream = VerifyEventStream(
+        unverifiedStreamInput: controller.stream,
+        eventVerifier: mockVerifier,
+        maxConcurrent: 10,
+      );
 
-        final subscription = verifyStream().listen((event) {
-          resultList.add(event);
-        });
+      final subscription = verifyStream().listen((event) {
+        resultList.add(event);
+      });
 
-        controller.add(createMockEvent('1'));
-        controller.add(createMockEvent('2'));
-        controller.add(createMockEvent('3'));
+      controller.add(createMockEvent('1'));
+      controller.add(createMockEvent('2'));
+      controller.add(createMockEvent('3'));
 
-        await Future.delayed(Duration(milliseconds: 100));
+      await Future.delayed(Duration(milliseconds: 100));
 
-        expect(
-          resultList.length,
-          equals(3),
-          reason:
-              'All events should be processed even when count < maxConcurrent',
-        );
+      expect(
+        resultList.length,
+        equals(3),
+        reason:
+            'All events should be processed even when count < maxConcurrent',
+      );
 
-        await subscription.cancel();
-        await controller.close();
-      },
-    );
+      await subscription.cancel();
+      await controller.close();
+    });
 
     test('should process events as they complete, not in order', () async {
       final controller = StreamController<Nip01Event>();
@@ -315,49 +312,8 @@ void main() {
       await controller.close();
     });
 
-    test('should handle continuous stream of events without blocking', () async {
-      final controller = StreamController<Nip01Event>();
-      final resultList = <Nip01Event>[];
-
-      final verifyStream = VerifyEventStream(
-        unverifiedStreamInput: controller.stream,
-        eventVerifier: mockVerifier,
-        maxConcurrent: 3,
-      );
-
-      final subscription = verifyStream().listen((event) {
-        resultList.add(event);
-      });
-
-      for (int i = 0; i < 10; i++) {
-        controller.add(createMockEvent('$i'));
-
-        await Future.delayed(Duration(milliseconds: 10));
-
-        if (i >= 2) {
-          expect(
-            resultList.length,
-            greaterThan(0),
-            reason:
-                'Events should be processed continuously, not waiting for stream end',
-          );
-        }
-      }
-
-      await Future.delayed(Duration(milliseconds: 100));
-
-      expect(
-        resultList.length,
-        equals(10),
-        reason: 'All events should be processed from continuous stream',
-      );
-
-      await subscription.cancel();
-      await controller.close();
-    });
-
     test(
-      'should not deadlock when maxConcurrent is reached with non-closing stream',
+      'should handle continuous stream of events without blocking',
       () async {
         final controller = StreamController<Nip01Event>();
         final resultList = <Nip01Event>[];
@@ -365,30 +321,70 @@ void main() {
         final verifyStream = VerifyEventStream(
           unverifiedStreamInput: controller.stream,
           eventVerifier: mockVerifier,
-          maxConcurrent: 2,
+          maxConcurrent: 3,
         );
 
         final subscription = verifyStream().listen((event) {
           resultList.add(event);
         });
 
-        controller.add(createMockEvent('1'));
-        controller.add(createMockEvent('2'));
-        controller.add(createMockEvent('3'));
-        controller.add(createMockEvent('4'));
+        for (int i = 0; i < 10; i++) {
+          controller.add(createMockEvent('$i'));
 
-        await Future.delayed(Duration(milliseconds: 200));
+          await Future.delayed(Duration(milliseconds: 10));
+
+          if (i >= 2) {
+            expect(
+              resultList.length,
+              greaterThan(0),
+              reason: 'Events should be processed continuously, not waiting for stream end',
+            );
+          }
+        }
+
+        await Future.delayed(Duration(milliseconds: 100));
 
         expect(
           resultList.length,
-          equals(4),
-          reason: 'Should process all events without deadlocking',
+          equals(10),
+          reason: 'All events should be processed from continuous stream',
         );
 
         await subscription.cancel();
         await controller.close();
       },
     );
+
+    test('should not deadlock when maxConcurrent is reached with non-closing stream', () async {
+      final controller = StreamController<Nip01Event>();
+      final resultList = <Nip01Event>[];
+
+      final verifyStream = VerifyEventStream(
+        unverifiedStreamInput: controller.stream,
+        eventVerifier: mockVerifier,
+        maxConcurrent: 2,
+      );
+
+      final subscription = verifyStream().listen((event) {
+        resultList.add(event);
+      });
+
+      controller.add(createMockEvent('1'));
+      controller.add(createMockEvent('2'));
+      controller.add(createMockEvent('3'));
+      controller.add(createMockEvent('4'));
+
+      await Future.delayed(Duration(milliseconds: 200));
+
+      expect(
+        resultList.length,
+        equals(4),
+        reason: 'Should process all events without deadlocking',
+      );
+
+      await subscription.cancel();
+      await controller.close();
+    });
 
     test(
       'should yield events immediately upon verification completion',

--- a/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite_clear_all.dart
+++ b/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite_clear_all.dart
@@ -96,15 +96,13 @@ void _runClearAllTests(CacheManager Function() getCacheManager) {
       isNotNull,
     );
     expect(
-      (await cacheManager.getKeysets(
-        mintUrl: 'https://clearall.mint.com',
-      )).length,
+      (await cacheManager.getKeysets(mintUrl: 'https://clearall.mint.com'))
+          .length,
       equals(1),
     );
     expect(
-      (await cacheManager.getProofs(
-        mintUrl: 'https://clearall.mint.com',
-      )).length,
+      (await cacheManager.getProofs(mintUrl: 'https://clearall.mint.com'))
+          .length,
       equals(1),
     );
 
@@ -132,15 +130,13 @@ void _runClearAllTests(CacheManager Function() getCacheManager) {
       isNull,
     );
     expect(
-      (await cacheManager.getKeysets(
-        mintUrl: 'https://clearall.mint.com',
-      )).length,
+      (await cacheManager.getKeysets(mintUrl: 'https://clearall.mint.com'))
+          .length,
       equals(0),
     );
     expect(
-      (await cacheManager.getProofs(
-        mintUrl: 'https://clearall.mint.com',
-      )).length,
+      (await cacheManager.getProofs(mintUrl: 'https://clearall.mint.com'))
+          .length,
       equals(0),
     );
   });

--- a/packages/ndk_flutter/lib/l10n/app_localizations_de.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_de.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_en.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_es.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_es.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_fi.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_fi.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_fr.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_fr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_it.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_it.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_ja.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_ja.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_pl.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_pl.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_pt.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_pt.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_ru.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_ru.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_sk.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_sk.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/l10n/app_localizations_zh.dart
+++ b/packages/ndk_flutter/lib/l10n/app_localizations_zh.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/ndk_flutter/lib/widgets/locale_switcher/n_locale_switcher.dart
+++ b/packages/ndk_flutter/lib/widgets/locale_switcher/n_locale_switcher.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+
 import '../../l10n/app_localizations.dart';
 
 /// Widget that allows switching between available locales.

--- a/packages/ndk_flutter/lib/widgets/login/n_login.dart
+++ b/packages/ndk_flutter/lib/widgets/login/n_login.dart
@@ -321,9 +321,8 @@ class _NLoginState extends State<NLogin> {
   }
 
   Future<void> loginWithNip05(String nip05) async {
-    if (!RegExp(
-      r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
-    ).hasMatch(nip05)) {
+    if (!RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')
+        .hasMatch(nip05)) {
       controller.nip05LoginError = 1;
       return;
     }

--- a/packages/ndk_flutter/lib/widgets/picture/n_picture.dart
+++ b/packages/ndk_flutter/lib/widgets/picture/n_picture.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ndk/ndk.dart';
 import 'package:ndk_flutter/ndk_flutter.dart';
+
 import '../../utils/nip_avatar.dart';
 
 class NPicture extends StatelessWidget {

--- a/packages/ndk_flutter/lib/widgets/wallets/n_add_wallet_dialogs.dart
+++ b/packages/ndk_flutter/lib/widgets/wallets/n_add_wallet_dialogs.dart
@@ -1013,9 +1013,8 @@ Future<bool> showAddWalletTypeDialog(
                 const SizedBox(height: 8),
                 Text(
                   l10n.chooseWalletType,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+                  style: Theme.of(context).textTheme.bodyMedium
+                      ?.copyWith(color: Colors.grey),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 24),
@@ -1143,9 +1142,8 @@ Future<bool> showNwcConnectionOptionsDialog(
                 const SizedBox(height: 8),
                 Text(
                   l10n.chooseNwcMethod,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+                  style: Theme.of(context).textTheme.bodyMedium
+                      ?.copyWith(color: Colors.grey),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 24),

--- a/packages/ndk_flutter/lib/widgets/wallets/n_cashu_seed_backup_warning.dart
+++ b/packages/ndk_flutter/lib/widgets/wallets/n_cashu_seed_backup_warning.dart
@@ -94,9 +94,9 @@ class _NCashuSeedBackupWarningState extends State<NCashuSeedBackupWarning> {
                               vertical: 6,
                             ),
                             decoration: BoxDecoration(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.surfaceContainerHighest,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .surfaceContainerHighest,
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Text(

--- a/packages/objectbox/lib/data_layer/db/object_box/db_init_object_box.dart
+++ b/packages/objectbox/lib/data_layer/db/object_box/db_init_object_box.dart
@@ -1,5 +1,6 @@
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+
 import '../../../objectbox.g.dart'; // created by `flutter pub run build_runner build`
 
 class ObjectBoxInit {

--- a/packages/objectbox/lib/data_layer/db/object_box/schema/db_relay_set.dart
+++ b/packages/objectbox/lib/data_layer/db/object_box/schema/db_relay_set.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:ndk/entities.dart';
 import 'package:objectbox/objectbox.dart';
 

--- a/packages/objectbox/lib/data_layer/db/object_box/schema/db_user_relay_list.dart
+++ b/packages/objectbox/lib/data_layer/db/object_box/schema/db_user_relay_list.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:ndk/entities.dart';
 import 'package:objectbox/objectbox.dart';
 

--- a/packages/objectbox/lib/objectbox.g.dart
+++ b/packages/objectbox/lib/objectbox.g.dart
@@ -807,27 +807,21 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final nameParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 6);
-        final versionParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 8);
-        final descriptionParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 10);
+        final nameParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 6);
+        final versionParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 8);
+        final descriptionParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 10);
         final descriptionLongParam = const fb.StringReader(
           asciiOptimization: true,
         ).vTableGetNullable(buffer, rootOffset, 12);
-        final contactJsonParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 14, '');
-        final motdParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 16);
-        final iconUrlParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 18);
+        final contactJsonParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 14, '');
+        final motdParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 16);
+        final iconUrlParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 18);
         final urlsParam = const fb.ListReader<String>(
           fb.StringReader(asciiOptimization: true),
           lazy: false,
@@ -837,12 +831,10 @@ obx_int.ModelDefinition getObjectBoxModel() {
           rootOffset,
           22,
         );
-        final tosUrlParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 24);
-        final nutsJsonParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 26, '');
+        final tosUrlParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 24);
+        final nutsJsonParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 26, '');
         final object = DbCashuMintInfo(
           name: nameParam,
           version: versionParam,
@@ -882,12 +874,10 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final mintUrlParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final keysetIdParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
+        final mintUrlParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final keysetIdParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
         final counterParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
@@ -930,9 +920,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
             final filterHashParam = const fb.StringReader(
               asciiOptimization: true,
             ).vTableGet(buffer, rootOffset, 6, '');
-            final relayUrlParam = const fb.StringReader(
-              asciiOptimization: true,
-            ).vTableGet(buffer, rootOffset, 8, '');
+            final relayUrlParam = const fb.StringReader(asciiOptimization: true)
+                .vTableGet(buffer, rootOffset, 8, '');
             final rangeStartParam = const fb.Int64Reader().vTableGet(
               buffer,
               rootOffset,
@@ -1004,21 +993,18 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final pubKeyParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
+        final pubKeyParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
         final kindParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
           12,
           0,
         );
-        final contentParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 14, '');
-        final nostrIdParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
+        final contentParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 14, '');
+        final nostrIdParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
         final createdAtParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
@@ -1039,9 +1025,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
                 4,
                 0,
               )
-              ..sig = const fb.StringReader(
-                asciiOptimization: true,
-              ).vTableGetNullable(buffer, rootOffset, 16)
+              ..sig = const fb.StringReader(asciiOptimization: true)
+                  .vTableGetNullable(buffer, rootOffset, 16)
               ..validSig = const fb.BoolReader().vTableGetNullable(
                 buffer,
                 rootOffset,
@@ -1090,12 +1075,10 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final pubKeyParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final nip05Param = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
+        final pubKeyParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final nip05Param = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
         final validParam = const fb.BoolReader().vTableGet(
           buffer,
           rootOffset,
@@ -1151,24 +1134,20 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final idParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final nameParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
-        final pubKeyParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 10, '');
+        final idParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final nameParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
+        final pubKeyParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 10, '');
         final relayMinCountPerPubkeyParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
           12,
           0,
         );
-        final directionParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 14, '');
+        final directionParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 14, '');
         final relaysMapJsonParam = const fb.StringReader(
           asciiOptimization: true,
         ).vTableGet(buffer, rootOffset, 16, '');
@@ -1214,12 +1193,10 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final pubKeyParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final relaysJsonParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 12, '');
+        final pubKeyParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final relaysJsonParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 12, '');
         final createdAtParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
@@ -1273,19 +1250,16 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final idParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final typeParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
+        final idParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final typeParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
         final supportedUnitsParam = const fb.ListReader<String>(
           fb.StringReader(asciiOptimization: true),
           lazy: false,
         ).vTableGet(buffer, rootOffset, 10, []);
-        final nameParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 12, '');
+        final nameParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 12, '');
         final metadataJsonStringParam = const fb.StringReader(
           asciiOptimization: true,
         ).vTableGet(buffer, rootOffset, 14, '');
@@ -1330,15 +1304,12 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final idParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final mintUrlParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
-        final unitParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 10, '');
+        final idParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final mintUrlParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
+        final unitParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 10, '');
         final activeParam = const fb.BoolReader().vTableGet(
           buffer,
           rootOffset,
@@ -1399,24 +1370,20 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final keysetIdParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
+        final keysetIdParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
         final amountParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
           8,
           0,
         );
-        final secretParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 10, '');
-        final unblindedSigParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 12, '');
-        final stateParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 14, '');
+        final secretParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 10, '');
+        final unblindedSigParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 12, '');
+        final stateParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 14, '');
         final object = DbWalletCashuProof(
           keysetId: keysetIdParam,
           amount: amountParam,
@@ -1466,27 +1433,22 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final idParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final walletIdParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 8, '');
+        final idParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final walletIdParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 8, '');
         final changeAmountParam = const fb.Int64Reader().vTableGet(
           buffer,
           rootOffset,
           10,
           0,
         );
-        final unitParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 12, '');
-        final walletTypeParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 14, '');
-        final stateParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 16, '');
+        final unitParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 12, '');
+        final walletTypeParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 14, '');
+        final stateParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 16, '');
         final completionMsgParam = const fb.StringReader(
           asciiOptimization: true,
         ).vTableGetNullable(buffer, rootOffset, 18);
@@ -1542,12 +1504,10 @@ obx_int.ModelDefinition getObjectBoxModel() {
       objectFromFB: (obx.Store store, ByteData fbData) {
         final buffer = fb.BufferContext(fbData);
         final rootOffset = buffer.derefObject(0);
-        final keyParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGet(buffer, rootOffset, 6, '');
-        final valueParam = const fb.StringReader(
-          asciiOptimization: true,
-        ).vTableGetNullable(buffer, rootOffset, 8);
+        final keyParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGet(buffer, rootOffset, 6, '');
+        final valueParam = const fb.StringReader(asciiOptimization: true)
+            .vTableGetNullable(buffer, rootOffset, 8);
         final object = DbKeyValue(key: keyParam, value: valueParam)
           ..dbId = const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
 

--- a/packages/sample-app/lib/accounts_page.dart
+++ b/packages/sample-app/lib/accounts_page.dart
@@ -46,9 +46,8 @@ class _AccountsPageState extends State<AccountsPage> {
           const SizedBox(height: 8),
           Text(
             l10n.accountsDescription,
-            style: Theme.of(
-              context,
-            ).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+            style: Theme.of(context).textTheme.bodyMedium
+                ?.copyWith(color: Colors.grey),
           ),
           const SizedBox(height: 16),
           if (isLoggedIn)

--- a/packages/sample-app/lib/dm_page.dart
+++ b/packages/sample-app/lib/dm_page.dart
@@ -55,8 +55,7 @@ class _DmInboxPageState extends State<DmInboxPage> {
     final myPubKey = ndk.accounts.getPublicKey();
     if (myPubKey == null) {
       setState(() {
-        _error =
-            'Log in first. This demo needs a signer and your own kind:10050 DM relay list.';
+        _error = 'Log in first. This demo needs a signer and your own kind:10050 DM relay list.';
       });
       return;
     }
@@ -393,8 +392,7 @@ class _DmConversationPageState extends State<DmConversationPage> {
     final myPubKey = ndk.accounts.getPublicKey();
     if (myPubKey == null) {
       setState(() {
-        _error =
-            'Log in first. This demo needs a signer and your own kind:10050 DM relay list.';
+        _error = 'Log in first. This demo needs a signer and your own kind:10050 DM relay list.';
       });
       return;
     }
@@ -533,9 +531,9 @@ class _DmConversationPageState extends State<DmConversationPage> {
                         child: Card(
                           color: message.isOutgoing
                               ? Theme.of(context).colorScheme.primaryContainer
-                              : Theme.of(
-                                  context,
-                                ).colorScheme.surfaceContainerHighest,
+                              : Theme.of(context)
+                                    .colorScheme
+                                    .surfaceContainerHighest,
                           child: Padding(
                             padding: const EdgeInsets.all(12),
                             child: IntrinsicWidth(

--- a/packages/sample-app/lib/home_page.dart
+++ b/packages/sample-app/lib/home_page.dart
@@ -66,9 +66,9 @@ class _HomePageState extends State<HomePage> {
               final profileIcon = loggedPubkey == null
                   ? CircleAvatar(
                       radius: 14,
-                      backgroundColor: Theme.of(
-                        context,
-                      ).colorScheme.surfaceContainerHighest,
+                      backgroundColor: Theme.of(context)
+                          .colorScheme
+                          .surfaceContainerHighest,
                       child: Icon(
                         Icons.person_outline,
                         size: 16,

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_de.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_de.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_en.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_es.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_es.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_fr.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_fr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_it.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_it.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_ja.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_ja.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_pl.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_pl.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_ru.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_ru.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/l10n/generated/sample_app_localizations_zh.dart
+++ b/packages/sample-app/lib/l10n/generated/sample_app_localizations_zh.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'sample_app_localizations.dart';
 
 // ignore_for_file: type=lint

--- a/packages/sample-app/lib/nwc_page.dart
+++ b/packages/sample-app/lib/nwc_page.dart
@@ -40,11 +40,9 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
   GetBalanceResponse? balance;
 
   // State variables to hold context from the NIP-47 auth initiation
-  String?
-  _pendingDiscoveryRelayUrl; // The relay specified in the nostr+walletauth URI's 'relay=' param,
+  String? _pendingDiscoveryRelayUrl; // The relay specified in the nostr+walletauth URI's 'relay=' param,
   // where we expect the kind 13194 event to be.
-  String?
-  _pendingAppPubkeyForAuth; // Our app's pubkey that was sent in the nostr+walletauth URI's 'pubkey=' param
+  String? _pendingAppPubkeyForAuth; // Our app's pubkey that was sent in the nostr+walletauth URI's 'pubkey=' param
   // and expected in the 'p' tag of the kind 13194 event.
   MakeInvoiceResponse?
   makeInvoice; // Will store result of normal or hold invoice creation
@@ -52,8 +50,7 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
 
   // MakeInvoiceResponse? makeHoldInvoiceResponse; // Removed, merged into makeInvoice
   String? holdInvoicePreimage;
-  String?
-  holdInvoicePaymentHash; // Still needed to identify the hold invoice for notifications/settle/cancel
+  String? holdInvoicePaymentHash; // Still needed to identify the hold invoice for notifications/settle/cancel
   bool isHoldInvoice = false; // For the checkbox
   bool _currentInvoiceWasHold =
       false; // To track if the current 'makeInvoice' is a hold type
@@ -341,8 +338,7 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
               scheme: 'nostr+walletauth',
               host: nwcAppKey!.publicKey, // Our app's pubkey
               queryParameters: {
-                'relay':
-                    discoveryRelay, // Relay for discovering the kind 13194 event
+                'relay': discoveryRelay, // Relay for discovering the kind 13194 event
                 'name': appName,
                 'request_methods': methods,
                 'icon': appIcon,
@@ -354,8 +350,7 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
 
             // Store the context needed for when onProtocolUrlReceived is called.
             _pendingDiscoveryRelayUrl = discoveryRelay;
-            _pendingAppPubkeyForAuth = nwcAppKey!
-                .publicKey; // This is the pubkey our app uses for this auth flow.
+            _pendingAppPubkeyForAuth = nwcAppKey!.publicKey; // This is the pubkey our app uses for this auth flow.
 
             print(
               "Attempting to launch NIP-47 Auth URI: ${launchUri.toString()}",
@@ -404,16 +399,15 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
                 decoration: InputDecoration(
                   prefixIcon: IconButton(
                     onPressed: () {
-                      Clipboard.getData(Clipboard.kTextPlain).then((
-                        clipboardData,
-                      ) {
-                        if (clipboardData != null &&
-                            clipboardData.text != null) {
-                          setState(() {
-                            uri.text = clipboardData.text!;
+                      Clipboard.getData(Clipboard.kTextPlain)
+                          .then((clipboardData) {
+                            if (clipboardData != null &&
+                                clipboardData.text != null) {
+                              setState(() {
+                                uri.text = clipboardData.text!;
+                              });
+                            }
                           });
-                        }
-                      });
                     },
                     icon: const Icon(Icons.paste),
                   ),
@@ -613,8 +607,7 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
                               makeInvoice =
                                   response; // Store in the unified makeInvoice
                               if (response.errorCode == null) {
-                                holdInvoiceStatusMessage =
-                                    "Hold invoice created. Waiting for acceptance...";
+                                holdInvoiceStatusMessage = "Hold invoice created. Waiting for acceptance...";
                                 _listenForHoldInvoiceAcceptance(paymentHashHex);
                               } else {
                                 holdInvoiceStatusMessage =
@@ -643,8 +636,7 @@ class NwcPageState extends State<NwcPage> with WidgetsBindingObserver {
                             setState(() {
                               makeInvoice = response;
                               if (response.errorCode == null) {
-                                regularInvoiceStatusMessage =
-                                    "Regular invoice created. Waiting for payment...";
+                                regularInvoiceStatusMessage = "Regular invoice created. Waiting for payment...";
                                 _listenForRegularInvoicePayment(
                                   response.paymentHash,
                                 );

--- a/packages/sample-app/lib/pending_requests_page.dart
+++ b/packages/sample-app/lib/pending_requests_page.dart
@@ -365,9 +365,8 @@ class _PendingRequestsPageState extends State<PendingRequestsPage> {
           const SizedBox(height: 8),
           Text(
             l10n.pendingDescription,
-            style: Theme.of(
-              context,
-            ).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+            style: Theme.of(context).textTheme.bodyMedium
+                ?.copyWith(color: Colors.grey),
           ),
           const SizedBox(height: 16),
 
@@ -576,9 +575,8 @@ class _PendingRequestCard extends StatelessWidget {
             Row(
               children: [
                 CircleAvatar(
-                  backgroundColor: _getColorForMethod(
-                    method,
-                  ).withValues(alpha: 0.2),
+                  backgroundColor: _getColorForMethod(method)
+                      .withValues(alpha: 0.2),
                   child: Icon(
                     _getIconForMethod(method),
                     color: _getColorForMethod(method),

--- a/packages/sample-app/lib/quantum_secure_page.dart
+++ b/packages/sample-app/lib/quantum_secure_page.dart
@@ -123,9 +123,8 @@ class _QuantumSecurePageState extends State<QuantumSecurePage> {
       setState(() {
         _signTimeMs = null;
       });
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Error signing events: $e')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Error signing events: $e')));
     }
   }
 
@@ -173,9 +172,8 @@ class _QuantumSecurePageState extends State<QuantumSecurePage> {
         statusMessage += ' ($failedCount failed)';
       }
 
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(statusMessage)));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(statusMessage)));
 
       if (!allValid) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -187,9 +185,8 @@ class _QuantumSecurePageState extends State<QuantumSecurePage> {
         _verifyTimeMs = null;
         _failedVerifications = null;
       });
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Error verifying events: $e')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Error verifying events: $e')));
     }
   }
 

--- a/packages/sample-app/lib/widgets_demo_page.dart
+++ b/packages/sample-app/lib/widgets_demo_page.dart
@@ -270,16 +270,14 @@ class _WidgetsDemoPageState extends State<WidgetsDemoPage> {
       children: [
         Text(
           title,
-          style: Theme.of(
-            context,
-          ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+          style: Theme.of(context).textTheme.headlineSmall
+              ?.copyWith(fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 4),
         Text(
           description,
-          style: Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
+          style: Theme.of(context).textTheme.bodyMedium
+              ?.copyWith(color: Colors.grey[600]),
         ),
         const SizedBox(height: 12),
         child,

--- a/packages/sample-app/lib/zaps_page.dart
+++ b/packages/sample-app/lib/zaps_page.dart
@@ -58,16 +58,15 @@ class _ZapsPageState extends State<ZapsPage> {
                 decoration: InputDecoration(
                   prefixIcon: IconButton(
                     onPressed: () {
-                      Clipboard.getData(Clipboard.kTextPlain).then((
-                        clipboardData,
-                      ) {
-                        if (clipboardData != null &&
-                            clipboardData.text != null) {
-                          setState(() {
-                            uri.text = clipboardData.text!;
+                      Clipboard.getData(Clipboard.kTextPlain)
+                          .then((clipboardData) {
+                            if (clipboardData != null &&
+                                clipboardData.text != null) {
+                              setState(() {
+                                uri.text = clipboardData.text!;
+                              });
+                            }
                           });
-                        }
-                      });
                     },
                     icon: const Icon(Icons.paste),
                   ),


### PR DESCRIPTION
## Why

The latest stable Dart/Flutter release changed the formatter's output, so the `format` CI check went red.

## What

- `dart format --language-version=latest .` over the whole repo (137 files).
- Removed `final` from function parameters in `search.dart` and `contact_list.dart`. Dart 3.13 reserves `final` and `var` in parameter lists for primary constructors, so the formatter could not even parse those two files and silently skipped them.