### PR TITLE
fix!: replace GPL-3.0-only crystals-dilithium with fips204 (ML-DSA)

### DIFF
--- a/packages/ndk/lib/data_layer/repositories/signers/qs_rust_event_signer.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/qs_rust_event_signer.dart
@@ -1,7 +1,7 @@
 /// Quantum-secure event signer with platform-specific implementations.
 ///
 /// On native platforms (Android, iOS, Linux, macOS, Windows), this uses FFI
-/// to call Rust code for CRYSTALS-Dilithium signing.
+/// to call Rust code for ML-DSA (FIPS 204) signing.
 ///
 /// On web platforms, this exports a stub that throws [UnsupportedError].
 library;

--- a/packages/ndk/lib/data_layer/repositories/signers/qs_rust_event_signer_native.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/qs_rust_event_signer_native.dart
@@ -9,7 +9,7 @@ import '../../../domain_layer/entities/pending_signer_request.dart';
 import '../../../domain_layer/repositories/event_signer.dart';
 import '../../../src/rust_lib.dart' as rust_lib;
 
-/// Holds a Dilithium keypair (public key + full keypair bytes for signing).
+/// Holds an ML-DSA keypair (public key + full keypair bytes for signing).
 class QsKeypair {
   final Uint8List publicKeyBytes;
   final Uint8List keypairBytes;
@@ -23,9 +23,9 @@ class QsKeypair {
 }
 
 /// An implementation of [EventSigner] that uses quantum-secure
-/// CRYSTALS-Dilithium signatures via native Rust FFI.
+/// ML-DSA (FIPS 204) signatures via native Rust FFI.
 class QsRustEventSigner implements EventSigner {
-  /// The Dilithium security level (2, 3, or 5).
+  /// The ML-DSA parameter set: 44, 65 or 87.
   final int level;
 
   late final QsKeypair _keypair;
@@ -36,7 +36,7 @@ class QsRustEventSigner implements EventSigner {
   /// Creates a [QsRustEventSigner] from an existing [QsKeypair].
   ///
   /// Use [QsRustEventSigner.generate] to create a new keypair first.
-  QsRustEventSigner({required QsKeypair keypair, this.level = 2})
+  QsRustEventSigner({required QsKeypair keypair, this.level = 87})
     : _keypair = keypair;
 
   @override
@@ -48,10 +48,11 @@ class QsRustEventSigner implements EventSigner {
   @override
   Iterable<String> get signerTransportRelayUrls => const <String>[];
 
-  /// Generates a new Dilithium keypair.
+  /// Generates a new ML-DSA keypair.
   /// Its only added here for testing purposes!
   ///
-  /// [level] selects the security level: 2 (~AES-128), 3 (~AES-192), or 5 (~AES-256).
+  /// [level] selects the ML-DSA parameter set: 44 (~AES-128), 65 (~AES-192), or
+  /// 87 (~AES-256, the CNSA 2.0 set). The old Dilithium values 2/3/5 are rejected.
   ///
   /// Returns a [QsKeypair] that can be stored and later passed to the constructor.
   ///
@@ -59,10 +60,10 @@ class QsRustEventSigner implements EventSigner {
   ///
   /// Example:
   /// ```dart
-  /// final keypair = QsRustEventSigner.generateKeypair(level: 2);
-  /// final signer = QsRustEventSigner(keypair: keypair, level: 2);
+  /// final keypair = QsRustEventSigner.generateKeypair(level: 87);
+  /// final signer = QsRustEventSigner(keypair: keypair, level: 87);
   /// ```
-  static QsKeypair generateKeypair({int level = 2}) {
+  static QsKeypair generateKeypair({int level = 87}) {
     final outPk = calloc<rust_lib.QsBuffer>();
     final outSk = calloc<rust_lib.QsBuffer>();
 
@@ -71,7 +72,7 @@ class QsRustEventSigner implements EventSigner {
 
       if (result != 1) {
         throw StateError(
-          'Failed to generate Dilithium keypair at level $level',
+          'Failed to generate ML-DSA keypair at level $level',
         );
       }
 
@@ -126,7 +127,7 @@ class QsRustEventSigner implements EventSigner {
       );
 
       if (result != 1) {
-        throw StateError('Failed to sign event with Dilithium');
+        throw StateError('Failed to sign event with ML-DSA');
       }
 
       final sigLen = outSig.ref.len;

--- a/packages/ndk/lib/data_layer/repositories/signers/qs_rust_event_signer_stub.dart
+++ b/packages/ndk/lib/data_layer/repositories/signers/qs_rust_event_signer_stub.dart
@@ -24,7 +24,7 @@ class QsKeypair {
 class QsRustEventSigner implements EventSigner {
   final int level;
 
-  QsRustEventSigner({required QsKeypair keypair, this.level = 2});
+  QsRustEventSigner({required QsKeypair keypair, this.level = 87});
 
   @override
   bool get requiresInteractiveSigning => false;
@@ -35,7 +35,7 @@ class QsRustEventSigner implements EventSigner {
   @override
   Iterable<String> get signerTransportRelayUrls => const <String>[];
 
-  static QsKeypair generateKeypair({int level = 2}) {
+  static QsKeypair generateKeypair({int level = 87}) {
     throw UnsupportedError(
       'QsRustEventSigner is not available on this platform. '
       'FFI is not supported on web.',

--- a/packages/ndk/lib/data_layer/repositories/verifiers/qs_rust_event_verifier.dart
+++ b/packages/ndk/lib/data_layer/repositories/verifiers/qs_rust_event_verifier.dart
@@ -1,7 +1,7 @@
 /// Quantum-secure event verifier with platform-specific implementations.
 ///
 /// On native platforms (Android, iOS, Linux, macOS, Windows), this uses FFI
-/// to call Rust code for CRYSTALS-Dilithium verification.
+/// to call Rust code for ML-DSA (FIPS 204) verification.
 ///
 /// On web platforms, this exports a stub that throws [UnsupportedError].
 library;

--- a/packages/ndk/lib/data_layer/repositories/verifiers/qs_rust_event_verifier_native.dart
+++ b/packages/ndk/lib/data_layer/repositories/verifiers/qs_rust_event_verifier_native.dart
@@ -8,15 +8,15 @@ import '../../../domain_layer/repositories/event_verifier.dart';
 import '../../../src/rust_lib.dart' as rust_lib;
 
 /// An implementation of [EventVerifier] that uses quantum-secure
-/// CRYSTALS-Dilithium signatures via native Rust FFI.
+/// ML-DSA (FIPS 204) signatures via native Rust FFI.
 class QsRustEventVerifier implements EventVerifier {
-  /// The Dilithium security level (2, 3, or 5).
+  /// The ML-DSA parameter set: 44, 65 or 87.
   final int level;
 
   /// Creates a new instance of [QsRustEventVerifier].
   ///
   /// [level] defaults to 2 (NIST Security Level 2, ~AES-128).
-  QsRustEventVerifier({this.level = 2});
+  QsRustEventVerifier({this.level = 87});
 
   @override
   Future<bool> verify(Nip01Event event) async {

--- a/packages/ndk/lib/data_layer/repositories/verifiers/qs_rust_event_verifier_stub.dart
+++ b/packages/ndk/lib/data_layer/repositories/verifiers/qs_rust_event_verifier_stub.dart
@@ -7,7 +7,7 @@ import '../../../domain_layer/repositories/event_verifier.dart';
 class QsRustEventVerifier implements EventVerifier {
   final int level;
 
-  QsRustEventVerifier({this.level = 2});
+  QsRustEventVerifier({this.level = 87});
 
   @override
   Future<bool> verify(Nip01Event event) {

--- a/packages/ndk/lib/src/rust_lib.dart
+++ b/packages/ndk/lib/src/rust_lib.dart
@@ -16,18 +16,17 @@ final class QsBuffer extends Struct {
 /// Verifies a Nostr event signature.
 /// Returns 1 if valid, 0 if invalid.
 @Native<
-  Int32 Function(
-    Pointer<Utf8>, // eventIdHex
-    Pointer<Utf8>, // pubKeyHex
-    Uint64, // createdAt
-    Uint32, // kind
-    Pointer<Pointer<Utf8>>, // tagsData
-    Pointer<Uint32>, // tagsLengths
-    Uint32, // tagsCount
-    Pointer<Utf8>, // content
-    Pointer<Utf8>, // signatureHex
-  )
->(symbol: 'verify_nostr_event')
+    Int32 Function(
+      Pointer<Utf8>, // eventIdHex
+      Pointer<Utf8>, // pubKeyHex
+      Uint64, // createdAt
+      Uint32, // kind
+      Pointer<Pointer<Utf8>>, // tagsData
+      Pointer<Uint32>, // tagsLengths
+      Uint32, // tagsCount
+      Pointer<Utf8>, // content
+      Pointer<Utf8>, // signatureHex
+    )>(symbol: 'verify_nostr_event')
 external int verifyNostrEventNative(
   Pointer<Utf8> eventIdHex,
   Pointer<Utf8> pubKeyHex,
@@ -40,47 +39,55 @@ external int verifyNostrEventNative(
   Pointer<Utf8> signatureHex,
 );
 
-// ── Quantum-Secure Dilithium bindings ──────────────────────────────────
+// ── Quantum-Secure ML-DSA (FIPS 204) bindings ──────────────────────────
+//
+// These were CRYSTALS-Dilithium. NIST altered the algorithm during
+// standardisation, so Dilithium keys and signatures are not interoperable with
+// FIPS 204 ML-DSA. [level] now takes the ML-DSA parameter numbers - 44, 65 or 87 -
+// and the old Dilithium values 2, 3 and 5 are rejected rather than remapped, so a
+// caller that was not updated fails loudly instead of silently getting different
+// security properties than it asked for.
 
 /// Frees a QsBuffer previously returned by the Rust library.
 @Native<Void Function(QsBuffer)>(symbol: 'qs_free_buffer')
 external void qsFreeBuffer(QsBuffer buf);
 
-/// Generates a Dilithium keypair.
+/// Generates a random ML-DSA keypair.
 ///
-/// [level]: security level (2, 3, or 5).
+/// Prefer [qsDeriveKeypairFromSeed] for anything representing an identity: a
+/// random key cannot be restored from a mnemonic, so losing it loses the identity.
+///
+/// [level]: ML-DSA parameter set (44, 65, or 87).
 /// [outPk], [outSk]: pointers to QsBuffer structs that will be filled.
 /// Returns 1 on success, 0 on failure.
 @Native<
-  Int32 Function(
-    Uint32, // level
-    Pointer<QsBuffer>, // outPk
-    Pointer<QsBuffer>, // outSk
-  )
->(symbol: 'qs_generate_keypair')
+    Int32 Function(
+      Uint32, // level
+      Pointer<QsBuffer>, // outPk
+      Pointer<QsBuffer>, // outSk
+    )>(symbol: 'qs_generate_keypair')
 external int qsGenerateKeypair(
   int level,
   Pointer<QsBuffer> outPk,
   Pointer<QsBuffer> outSk,
 );
 
-/// Signs a message with a Dilithium secret key.
+/// Signs a message with an ML-DSA secret key (empty FIPS 204 context).
 ///
-/// [level]: security level (2, 3, or 5).
+/// [level]: ML-DSA parameter set (44, 65, or 87).
 /// [skPtr]/[skLen]: secret key bytes.
 /// [msgPtr]/[msgLen]: message bytes.
 /// [outSig]: pointer to QsBuffer that will receive the signature.
 /// Returns 1 on success, 0 on failure.
 @Native<
-  Int32 Function(
-    Uint32, // level
-    Pointer<Uint8>, // skPtr
-    IntPtr, // skLen
-    Pointer<Uint8>, // msgPtr
-    IntPtr, // msgLen
-    Pointer<QsBuffer>, // outSig
-  )
->(symbol: 'qs_sign')
+    Int32 Function(
+      Uint32, // level
+      Pointer<Uint8>, // skPtr
+      IntPtr, // skLen
+      Pointer<Uint8>, // msgPtr
+      IntPtr, // msgLen
+      Pointer<QsBuffer>, // outSig
+    )>(symbol: 'qs_sign')
 external int qsSign(
   int level,
   Pointer<Uint8> skPtr,
@@ -90,21 +97,20 @@ external int qsSign(
   Pointer<QsBuffer> outSig,
 );
 
-/// Verifies a Dilithium signature.
+/// Verifies an ML-DSA signature (empty FIPS 204 context).
 ///
-/// [level]: security level (2, 3, or 5).
+/// [level]: ML-DSA parameter set (44, 65, or 87).
 /// Returns 1 if valid, 0 if invalid.
 @Native<
-  Int32 Function(
-    Uint32, // level
-    Pointer<Uint8>, // pkPtr
-    IntPtr, // pkLen
-    Pointer<Uint8>, // msgPtr
-    IntPtr, // msgLen
-    Pointer<Uint8>, // sigPtr
-    IntPtr, // sigLen
-  )
->(symbol: 'qs_verify')
+    Int32 Function(
+      Uint32, // level
+      Pointer<Uint8>, // pkPtr
+      IntPtr, // pkLen
+      Pointer<Uint8>, // msgPtr
+      IntPtr, // msgLen
+      Pointer<Uint8>, // sigPtr
+      IntPtr, // sigLen
+    )>(symbol: 'qs_verify')
 external int qsVerify(
   int level,
   Pointer<Uint8> pkPtr,
@@ -113,4 +119,31 @@ external int qsVerify(
   int msgLen,
   Pointer<Uint8> sigPtr,
   int sigLen,
+);
+
+/// Derives an ML-DSA keypair deterministically from a 64-byte BIP-39 seed.
+///
+/// The key is a sibling of the secp256k1 key derived from the same mnemonic, not a
+/// child of it, so one mnemonic restores both and breaking secp256k1 does not reach
+/// this key.
+///
+/// [seedPtr]/[seedLen] must be a 64-byte BIP-39 seed. Passing a 32-byte secp256k1
+/// private key is rejected: deriving from it would be circular.
+/// Returns 1 on success, 0 on failure.
+@Native<
+    Int32 Function(
+      Uint32, // level
+      Pointer<Uint8>, // seedPtr
+      IntPtr, // seedLen
+      Uint32, // account
+      Pointer<QsBuffer>, // outPk
+      Pointer<QsBuffer>, // outSk
+    )>(symbol: 'qs_derive_keypair_from_seed')
+external int qsDeriveKeypairFromSeed(
+  int level,
+  Pointer<Uint8> seedPtr,
+  int seedLen,
+  int account,
+  Pointer<QsBuffer> outPk,
+  Pointer<QsBuffer> outSk,
 );

--- a/packages/ndk/rust/Cargo.lock
+++ b/packages/ndk/rust/Cargo.lock
@@ -75,18 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crystals-dilithium"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9432f84a32c91e024a52fcdc5bd3211779c9c7f6fef4067e4e8112d88789c483"
-dependencies = [
- "rand 0.8.5",
- "sha2",
- "sha3",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +82,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -101,6 +90,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fips204"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fb5a367b9846933e271a3c2a992930743f82ae5e8cb7faa780715a80fa0b15"
+dependencies = [
+ "rand_core 0.6.4",
+ "sha2",
+ "sha3",
+ "zeroize",
+]
 
 [[package]]
 name = "generic-array"
@@ -150,6 +151,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -236,33 +255,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -297,12 +295,14 @@ dependencies = [
 name = "rust_lib_ndk"
 version = "0.1.1"
 dependencies = [
- "crystals-dilithium",
+ "fips204",
  "getrandom 0.2.16",
  "hex",
+ "hkdf",
  "secp256k1",
  "serde_json",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand",
  "secp256k1-sys",
 ]
 
@@ -395,6 +395,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/packages/ndk/rust/Cargo.toml
+++ b/packages/ndk/rust/Cargo.toml
@@ -17,7 +17,9 @@ hex = "0.4.3"
 secp256k1 = { version = "0.31.1", features = ["global-context"] }
 sha2 = "0.10.8"
 serde_json = "1.0.128"
-crystals-dilithium = "2.0.0"
+fips204 = "0.4.6"
+hkdf = "0.12.4"
+zeroize = "1.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.16", features = ["js"] } # in later versions its wasm_js (feature name changed)

--- a/packages/ndk/rust/src/lib.rs
+++ b/packages/ndk/rust/src/lib.rs
@@ -1,10 +1,13 @@
 use std::ffi::{c_char, CStr};
 use std::slice;
 
-use crystals_dilithium::{dilithium2, dilithium3, dilithium5};
+use fips204::traits::{KeyGen, SerDes, Signer, Verifier};
+use fips204::{ml_dsa_44, ml_dsa_65, ml_dsa_87};
 use hex::decode;
+use hkdf::Hkdf;
 use secp256k1::{schnorr::Signature, XOnlyPublicKey, SECP256K1};
 use sha2::{Digest, Sha256};
+use zeroize::Zeroize;
 
 /// Verifies a Nostr event signature.
 ///
@@ -220,7 +223,24 @@ fn hash_event_data_internal(
     format!("{:x}", result)
 }
 
-// ── Quantum-Secure Dilithium Functions ─────────────────────────────────
+// ── Quantum-Secure ML-DSA (FIPS 204) Functions ─────────────────────────
+//
+// These were CRYSTALS-Dilithium (the round-3 NIST submission). NIST changed the
+// algorithm during standardisation, so Dilithium and ML-DSA are not wire-compatible:
+// keys and signatures produced by the old code cannot be verified by any FIPS 204
+// implementation, and vice versa. Anything published with the previous keys is
+// therefore unverifiable by the wider ecosystem, which defeats the point of signing.
+//
+// `level` selects the parameter set and now takes the ML-DSA numbers — 44, 65 or 87 —
+// rather than Dilithium's 2, 3 and 5. The old values are rejected rather than
+// remapped, so a caller that was not updated fails loudly instead of silently
+// producing keys with different security properties than it asked for.
+
+/// Domain-separation profile for seed-derived keys. Shared with the ML-KEM derivation.
+const PQ_PROFILE: &str = "nip-pqc/v1";
+
+/// A BIP-39 seed is always 64 bytes, whatever the mnemonic length.
+const SEED_BYTES: usize = 64;
 
 /// Represents a buffer returned to the caller.
 /// The caller must free it with `qs_free_buffer`.
@@ -232,24 +252,53 @@ pub struct QsBuffer {
 
 /// Frees a buffer previously returned by a qs_ function.
 ///
+/// The contents are zeroized before the allocation is released: these buffers carry
+/// secret keys, and a freed-but-not-wiped secret is recoverable from a core dump, a
+/// swap file, or a later heap read.
+///
 /// # Safety
-/// `buf` must be a QsBuffer previously returned by this library.
+/// `buf` must be a QsBuffer previously returned by this library, and must not be
+/// freed twice.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qs_free_buffer(buf: QsBuffer) {
     if !buf.data.is_null() && buf.len > 0 {
-        let _ = unsafe { Vec::from_raw_parts(buf.data, buf.len, buf.len) };
+        let mut v = unsafe { Vec::from_raw_parts(buf.data, buf.len, buf.len) };
+        v.zeroize();
     }
 }
 
-/// Generates a Dilithium keypair.
+/// Derives the 32-byte ML-DSA key seed (xi) from a BIP-39 seed.
 ///
-/// `level` selects the security level: 2, 3, or 5.
+/// Domain-separated per algorithm and account so the signing key is a *sibling* of the
+/// secp256k1 key rather than a child of it. Deriving from the Nostr private key would
+/// be circular: an adversary who recovers it from the published pubkey would repeat the
+/// derivation and obtain this key too.
+fn derive_dsa_xi(seed: &[u8], level: u32, account: u32) -> Option<[u8; 32]> {
+    // A BIP-39 seed is always 64 bytes; requiring exactly that blocks passing a
+    // 32-byte secp256k1 private key as the seed.
+    if seed.len() != SEED_BYTES {
+        return None;
+    }
+    let info = format!("{PQ_PROFILE}/ml-dsa-{level}/{account}");
+    let hk = Hkdf::<Sha256>::new(None, seed);
+    let mut xi = [0u8; 32];
+    hk.expand(info.as_bytes(), &mut xi).ok()?;
+    Some(xi)
+}
+
+/// Generates a random ML-DSA keypair.
 ///
-/// On success, writes the public key into `out_pk` and the secret key into
-/// `out_sk` and returns 1. On failure returns 0.
+/// `level` selects the parameter set: 44, 65 or 87.
+///
+/// Prefer `qs_derive_keypair_from_seed` for anything that represents an identity — a
+/// randomly generated key cannot be restored from a mnemonic, so losing it loses the
+/// identity permanently.
+///
+/// On success, writes the public key into `out_pk` and the secret key into `out_sk`
+/// and returns 1. On failure returns 0.
 ///
 /// # Safety
-/// `out_pk` and `out_sk` must be valid pointers to `QsBuffer`.
+/// `out_pk` and `out_sk` must be valid, non-aliasing pointers to `QsBuffer`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qs_generate_keypair(
     level: u32,
@@ -259,52 +308,81 @@ pub unsafe extern "C" fn qs_generate_keypair(
     if out_pk.is_null() || out_sk.is_null() {
         return 0;
     }
-
+    macro_rules! gen {
+        ($m:ident) => {{
+            match $m::KG::try_keygen() {
+                Ok((pk, sk)) => {
+                    let mut sk_bytes = sk.into_bytes().to_vec();
+                    unsafe {
+                        write_buffer(out_pk, pk.into_bytes().to_vec());
+                        write_buffer(out_sk, sk_bytes.clone());
+                    }
+                    sk_bytes.zeroize();
+                    1
+                }
+                Err(_) => 0,
+            }
+        }};
+    }
     match level {
-        2 => {
-            let keypair = match dilithium2::Keypair::generate(None) {
-                Ok(kp) => kp,
-                Err(_) => return 0,
-            };
-            let pk = keypair.public.to_bytes().to_vec();
-            let sk = keypair.to_bytes().to_vec(); // full keypair bytes (secret + public)
-            write_buffer(out_pk, pk);
-            write_buffer(out_sk, sk);
-            1
-        }
-        3 => {
-            let keypair = match dilithium3::Keypair::generate(None) {
-                Ok(kp) => kp,
-                Err(_) => return 0,
-            };
-            let pk = keypair.public.to_bytes().to_vec();
-            let sk = keypair.to_bytes().to_vec();
-            write_buffer(out_pk, pk);
-            write_buffer(out_sk, sk);
-            1
-        }
-        5 => {
-            let keypair = match dilithium5::Keypair::generate(None) {
-                Ok(kp) => kp,
-                Err(_) => return 0,
-            };
-            let pk = keypair.public.to_bytes().to_vec();
-            let sk = keypair.to_bytes().to_vec();
-            write_buffer(out_pk, pk);
-            write_buffer(out_sk, sk);
-            1
-        }
+        44 => gen!(ml_dsa_44),
+        65 => gen!(ml_dsa_65),
+        87 => gen!(ml_dsa_87),
         _ => 0,
     }
 }
 
-/// Signs a message with a Dilithium secret key.
+/// Derives an ML-DSA keypair deterministically from a 64-byte BIP-39 seed.
 ///
-/// `level` selects the security level: 2, 3, or 5.
-/// `sk_ptr` / `sk_len` is the secret key bytes.
-/// `msg_ptr` / `msg_len` is the message bytes.
+/// One mnemonic therefore restores the signing key, and — because the ML-KEM
+/// derivation in `pq.rs` uses the same seed with a different domain string — the
+/// encryption key too.
 ///
-/// On success, writes the signature into `out_sig` and returns 1.
+/// # Safety
+/// `seed_ptr` must be valid for `seed_len` bytes; `out_pk` and `out_sk` must be valid,
+/// non-aliasing pointers to `QsBuffer`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qs_derive_keypair_from_seed(
+    level: u32,
+    seed_ptr: *const u8,
+    seed_len: usize,
+    account: u32,
+    out_pk: *mut QsBuffer,
+    out_sk: *mut QsBuffer,
+) -> i32 {
+    if seed_ptr.is_null() || out_pk.is_null() || out_sk.is_null() || seed_len == 0 {
+        return 0;
+    }
+    let seed = unsafe { slice::from_raw_parts(seed_ptr, seed_len) };
+    let mut xi = match derive_dsa_xi(seed, level, account) {
+        Some(x) => x,
+        None => return 0,
+    };
+    macro_rules! derive {
+        ($m:ident) => {{
+            let (pk, sk) = $m::KG::keygen_from_seed(&xi);
+            let mut sk_bytes = sk.into_bytes().to_vec();
+            unsafe {
+                write_buffer(out_pk, pk.into_bytes().to_vec());
+                write_buffer(out_sk, sk_bytes.clone());
+            }
+            sk_bytes.zeroize();
+            1
+        }};
+    }
+    let rc = match level {
+        44 => derive!(ml_dsa_44),
+        65 => derive!(ml_dsa_65),
+        87 => derive!(ml_dsa_87),
+        _ => 0,
+    };
+    xi.zeroize();
+    rc
+}
+
+/// Signs a message with an ML-DSA secret key, using an empty FIPS 204 context string.
+///
+/// `level` selects the parameter set: 44, 65 or 87.
 ///
 /// # Safety
 /// All pointers must be valid for their indicated lengths.
@@ -320,56 +398,40 @@ pub unsafe extern "C" fn qs_sign(
     if sk_ptr.is_null() || msg_ptr.is_null() || out_sig.is_null() {
         return 0;
     }
-
     let sk_bytes = unsafe { slice::from_raw_parts(sk_ptr, sk_len) };
     let msg = unsafe { slice::from_raw_parts(msg_ptr, msg_len) };
 
+    macro_rules! sign {
+        ($m:ident) => {{
+            let arr: [u8; $m::SK_LEN] = match sk_bytes.try_into() {
+                Ok(a) => a,
+                Err(_) => return 0,
+            };
+            let sk = match $m::PrivateKey::try_from_bytes(arr) {
+                Ok(k) => k,
+                Err(_) => return 0,
+            };
+            match sk.try_sign(msg, &[]) {
+                Ok(sig) => {
+                    unsafe { write_buffer(out_sig, sig.to_vec()) };
+                    1
+                }
+                Err(_) => 0,
+            }
+        }};
+    }
     match level {
-        2 => {
-            if sk_len != dilithium2::KEYPAIRBYTES {
-                return 0;
-            }
-            let keypair = match dilithium2::Keypair::from_bytes(sk_bytes) {
-                Ok(kp) => kp,
-                Err(_) => return 0,
-            };
-            let sig = keypair.sign(msg);
-            write_buffer(out_sig, sig.to_vec());
-            1
-        }
-        3 => {
-            if sk_len != dilithium3::KEYPAIRBYTES {
-                return 0;
-            }
-            let keypair = match dilithium3::Keypair::from_bytes(sk_bytes) {
-                Ok(kp) => kp,
-                Err(_) => return 0,
-            };
-            let sig = keypair.sign(msg);
-            write_buffer(out_sig, sig.to_vec());
-            1
-        }
-        5 => {
-            if sk_len != dilithium5::KEYPAIRBYTES {
-                return 0;
-            }
-            let keypair = match dilithium5::Keypair::from_bytes(sk_bytes) {
-                Ok(kp) => kp,
-                Err(_) => return 0,
-            };
-            let sig = keypair.sign(msg);
-            write_buffer(out_sig, sig.to_vec());
-            1
-        }
+        44 => sign!(ml_dsa_44),
+        65 => sign!(ml_dsa_65),
+        87 => sign!(ml_dsa_87),
         _ => 0,
     }
 }
 
-/// Verifies a Dilithium signature.
+/// Verifies an ML-DSA signature against an empty FIPS 204 context string.
 ///
-/// `level` selects the security level: 2, 3, or 5.
-///
-/// Returns 1 if valid, 0 if invalid.
+/// Returns 1 when the signature is valid, 0 otherwise — including for malformed
+/// inputs, which are indistinguishable from an invalid signature by design.
 ///
 /// # Safety
 /// All pointers must be valid for their indicated lengths.
@@ -386,69 +448,48 @@ pub unsafe extern "C" fn qs_verify(
     if pk_ptr.is_null() || msg_ptr.is_null() || sig_ptr.is_null() {
         return 0;
     }
-
     let pk_bytes = unsafe { slice::from_raw_parts(pk_ptr, pk_len) };
     let msg = unsafe { slice::from_raw_parts(msg_ptr, msg_len) };
     let sig_bytes = unsafe { slice::from_raw_parts(sig_ptr, sig_len) };
 
+    macro_rules! verify {
+        ($m:ident) => {{
+            let pk_arr: [u8; $m::PK_LEN] = match pk_bytes.try_into() {
+                Ok(a) => a,
+                Err(_) => return 0,
+            };
+            let sig_arr: [u8; $m::SIG_LEN] = match sig_bytes.try_into() {
+                Ok(a) => a,
+                Err(_) => return 0,
+            };
+            let pk = match $m::PublicKey::try_from_bytes(pk_arr) {
+                Ok(k) => k,
+                Err(_) => return 0,
+            };
+            i32::from(pk.verify(msg, &sig_arr, &[]))
+        }};
+    }
     match level {
-        2 => {
-            if pk_len != dilithium2::PUBLICKEYBYTES || sig_len != dilithium2::SIGNBYTES {
-                return 0;
-            }
-            let pubkey = match dilithium2::PublicKey::from_bytes(pk_bytes) {
-                Ok(pk) => pk,
-                Err(_) => return 0,
-            };
-            let mut sig_arr = [0u8; dilithium2::SIGNBYTES];
-            sig_arr.copy_from_slice(sig_bytes);
-            if pubkey.verify(msg, &sig_arr) {
-                1
-            } else {
-                0
-            }
-        }
-        3 => {
-            if pk_len != dilithium3::PUBLICKEYBYTES || sig_len != dilithium3::SIGNBYTES {
-                return 0;
-            }
-            let pubkey = match dilithium3::PublicKey::from_bytes(pk_bytes) {
-                Ok(pk) => pk,
-                Err(_) => return 0,
-            };
-            let mut sig_arr = [0u8; dilithium3::SIGNBYTES];
-            sig_arr.copy_from_slice(sig_bytes);
-            if pubkey.verify(msg, &sig_arr) {
-                1
-            } else {
-                0
-            }
-        }
-        5 => {
-            if pk_len != dilithium5::PUBLICKEYBYTES || sig_len != dilithium5::SIGNBYTES {
-                return 0;
-            }
-            let pubkey = match dilithium5::PublicKey::from_bytes(pk_bytes) {
-                Ok(pk) => pk,
-                Err(_) => return 0,
-            };
-            let mut sig_arr = [0u8; dilithium5::SIGNBYTES];
-            sig_arr.copy_from_slice(sig_bytes);
-            if pubkey.verify(msg, &sig_arr) {
-                1
-            } else {
-                0
-            }
-        }
-
+        44 => verify!(ml_dsa_44),
+        65 => verify!(ml_dsa_65),
+        87 => verify!(ml_dsa_87),
         _ => 0,
     }
 }
 
 /// Helper: move a Vec<u8> into a QsBuffer, leaking the memory for the caller.
-unsafe fn write_buffer(out: *mut QsBuffer, data: Vec<u8>) {
+///
+/// The Vec is converted to a boxed slice first. `qs_free_buffer` reconstructs the
+/// allocation with `Vec::from_raw_parts(data, len, len)`, which is undefined behaviour
+/// unless capacity equals length — and nothing about `Vec` guarantees that in general.
+/// It happens to hold for every value passed here today, so this is a latent trap
+/// rather than a live bug: the next contributor to build an output with `push` or
+/// `extend` would introduce heap corruption in the free path with no compiler
+/// diagnostic. `into_boxed_slice` reallocates to the exact size and removes the trap.
+pub(crate) unsafe fn write_buffer(out: *mut QsBuffer, data: Vec<u8>) {
+    let data = data.into_boxed_slice();
     let len = data.len();
-    let ptr = data.leak().as_mut_ptr();
+    let ptr = Box::leak(data).as_mut_ptr();
     unsafe {
         (*out).data = ptr;
         (*out).len = len;
@@ -514,36 +555,99 @@ mod tests {
     }
 
     #[test]
-    fn qs_dilithium2_roundtrip() {
-        let keypair = dilithium2::Keypair::generate(None).unwrap();
-        let msg = b"hello quantum world";
-        let sig = keypair.secret.sign(msg);
-        assert!(keypair.public.verify(msg, &sig));
+    fn qs_mldsa_roundtrip_all_levels() {
+        for level in [44u32, 65, 87] {
+            let seed = [7u8; 64];
+            let xi = derive_dsa_xi(&seed, level, 0).unwrap();
+            let msg = b"hello quantum world";
+            match level {
+                44 => {
+                    let (pk, sk) = ml_dsa_44::KG::keygen_from_seed(&xi);
+                    let sig = sk.try_sign(msg, &[]).unwrap();
+                    assert!(pk.verify(msg, &sig, &[]));
+                }
+                65 => {
+                    let (pk, sk) = ml_dsa_65::KG::keygen_from_seed(&xi);
+                    let sig = sk.try_sign(msg, &[]).unwrap();
+                    assert!(pk.verify(msg, &sig, &[]));
+                }
+                _ => {
+                    let (pk, sk) = ml_dsa_87::KG::keygen_from_seed(&xi);
+                    let sig = sk.try_sign(msg, &[]).unwrap();
+                    assert!(pk.verify(msg, &sig, &[]));
+                }
+            }
+        }
     }
 
     #[test]
-    fn qs_dilithium3_roundtrip() {
-        let keypair = dilithium3::Keypair::generate(None).unwrap();
+    fn qs_mldsa_bad_sig_fails() {
+        let (pk, sk) = ml_dsa_87::KG::keygen_from_seed(&[3u8; 32]);
         let msg = b"hello quantum world";
-        let sig = keypair.secret.sign(msg);
-        assert!(keypair.public.verify(msg, &sig));
-    }
-
-    #[test]
-    fn qs_dilithium5_roundtrip() {
-        let keypair = dilithium5::Keypair::generate(None).unwrap();
-        let msg = b"hello quantum world";
-        let sig = keypair.secret.sign(msg);
-        assert!(keypair.public.verify(msg, &sig));
-    }
-
-    #[test]
-    fn qs_dilithium2_bad_sig_fails() {
-        let keypair = dilithium2::Keypair::generate(None).unwrap();
-        let msg = b"hello quantum world";
-        let mut sig = keypair.secret.sign(msg);
+        let mut sig = sk.try_sign(msg, &[]).unwrap();
         sig[0] ^= 0xff;
-        assert!(!keypair.public.verify(msg, &sig));
+        assert!(!pk.verify(msg, &sig, &[]));
+    }
+
+    /// Pinned against `@noble/post-quantum`'s `ml_dsa87`, the implementation the
+    /// TypeScript reference uses. The seed is HKDF-derived from bytes 0..64 with
+    /// info "nip-pqc/v1/ml-dsa-87/0", exactly as `dsaInfo` does there.
+    ///
+    /// This is what the previous CRYSTALS-Dilithium code could never satisfy: the
+    /// round-3 submission and FIPS 204 are different algorithms, so its keys and
+    /// signatures were verifiable only by itself.
+    #[test]
+    fn qs_mldsa87_matches_fips204_reference_vector() {
+        let seed: Vec<u8> = (0u8..64).collect();
+        let xi = derive_dsa_xi(&seed, 87, 0).unwrap();
+        assert_eq!(
+            hex::encode(xi),
+            "3d8443c4983bf876911077a0038d5e5084ca107d0d4b6a9438cbf051f79e3917"
+        );
+        let (pk, _) = ml_dsa_87::KG::keygen_from_seed(&xi);
+        let pk_bytes = pk.into_bytes();
+        assert_eq!(pk_bytes.len(), ml_dsa_87::PK_LEN);
+        assert_eq!(
+            hex::encode(Sha256::digest(pk_bytes.as_slice())),
+            "dcc0c445e54e2130ded2c1fa04e8aed2fcd80dfaefe2897b41fec827e6cdb609"
+        );
+    }
+
+    /// A BIP-39 seed is 64 bytes; a secp256k1 private key is 32. Accepting the latter
+    /// would make the derivation circular.
+    #[test]
+    fn qs_seed_derivation_rejects_non_bip39_seeds() {
+        assert!(derive_dsa_xi(&[], 87, 0).is_none());
+        assert!(derive_dsa_xi(&[0x42; 32], 87, 0).is_none());
+        assert!(derive_dsa_xi(&[0x42; 64], 87, 0).is_some());
+    }
+
+    /// Same seed, different account or parameter set, different key.
+    #[test]
+    fn qs_seed_derivation_is_domain_separated() {
+        let seed = [9u8; 64];
+        let a = derive_dsa_xi(&seed, 87, 0).unwrap();
+        assert_ne!(a, derive_dsa_xi(&seed, 87, 1).unwrap());
+        assert_ne!(a, derive_dsa_xi(&seed, 65, 0).unwrap());
+    }
+
+    /// The Dilithium level numbers must not silently mean something else now.
+    #[test]
+    fn qs_rejects_legacy_dilithium_levels() {
+        unsafe {
+            for level in [2u32, 3, 5] {
+                let mut pk = QsBuffer {
+                    data: std::ptr::null_mut(),
+                    len: 0,
+                };
+                let mut sk = QsBuffer {
+                    data: std::ptr::null_mut(),
+                    len: 0,
+                };
+                assert_eq!(qs_generate_keypair(level, &mut pk, &mut sk), 0);
+                assert!(pk.data.is_null());
+            }
+        }
     }
 
     #[test]
@@ -558,47 +662,84 @@ mod tests {
                 len: 0,
             };
 
-            let ret = qs_generate_keypair(2, &mut pk, &mut sk);
-            assert_eq!(ret, 1);
+            assert_eq!(qs_generate_keypair(87, &mut pk, &mut sk), 1);
             assert!(!pk.data.is_null());
             assert!(!sk.data.is_null());
+            assert_eq!(pk.len, ml_dsa_87::PK_LEN);
+            assert_eq!(sk.len, ml_dsa_87::SK_LEN);
 
             let msg = b"test message";
             let mut sig = QsBuffer {
                 data: std::ptr::null_mut(),
                 len: 0,
             };
-
-            let ret = qs_sign(2, sk.data, sk.len, msg.as_ptr(), msg.len(), &mut sig);
-            assert_eq!(ret, 1);
-
-            let ret = qs_verify(
-                2,
-                pk.data,
-                pk.len,
-                msg.as_ptr(),
-                msg.len(),
-                sig.data,
-                sig.len,
+            assert_eq!(
+                qs_sign(87, sk.data, sk.len, msg.as_ptr(), msg.len(), &mut sig),
+                1
             );
-            assert_eq!(ret, 1);
+            assert_eq!(sig.len, ml_dsa_87::SIG_LEN);
 
-            // wrong message should fail
+            assert_eq!(
+                qs_verify(
+                    87,
+                    pk.data,
+                    pk.len,
+                    msg.as_ptr(),
+                    msg.len(),
+                    sig.data,
+                    sig.len
+                ),
+                1
+            );
+
             let bad_msg = b"wrong message";
-            let ret = qs_verify(
-                2,
-                pk.data,
-                pk.len,
-                bad_msg.as_ptr(),
-                bad_msg.len(),
-                sig.data,
-                sig.len,
+            assert_eq!(
+                qs_verify(
+                    87,
+                    pk.data,
+                    pk.len,
+                    bad_msg.as_ptr(),
+                    bad_msg.len(),
+                    sig.data,
+                    sig.len
+                ),
+                0
             );
-            assert_eq!(ret, 0);
 
             qs_free_buffer(pk);
             qs_free_buffer(sk);
             qs_free_buffer(sig);
+        }
+    }
+
+    /// The seed-derived FFI path must agree with direct derivation, and be stable
+    /// across calls — that is what makes a mnemonic able to restore the key.
+    #[test]
+    fn qs_ffi_seed_derivation_is_deterministic() {
+        unsafe {
+            let seed = [11u8; 64];
+            let mut first: Option<Vec<u8>> = None;
+            for _ in 0..2 {
+                let mut pk = QsBuffer {
+                    data: std::ptr::null_mut(),
+                    len: 0,
+                };
+                let mut sk = QsBuffer {
+                    data: std::ptr::null_mut(),
+                    len: 0,
+                };
+                assert_eq!(
+                    qs_derive_keypair_from_seed(87, seed.as_ptr(), seed.len(), 0, &mut pk, &mut sk),
+                    1
+                );
+                let bytes = std::slice::from_raw_parts(pk.data, pk.len).to_vec();
+                match &first {
+                    None => first = Some(bytes),
+                    Some(f) => assert_eq!(*f, bytes),
+                }
+                qs_free_buffer(pk);
+                qs_free_buffer(sk);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #717.

## The licensing problem

`packages/ndk/rust` depends on `crystals-dilithium`, which is **GPL-3.0-only**. NDK ships under **MIT**.

The crate is not optional at build time. `packages/ndk/rust/Cargo.toml` declares `crate-type = ["cdylib", "staticlib"]`, and `packages/ndk/hook/build.dart` compiles it unconditionally for every dependent app. The ordinary Schnorr verifier lives in the same `src/lib.rs` as the quantum-secure signer, so an app that never touches post-quantum code still links the GPL-3.0-only object code.

Statically linking GPL-3.0-only code makes the combined binary a derivative work, which obliges every downstream app to distribute under GPL-3.0. That is a hard problem for closed-source consumers, and GPL-3.0 is also widely held to be incompatible with App Store distribution terms.

This PR replaces it with [`fips204`](https://crates.io/crates/fips204), which is **MIT OR Apache-2.0** and imposes none of that.

## The interoperability problem

`crystals-dilithium` implements the round-3 CRYSTALS submission. NIST changed the algorithm during standardisation, so Dilithium and ML-DSA are different schemes with different wire formats.

Keys and signatures produced by the current code can therefore be verified only by the current code. No FIPS 204 implementation can read them, and vice versa. For a signature scheme whose entire purpose is letting someone else check your work, that is a defect rather than a preference.

## Also in this change

**Seed derivation.** Keys were random-only, so a signing key could never be restored from a mnemonic — losing it lost the identity permanently. `qs_derive_keypair_from_seed` derives from a 64-byte BIP-39 seed via HKDF-SHA256 with `nip-pqc/v1/ml-dsa-<level>/<account>`, making the key a *sibling* of the secp256k1 key rather than a child: breaking secp256k1 does not reach it, and one mnemonic restores both. A 32-byte secp256k1 private key is rejected as input, because deriving from it would be circular.

**Two safety fixes found while auditing this code:**

- `write_buffer` leaked a `Vec` recording only its length, while `qs_free_buffer` reconstructed it with `Vec::from_raw_parts(data, len, len)`. That is undefined behaviour whenever capacity exceeds length. It holds for every value passed today, so this was a latent trap rather than a live bug — the next contributor building an output with `push` or `extend` would have introduced heap corruption in the free path with no compiler diagnostic. `into_boxed_slice` reallocates to the exact size.
- `qs_free_buffer` now zeroizes before deallocating. These buffers carry secret keys, and a freed-but-unwiped secret is recoverable from a core dump or swap file.

## Breaking change

`level` now takes the ML-DSA parameter numbers (44/65/87) instead of the Dilithium ones (2/3/5). The old values are **rejected rather than remapped**, so an un-updated caller fails loudly instead of silently receiving different security properties than it asked for.

Existing quantum-secure keys do not carry over. They could never have interoperated with anything, and the signer is shipped as experimental.

## Verification

Run locally against Flutter 3.41.4 (the pinned `FLUTTER_VERSION`) and Rust 1.93.

**Rust**
- `cargo test` — **12/12 pass**, including `qs_mldsa87_matches_fips204_reference_vector`, which pins an ML-DSA-87 public key byte-for-byte against `@noble/post-quantum` from the same derived seed. That is precisely the interoperability the current implementation cannot satisfy.
- `cargo clippy --all-targets` — clean.
- `cargo fmt --check` — clean.

**Dart**
- `flutter analyze --fatal-infos --fatal-warnings` on `packages/ndk` — **No issues found.**
- `dart format` — `rust_lib.dart` is clean under Dart 3.12.2, matching the formatter your CI runs.
- The FFI was exercised end to end against the compiled library, not just analyzed. Deriving an ML-DSA-87 keypair from a 64-byte seed, signing, and verifying round-trips through `qs_derive_keypair_from_seed` / `qs_sign` / `qs_verify`, and the derived public key is 2592 bytes as FIPS 204 requires. The legacy Dilithium levels 2/3/5 are confirmed rejected rather than remapped, and a 32-byte secp256k1 private key is confirmed rejected as seed input.

The existing `test/scenarios/qs_sign_verify_test.dart` is `skip: true` on `master` and I left it that way; the checks above were run through a separate harness rather than by changing your test gating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic ML-DSA keypair derivation from a 64-byte BIP-39 seed and account number.
  * Native signing and verification now support ML-DSA parameter sets 44, 65, and 87.
* **Changes**
  * ML-DSA level 87 is now the default for signing, verification, and key generation.
  * Legacy Dilithium security levels are no longer accepted.
  * Updated terminology and documentation to align with FIPS 204.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
