### PR TITLE
fix: encode negentropy messages per protocol v1

### DIFF
--- a/packages/ndk/lib/shared/nips/nip77/negentropy.dart
+++ b/packages/ndk/lib/shared/nips/nip77/negentropy.dart
@@ -1,10 +1,12 @@
 import 'dart:typed_data';
+
 import 'package:crypto/crypto.dart';
 
-/// Negentropy protocol encoder implementation for NIP-77
-/// Handles varint encoding, fingerprints, bounds, and message framing
+/// Negentropy Protocol V1 codec, as specified in the NIP-77 appendix.
+///
+/// See https://github.com/hoytech/negentropy/blob/master/docs/negentropy-protocol-v1.md
 class NegentropyEncoder {
-  /// Protocol version byte
+  /// Protocol version byte (version 1)
   static const int protocolVersion = 0x61;
 
   /// Size of event ID in bytes (32 bytes = 64 hex chars)
@@ -18,7 +20,19 @@ class NegentropyEncoder {
   static const int modeFingerprint = 1;
   static const int modeIdList = 2;
 
-  /// Encodes an integer as a varint (base-128, MSB-first)
+  /// Reserved "infinity" timestamp. The spec reserves `2**64 - 1`, which does
+  /// not survive dart2js; this sentinel is the largest exactly representable
+  /// integer on both native and web, and never touches the wire (infinity is
+  /// always encoded as `0`).
+  static const int infiniteTimestamp = 9007199254740991;
+
+  /// Number of sub-ranges a mismatching range is split into
+  static const int _buckets = 16;
+
+  /// Ranges with fewer items than this are sent as an id list instead of split
+  static const int _idListThreshold = _buckets * 2;
+
+  /// Encodes an integer as a varint (base-128, most significant digit first)
   static Uint8List encodeVarint(int value) {
     if (value < 0) {
       throw ArgumentError('Varint value must be non-negative');
@@ -32,11 +46,10 @@ class NegentropyEncoder {
     var remaining = value;
 
     while (remaining > 0) {
-      bytes.insert(0, remaining & 0x7F);
-      remaining >>= 7;
+      bytes.insert(0, remaining % 128);
+      remaining = remaining ~/ 128;
     }
 
-    // Set continuation bits (MSB) on all bytes except the last
     for (var i = 0; i < bytes.length - 1; i++) {
       bytes[i] |= 0x80;
     }
@@ -49,83 +62,118 @@ class NegentropyEncoder {
     Uint8List data, [
     int offset = 0,
   ]) {
-    if (offset >= data.length) {
-      throw ArgumentError('Not enough data to decode varint');
-    }
+    var value = 0;
+    var bytesConsumed = 0;
 
-    int value = 0;
-    int bytesConsumed = 0;
+    while (true) {
+      if (offset + bytesConsumed >= data.length) {
+        throw ArgumentError('Truncated varint');
+      }
 
-    while (offset + bytesConsumed < data.length) {
       final byte = data[offset + bytesConsumed];
-      value = (value << 7) | (byte & 0x7F);
       bytesConsumed++;
 
+      final digit = byte & 0x7F;
+      if (value > (infiniteTimestamp - digit) ~/ 128) {
+        throw ArgumentError('Varint exceeds the supported integer range');
+      }
+      value = value * 128 + digit;
+
       if ((byte & 0x80) == 0) {
-        break;
-      }
-
-      if (bytesConsumed > 9) {
-        throw ArgumentError('Varint too long');
+        return (value, bytesConsumed);
       }
     }
-
-    // Check if we reached end of data with continuation bit still set
-    final lastByte = data[offset + bytesConsumed - 1];
-    if ((lastByte & 0x80) != 0) {
-      throw ArgumentError(
-        'Truncated varint: data ends with continuation bit set',
-      );
-    }
-
-    return (value, bytesConsumed);
   }
 
-  /// Calculates fingerprint from a list of event IDs
-  /// Fingerprint = SHA256(XOR of all IDs || count as little-endian u64)[0:16]
+  /// Calculates the fingerprint of a range: the first 16 bytes of
+  /// `SHA256(sum of the IDs mod 2^256, little-endian || varint(count))`.
   static Uint8List calculateFingerprint(List<Uint8List> ids) {
-    // XOR all IDs together
-    final xorResult = Uint8List(idSize);
+    final accumulator = Uint8List(idSize);
 
     for (final id in ids) {
-      for (var i = 0; i < idSize && i < id.length; i++) {
-        xorResult[i] ^= id[i];
+      var carry = 0;
+      for (var i = 0; i < idSize; i++) {
+        final sum = accumulator[i] + (i < id.length ? id[i] : 0) + carry;
+        accumulator[i] = sum & 0xFF;
+        carry = sum >> 8;
       }
     }
 
-    // Count as little-endian u64 (8 bytes)
-    final countBytes = Uint8List(8);
-    var count = ids.length;
-    for (var i = 0; i < 8; i++) {
-      countBytes[i] = count & 0xFF;
-      count >>= 8;
-    }
-
-    // SHA256 and take first 16 bytes
-    final combined = Uint8List.fromList([...xorResult, ...countBytes]);
-    final digest = sha256.convert(combined);
+    final digest = sha256.convert([
+      ...accumulator,
+      ...encodeVarint(ids.length),
+    ]);
 
     return Uint8List.fromList(digest.bytes.sublist(0, fingerprintSize));
   }
 
-  /// Encodes a bound (timestamp + ID prefix)
-  static Uint8List encodeBound(int timestamp, Uint8List idPrefix) {
-    final timestampBytes = encodeVarint(timestamp);
-    final lengthByte = Uint8List.fromList([idPrefix.length]);
-    return Uint8List.fromList([...timestampBytes, ...lengthByte, ...idPrefix]);
+  /// Encodes a bound. Timestamps are delta encoded against [lastTimestamp],
+  /// which is the timestamp of the previously encoded bound in the same
+  /// message (0 at the start of every message).
+  static Uint8List encodeBound(
+    int timestamp,
+    Uint8List idPrefix, {
+    int lastTimestamp = 0,
+  }) {
+    if (idPrefix.length > idSize) {
+      throw ArgumentError('Bound ID prefix must be at most $idSize bytes');
+    }
+
+    final output = BytesBuilder();
+
+    if (timestamp >= infiniteTimestamp) {
+      output.addByte(0);
+    } else {
+      if (timestamp < lastTimestamp) {
+        throw ArgumentError('Bound timestamps must be non-decreasing');
+      }
+      output.add(encodeVarint(timestamp - lastTimestamp + 1));
+    }
+
+    output.add(encodeVarint(idPrefix.length));
+    output.add(idPrefix);
+
+    return output.toBytes();
   }
 
-  /// Decodes a bound from bytes
+  /// Decodes a bound. [lastTimestamp] is the timestamp of the previously
+  /// decoded bound in the same message (0 at the start of every message).
   static (int timestamp, Uint8List idPrefix, int bytesConsumed) decodeBound(
     Uint8List data, [
     int offset = 0,
+    int lastTimestamp = 0,
   ]) {
-    final (timestamp, tsBytes) = decodeVarint(data, offset);
-    final prefixLength = data[offset + tsBytes];
+    var pos = offset;
+
+    final (encodedTimestamp, timestampBytes) = decodeVarint(data, pos);
+    pos += timestampBytes;
+
+    final int timestamp;
+    if (encodedTimestamp == 0) {
+      timestamp = infiniteTimestamp;
+    } else {
+      timestamp = lastTimestamp + encodedTimestamp - 1;
+      if (timestamp >= infiniteTimestamp) {
+        throw ArgumentError('Bound timestamp out of range');
+      }
+    }
+
+    final (prefixLength, lengthBytes) = decodeVarint(data, pos);
+    pos += lengthBytes;
+
+    if (prefixLength > idSize) {
+      throw ArgumentError('Bound ID prefix too long: $prefixLength');
+    }
+    if (pos + prefixLength > data.length) {
+      throw ArgumentError('Truncated bound ID prefix');
+    }
+
     final idPrefix = Uint8List.fromList(
-      data.sublist(offset + tsBytes + 1, offset + tsBytes + 1 + prefixLength),
+      data.sublist(pos, pos + prefixLength),
     );
-    return (timestamp, idPrefix, tsBytes + 1 + prefixLength);
+    pos += prefixLength;
+
+    return (timestamp, idPrefix, pos - offset);
   }
 
   /// Parses a hex string to bytes
@@ -141,191 +189,302 @@ class NegentropyEncoder {
   }
 
   /// Converts bytes to hex string
-  static String bytesToHex(Uint8List bytes) {
+  static String bytesToHex(List<int> bytes) {
     return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
   }
 
-  /// Creates an initial client message (NEG-OPEN query payload)
+  /// Creates the initial message an initiator sends in `NEG-OPEN`.
   static Uint8List createInitialMessage(
-    List<NegentropyItem> items,
-    int idSize,
-  ) {
-    items.sort((a, b) {
-      final tsCmp = a.timestamp.compareTo(b.timestamp);
-      if (tsCmp != 0) return tsCmp;
-      return _compareBytes(a.id, b.id);
-    });
+    List<NegentropyItem> items, [
+    int itemIdSize = idSize,
+  ]) {
+    if (itemIdSize != idSize) {
+      throw ArgumentError('Negentropy v1 requires $idSize byte IDs');
+    }
 
-    final output = BytesBuilder();
-    output.addByte(protocolVersion);
-
-    // Single range covering all items with fingerprint
-    // Upper bound - use max timestamp + 1 if we have items, otherwise use a large value
-    final maxTs = items.isEmpty ? 0x7FFFFFFF : items.last.timestamp + 1;
-    output.add(encodeVarint(maxTs));
-    output.addByte(0); // prefix length
-
-    // Always send fingerprint mode (even for empty set)
-    output.addByte(modeFingerprint);
-    final ids = items.map((i) => i.id).toList();
-    output.add(calculateFingerprint(ids));
+    final sorted = _prepare(items);
+    final output = _MessageWriter()..addByte(protocolVersion);
+    _splitRange(sorted, 0, sorted.length, _infinityBound, output);
 
     return output.toBytes();
   }
 
-  /// Reconciles received message and creates response
-  /// Returns (response bytes, need IDs, have IDs)
+  /// Reconciles a message received from the other side as the initiator.
+  ///
+  /// Returns the response to send back plus the IDs discovered so far:
+  /// [needIds] are held by the other side only, [haveIds] by us only. A
+  /// response consisting of nothing but the version byte means the
+  /// reconciliation has converged.
   static (Uint8List response, List<String> needIds, List<String> haveIds)
   reconcile(Uint8List message, List<NegentropyItem> items) {
-    items.sort((a, b) {
-      final tsCmp = a.timestamp.compareTo(b.timestamp);
-      if (tsCmp != 0) return tsCmp;
-      return _compareBytes(a.id, b.id);
-    });
-
-    int offset = 0;
-
-    // Check version
-    if (message.isEmpty || message[0] != protocolVersion) {
-      throw ArgumentError('Invalid protocol version');
-    }
-    offset++;
-
     final needIds = <String>[];
     final haveIds = <String>[];
-    final output = BytesBuilder();
-    output.addByte(protocolVersion);
+    final response = _reconcileAux(
+      message,
+      items,
+      isInitiator: true,
+      needIds: needIds,
+      haveIds: haveIds,
+    );
+    return (response, needIds, haveIds);
+  }
 
+  /// Reconciles a message received from an initiator, as the responding side.
+  ///
+  /// Only the initiator learns the have/need sets, so this returns just the
+  /// response message.
+  static Uint8List respond(Uint8List message, List<NegentropyItem> items) {
+    return _reconcileAux(
+      message,
+      items,
+      isInitiator: false,
+      needIds: [],
+      haveIds: [],
+    );
+  }
+
+  static Uint8List _reconcileAux(
+    Uint8List message,
+    List<NegentropyItem> items, {
+    required bool isInitiator,
+    required List<String> needIds,
+    required List<String> haveIds,
+  }) {
+    if (message.isEmpty) {
+      throw ArgumentError('Empty negentropy message');
+    }
+    if (message[0] != protocolVersion) {
+      throw ArgumentError(
+        'Unsupported negentropy protocol version: '
+        '0x${message[0].toRadixString(16)}',
+      );
+    }
+
+    final sorted = _prepare(items);
+    final output = _MessageWriter()..addByte(protocolVersion);
+
+    var offset = 1;
+    var lastTimestampIn = 0;
     var prevBound = _Bound(0, Uint8List(0));
-    var itemIndex = 0;
+    var prevIndex = 0;
+    var pendingSkip = false;
+
+    // Adjacent skipped ranges are coalesced into one, emitted only once a
+    // range that carries a payload follows.
+    void flushSkip() {
+      if (!pendingSkip) return;
+      pendingSkip = false;
+      output.addBound(prevBound);
+      output.addVarint(modeSkip);
+    }
 
     while (offset < message.length) {
-      // Decode upper bound
-      final (timestamp, idPrefix, boundBytes) = decodeBound(message, offset);
+      final (timestamp, idPrefix, boundBytes) = decodeBound(
+        message,
+        offset,
+        lastTimestampIn,
+      );
       offset += boundBytes;
-
+      lastTimestampIn = timestamp;
       final currBound = _Bound(timestamp, idPrefix);
 
-      // Get items in range [prevBound, currBound)
-      final rangeItems = <NegentropyItem>[];
-      while (itemIndex < items.length) {
-        final item = items[itemIndex];
-        if (_isInRange(item, prevBound, currBound)) {
-          rangeItems.add(item);
-          itemIndex++;
-        } else if (_isBeforeBound(item, currBound)) {
-          itemIndex++;
-        } else {
-          break;
-        }
+      if (offset >= message.length) {
+        throw ArgumentError('Truncated range: missing mode');
       }
+      final (mode, modeBytes) = decodeVarint(message, offset);
+      offset += modeBytes;
 
-      // Decode mode
-      if (offset >= message.length) break;
-      final mode = message[offset++];
+      final lower = prevIndex;
+      final upper = _lowerBound(sorted, prevIndex, currBound);
 
       switch (mode) {
         case modeSkip:
-          // Do nothing, this range is synchronized
-          break;
+          pendingSkip = true;
 
         case modeFingerprint:
-          // Read fingerprint
           if (offset + fingerprintSize > message.length) {
-            throw ArgumentError('Not enough data for fingerprint');
+            throw ArgumentError('Truncated fingerprint');
           }
-          final theirFingerprint = Uint8List.fromList(
-            message.sublist(offset, offset + fingerprintSize),
+          final theirFingerprint = Uint8List.sublistView(
+            message,
+            offset,
+            offset + fingerprintSize,
           );
           offset += fingerprintSize;
 
-          // Calculate our fingerprint for this range
-          final ourIds = rangeItems.map((i) => i.id).toList();
-          final ourFingerprint = calculateFingerprint(ourIds);
+          final ourFingerprint = calculateFingerprint([
+            for (var i = lower; i < upper; i++) sorted[i].id,
+          ]);
 
-          if (!_bytesEqual(theirFingerprint, ourFingerprint)) {
-            // Mismatch - need to split or send IDs
-            if (rangeItems.length <= 2) {
-              // Send our IDs directly
-              output.add(encodeBound(timestamp, idPrefix));
-              output.addByte(modeIdList);
-              output.add(encodeVarint(rangeItems.length));
-              for (final item in rangeItems) {
-                output.add(item.id);
-              }
-            } else {
-              // Split range in half
-              final mid = rangeItems.length ~/ 2;
-              final midItem = rangeItems[mid];
-
-              // First half
-              output.add(encodeBound(midItem.timestamp, midItem.id));
-              output.addByte(modeFingerprint);
-              final firstHalfIds = rangeItems
-                  .sublist(0, mid)
-                  .map((i) => i.id)
-                  .toList();
-              output.add(calculateFingerprint(firstHalfIds));
-
-              // Second half
-              output.add(encodeBound(timestamp, idPrefix));
-              output.addByte(modeFingerprint);
-              final secondHalfIds = rangeItems
-                  .sublist(mid)
-                  .map((i) => i.id)
-                  .toList();
-              output.add(calculateFingerprint(secondHalfIds));
-            }
+          if (_bytesEqual(theirFingerprint, ourFingerprint)) {
+            pendingSkip = true;
+          } else {
+            flushSkip();
+            _splitRange(sorted, lower, upper, currBound, output);
           }
-          break;
 
         case modeIdList:
-          // Read their IDs
           final (count, countBytes) = decodeVarint(message, offset);
           offset += countBytes;
+          if (count > (message.length - offset) ~/ idSize) {
+            throw ArgumentError('Truncated ID list');
+          }
 
-          final theirIds = <Uint8List>[];
+          final theirIds = <String>{};
           for (var i = 0; i < count; i++) {
-            if (offset + idSize > message.length) {
-              throw ArgumentError('Not enough data for ID');
-            }
             theirIds.add(
-              Uint8List.fromList(message.sublist(offset, offset + idSize)),
+              bytesToHex(
+                Uint8List.sublistView(message, offset, offset + idSize),
+              ),
             );
             offset += idSize;
           }
 
-          // Find differences
-          final ourIdSet = rangeItems.map((i) => bytesToHex(i.id)).toSet();
-          final theirIdSet = theirIds.map(bytesToHex).toSet();
-
-          // We need IDs they have that we don't
-          for (final theirId in theirIdSet) {
-            if (!ourIdSet.contains(theirId)) {
-              needIds.add(theirId);
+          if (isInitiator) {
+            for (var i = lower; i < upper; i++) {
+              final ourId = bytesToHex(sorted[i].id);
+              if (!theirIds.remove(ourId)) {
+                haveIds.add(ourId);
+              }
+            }
+            needIds.addAll(theirIds);
+            pendingSkip = true;
+          } else {
+            flushSkip();
+            output.addBound(currBound);
+            output.addVarint(modeIdList);
+            output.addVarint(upper - lower);
+            for (var i = lower; i < upper; i++) {
+              output.addBytes(sorted[i].id);
             }
           }
-
-          // We have IDs that they don't
-          for (final ourId in ourIdSet) {
-            if (!theirIdSet.contains(ourId)) {
-              haveIds.add(ourId);
-            }
-          }
-
-          // Send skip for this range
-          output.add(encodeBound(timestamp, idPrefix));
-          output.addByte(modeSkip);
-          break;
 
         default:
-          throw ArgumentError('Unknown mode: $mode');
+          throw ArgumentError('Unknown negentropy mode: $mode');
       }
 
       prevBound = currBound;
+      prevIndex = upper;
     }
 
-    return (output.toBytes(), needIds, haveIds);
+    // A trailing skip needs no encoding: the spec appends an implicit skip to
+    // infinity after the last range.
+    return output.toBytes();
+  }
+
+  /// Emits [lower, upper) either as an id list or as [_buckets] sub-ranges
+  /// covered by fingerprints, ending on [upperBound].
+  static void _splitRange(
+    List<NegentropyItem> items,
+    int lower,
+    int upper,
+    _Bound upperBound,
+    _MessageWriter output,
+  ) {
+    final numElems = upper - lower;
+
+    if (numElems < _idListThreshold) {
+      output.addBound(upperBound);
+      output.addVarint(modeIdList);
+      output.addVarint(numElems);
+      for (var i = lower; i < upper; i++) {
+        output.addBytes(items[i].id);
+      }
+      return;
+    }
+
+    final itemsPerBucket = numElems ~/ _buckets;
+    final bucketsWithExtra = numElems % _buckets;
+    var curr = lower;
+
+    for (var i = 0; i < _buckets; i++) {
+      final bucketSize = itemsPerBucket + (i < bucketsWithExtra ? 1 : 0);
+      final next = curr + bucketSize;
+
+      final bound = next >= upper
+          ? upperBound
+          : _minimalBound(items[next - 1], items[next]);
+
+      output.addBound(bound);
+      output.addVarint(modeFingerprint);
+      output.addBytes(
+        calculateFingerprint([
+          for (var j = curr; j < next; j++) items[j].id,
+        ]),
+      );
+
+      curr = next;
+    }
+  }
+
+  /// Shortest bound that separates [prev] from [curr]
+  static _Bound _minimalBound(NegentropyItem prev, NegentropyItem curr) {
+    if (curr.timestamp != prev.timestamp) {
+      return _Bound(curr.timestamp, Uint8List(0));
+    }
+
+    var shared = 0;
+    while (shared < idSize && curr.id[shared] == prev.id[shared]) {
+      shared++;
+    }
+
+    return _Bound(
+      curr.timestamp,
+      Uint8List.fromList(curr.id.sublist(0, shared + 1 > idSize ? idSize : shared + 1)),
+    );
+  }
+
+  /// Index of the first item at or after [bound], searching from [from]
+  static int _lowerBound(List<NegentropyItem> items, int from, _Bound bound) {
+    var low = from;
+    var high = items.length;
+
+    while (low < high) {
+      final mid = low + ((high - low) >> 1);
+      if (_compareItemToBound(items[mid], bound) < 0) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+
+    return low;
+  }
+
+  /// Sorts by (timestamp, id) ascending and drops duplicates
+  static List<NegentropyItem> _prepare(List<NegentropyItem> items) {
+    items.sort(_compareItems);
+
+    final prepared = <NegentropyItem>[];
+    for (final item in items) {
+      if (prepared.isNotEmpty && _compareItems(prepared.last, item) == 0) {
+        continue;
+      }
+      prepared.add(item);
+    }
+
+    return prepared;
+  }
+
+  static int _compareItems(NegentropyItem a, NegentropyItem b) {
+    final timestampCmp = a.timestamp.compareTo(b.timestamp);
+    if (timestampCmp != 0) return timestampCmp;
+    return _compareBytes(a.id, b.id);
+  }
+
+  /// Compares an item against a bound whose ID prefix is implicitly
+  /// zero-padded to [idSize] bytes.
+  static int _compareItemToBound(NegentropyItem item, _Bound bound) {
+    if (item.timestamp != bound.timestamp) {
+      return item.timestamp.compareTo(bound.timestamp);
+    }
+    for (var i = 0; i < idSize; i++) {
+      final boundByte = i < bound.idPrefix.length ? bound.idPrefix[i] : 0;
+      if (item.id[i] != boundByte) {
+        return item.id[i].compareTo(boundByte);
+      }
+    }
+    return 0;
   }
 
   static int _compareBytes(Uint8List a, Uint8List b) {
@@ -338,7 +497,7 @@ class NegentropyEncoder {
     return a.length.compareTo(b.length);
   }
 
-  static bool _bytesEqual(Uint8List a, Uint8List b) {
+  static bool _bytesEqual(List<int> a, List<int> b) {
     if (a.length != b.length) return false;
     for (var i = 0; i < a.length; i++) {
       if (a[i] != b[i]) return false;
@@ -346,25 +505,10 @@ class NegentropyEncoder {
     return true;
   }
 
-  static bool _isInRange(NegentropyItem item, _Bound lower, _Bound upper) {
-    // item >= lower AND item < upper
-    return _compareWithBound(item, lower) >= 0 &&
-        _compareWithBound(item, upper) < 0;
-  }
-
-  static bool _isBeforeBound(NegentropyItem item, _Bound bound) {
-    return _compareWithBound(item, bound) < 0;
-  }
-
-  static int _compareWithBound(NegentropyItem item, _Bound bound) {
-    if (item.timestamp != bound.timestamp) {
-      return item.timestamp.compareTo(bound.timestamp);
-    }
-    if (bound.idPrefix.isEmpty) {
-      return -1; // Empty prefix means "end of timestamp bucket"
-    }
-    return _compareBytes(item.id, bound.idPrefix);
-  }
+  static final _Bound _infinityBound = _Bound(
+    infiniteTimestamp,
+    Uint8List(0),
+  );
 }
 
 /// Represents an item for negentropy reconciliation
@@ -372,7 +516,17 @@ class NegentropyItem {
   final int timestamp;
   final Uint8List id;
 
-  NegentropyItem({required this.timestamp, required this.id});
+  NegentropyItem({required this.timestamp, required this.id}) {
+    if (id.length != NegentropyEncoder.idSize) {
+      throw ArgumentError(
+        'Negentropy IDs must be ${NegentropyEncoder.idSize} bytes, '
+        'got ${id.length}',
+      );
+    }
+    if (timestamp < 0 || timestamp >= NegentropyEncoder.infiniteTimestamp) {
+      throw ArgumentError('Negentropy timestamp out of range: $timestamp');
+    }
+  }
 
   factory NegentropyItem.fromHex({
     required int timestamp,
@@ -383,6 +537,33 @@ class NegentropyItem {
       id: NegentropyEncoder.hexToBytes(idHex),
     );
   }
+}
+
+/// Accumulates a message while delta encoding bound timestamps against the
+/// previously written bound.
+class _MessageWriter {
+  final BytesBuilder _output = BytesBuilder();
+  int _lastTimestamp = 0;
+
+  void addByte(int byte) => _output.addByte(byte);
+
+  void addBytes(Uint8List bytes) => _output.add(bytes);
+
+  void addVarint(int value) =>
+      _output.add(NegentropyEncoder.encodeVarint(value));
+
+  void addBound(_Bound bound) {
+    _output.add(
+      NegentropyEncoder.encodeBound(
+        bound.timestamp,
+        bound.idPrefix,
+        lastTimestamp: _lastTimestamp,
+      ),
+    );
+    _lastTimestamp = bound.timestamp;
+  }
+
+  Uint8List toBytes() => _output.toBytes();
 }
 
 class _Bound {

--- a/packages/ndk/test/nips/nip77_test.dart
+++ b/packages/ndk/test/nips/nip77_test.dart
@@ -1,7 +1,53 @@
+import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:ndk/shared/nips/nip77/negentropy.dart';
 import 'package:test/test.dart';
+
+Uint8List _id(int i) => Uint8List.fromList(sha256.convert([i]).bytes);
+
+List<NegentropyItem> _items(
+  int count, {
+  int baseTimestamp = 1700000000,
+  int step = 17,
+}) => [
+  for (var i = 0; i < count; i++)
+    NegentropyItem(timestamp: baseTimestamp + i * step, id: _id(i)),
+];
+
+/// Drives a full reconciliation to convergence and returns what the initiator
+/// learned.
+({List<String> needIds, List<String> haveIds, int rounds}) _syncToCompletion(
+  List<NegentropyItem> initiator,
+  List<NegentropyItem> responder, {
+  int maxRounds = 50,
+}) {
+  final needIds = <String>[];
+  final haveIds = <String>[];
+  var message = NegentropyEncoder.createInitialMessage(initiator);
+
+  for (var round = 1; round <= maxRounds; round++) {
+    final response = NegentropyEncoder.respond(message, responder);
+    if (response.length == 1) {
+      return (needIds: needIds, haveIds: haveIds, rounds: round);
+    }
+
+    final (next, newNeed, newHave) = NegentropyEncoder.reconcile(
+      response,
+      initiator,
+    );
+    needIds.addAll(newNeed);
+    haveIds.addAll(newHave);
+
+    if (next.length == 1) {
+      return (needIds: needIds, haveIds: haveIds, rounds: round);
+    }
+    message = next;
+  }
+
+  fail('reconciliation did not converge within $maxRounds rounds');
+}
 
 void main() {
   group('NegentropyEncoder Varint', () {
@@ -52,9 +98,63 @@ void main() {
         expect(decoded, equals(value), reason: 'Failed for value $value');
       }
     });
+
+    test('throws on truncated varint', () {
+      expect(
+        () => NegentropyEncoder.decodeVarint(Uint8List.fromList([0x81])),
+        throwsArgumentError,
+      );
+      expect(
+        () => NegentropyEncoder.decodeVarint(Uint8List(0)),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when the varint exceeds the supported range', () {
+      final tooBig = Uint8List.fromList([
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0x7F,
+      ]);
+      expect(
+        () => NegentropyEncoder.decodeVarint(tooBig),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('NegentropyEncoder Fingerprint', () {
+    // Golden values from an independent implementation of the
+    // Negentropy V1 fingerprint algorithm (sum of IDs mod 2^256 as
+    // little-endian integers, concatenated with a varint count, SHA-256,
+    // first 16 bytes). IDs are sha256([i]).
+    test('matches the spec for known ID sets', () {
+      final expected = {
+        0: '7f9c9e31ac8256ca2f258583df262dbc',
+        1: 'c7ff0bfd6010fdb4d1e3220933f1e183',
+        3: 'c67390ff1b306527670a720b71c13133',
+        8: 'a8c30ae01b85dbf46744d5eaafbd8229',
+      };
+
+      expected.forEach((count, hex) {
+        final ids = [for (var i = 0; i < count; i++) _id(i)];
+        expect(
+          NegentropyEncoder.bytesToHex(
+            NegentropyEncoder.calculateFingerprint(ids),
+          ),
+          equals(hex),
+          reason: 'fingerprint of $count IDs',
+        );
+      });
+    });
+
     test('empty list fingerprint', () {
       final fp = NegentropyEncoder.calculateFingerprint([]);
       expect(fp.length, equals(NegentropyEncoder.fingerprintSize));
@@ -81,18 +181,49 @@ void main() {
       expect(fp1, isNot(equals(fp2)));
     });
 
-    test('order matters for fingerprint', () {
-      final id1 = Uint8List(32);
-      final id2 = Uint8List(32);
-      id1[0] = 1;
-      id2[0] = 2;
+    test('is order independent', () {
+      final fp1 = NegentropyEncoder.calculateFingerprint([
+        _id(0),
+        _id(1),
+        _id(2),
+      ]);
+      final fp2 = NegentropyEncoder.calculateFingerprint([
+        _id(2),
+        _id(0),
+        _id(1),
+      ]);
+      final fp3 = NegentropyEncoder.calculateFingerprint([
+        _id(1),
+        _id(2),
+        _id(0),
+      ]);
 
-      final fp1 = NegentropyEncoder.calculateFingerprint([id1, id2]);
-      final fp2 = NegentropyEncoder.calculateFingerprint([id2, id1]);
-
-      // Sum is commutative, so fingerprints should be equal
-      // Actually, the sum mod 2^256 is commutative, so these should be equal
       expect(fp1, equals(fp2));
+      expect(fp2, equals(fp3));
+    });
+
+    test('carries between limbs of the 256 bit accumulator', () {
+      final allOnes = Uint8List(32)..fillRange(0, 32, 0xFF);
+      final one = Uint8List(32)..[0] = 1;
+
+      // 2^256 - 1 + 1 wraps to zero, which is the accumulator of an empty
+      // range, so only the element count separates the two fingerprints.
+      final wrapped = NegentropyEncoder.calculateFingerprint([allOnes, one]);
+      final zeroes = NegentropyEncoder.calculateFingerprint([
+        Uint8List(32),
+        Uint8List(32),
+      ]);
+
+      expect(wrapped, equals(zeroes));
+    });
+
+    test('fingerprint includes the element count', () {
+      final id = Uint8List(32)..[0] = 1;
+
+      final fp1 = NegentropyEncoder.calculateFingerprint([id]);
+      final fp2 = NegentropyEncoder.calculateFingerprint([id, id]);
+
+      expect(fp1, isNot(equals(fp2)));
     });
   });
 
@@ -136,6 +267,63 @@ void main() {
       expect(decodedPrefix, equals(prefix));
       expect(consumed, equals(encoded.length));
     });
+
+    test('delta encodes timestamps against the previous bound', () {
+      // 1 + (1700000100 - 1700000000) == 101
+      final encoded = NegentropyEncoder.encodeBound(
+        1700000100,
+        Uint8List(0),
+        lastTimestamp: 1700000000,
+      );
+      expect(encoded, equals([101, 0]));
+
+      final (ts, _, _) = NegentropyEncoder.decodeBound(
+        encoded,
+        0,
+        1700000000,
+      );
+      expect(ts, equals(1700000100));
+    });
+
+    test('encodes the infinity timestamp as zero', () {
+      final encoded = NegentropyEncoder.encodeBound(
+        NegentropyEncoder.infiniteTimestamp,
+        Uint8List(0),
+        lastTimestamp: 1700000000,
+      );
+      expect(encoded, equals([0, 0]));
+
+      final (ts, _, _) = NegentropyEncoder.decodeBound(
+        encoded,
+        0,
+        1700000000,
+      );
+      expect(ts, equals(NegentropyEncoder.infiniteTimestamp));
+    });
+
+    test('rejects decreasing timestamps', () {
+      expect(
+        () => NegentropyEncoder.encodeBound(
+          100,
+          Uint8List(0),
+          lastTimestamp: 200,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an over-long ID prefix', () {
+      expect(
+        () => NegentropyEncoder.encodeBound(1, Uint8List(33)),
+        throwsArgumentError,
+      );
+      expect(
+        () => NegentropyEncoder.decodeBound(
+          Uint8List.fromList([2, 33, ...List.filled(33, 0)]),
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('NegentropyItem', () {
@@ -147,199 +335,261 @@ void main() {
       expect(item.id.length, equals(32));
       expect(NegentropyEncoder.bytesToHex(item.id), equals(hexId));
     });
+
+    test('rejects IDs that are not 32 bytes', () {
+      expect(
+        () => NegentropyItem.fromHex(timestamp: 1000, idHex: 'aabb'),
+        throwsArgumentError,
+      );
+    });
   });
 
-  group('NegentropyEncoder Protocol', () {
-    test('creates initial message with version byte', () {
-      final items = <NegentropyItem>[];
-      final msg = NegentropyEncoder.createInitialMessage(
-        items,
-        NegentropyEncoder.idSize,
-      );
-      expect(msg[0], equals(NegentropyEncoder.protocolVersion));
+  group('NegentropyEncoder wire format', () {
+    // Golden messages produced by an independent implementation written
+    // directly from the Negentropy Protocol V1 spec.
+    test('initial message for an empty set is an empty ID list', () {
+      final msg = NegentropyEncoder.createInitialMessage([]);
+      expect(NegentropyEncoder.bytesToHex(msg), equals('6100000200'));
     });
 
-    test('creates initial message for empty items with fingerprint mode', () {
-      final items = <NegentropyItem>[];
-      final msg = NegentropyEncoder.createInitialMessage(
-        items,
-        NegentropyEncoder.idSize,
+    test('initial message for a small set is an ID list to infinity', () {
+      final msg = NegentropyEncoder.createInitialMessage(_items(3));
+      expect(
+        NegentropyEncoder.bytesToHex(msg),
+        equals(
+          '610000020'
+          '36e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d'
+          '4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a'
+          'dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986',
+        ),
       );
-      // Should have: version(1) + bound + mode(1) + fingerprint(16)
-      expect(msg.length, greaterThanOrEqualTo(1 + 16));
-      // Should use fingerprint mode, not skip
-      expect(msg.contains(NegentropyEncoder.modeFingerprint), isTrue);
     });
 
-    test('creates initial message for single item', () {
+    test('initial message for a large set is 16 fingerprint buckets', () {
+      final msg = NegentropyEncoder.createInitialMessage(_items(40));
+      expect(
+        NegentropyEncoder.bytesToHex(msg),
+        equals(
+          '6186aacfe2340001c67390ff1b306527670a720b71c1313334000168e8aac011'
+          '05aee8cbd5cef6d861d7853400017bdb8c88ea5c2575d64d4485c5f31d3b3400'
+          '01e57703823294d3e1bfb1fd48ad02e7fa340001e466c5e561f2086830cb942e'
+          '2012120e340001bcdad9758968b3e8858c463f277cd4e5340001abe26abb02d3'
+          'f24122bdc508a9f01ce2340001305acbaa7248174e19fc580550fa6b38230001'
+          'b5a057a5e1965d648738943acd9358162300011431730cce1783fa1dc714ffd0'
+          '2b8bfa23000171b0f1f0f5efe008d9fd5520268ed05f230001650d16d7641d13'
+          '18a09f3f69df601c66230001bcee68120de574cb63cdea05aa0073d223000105'
+          'd71f04b1dbcda58cc3537b15242d3e230001681e53ebcdfd0c76e7a3e5ea3a8e'
+          '993000000134fa1dc1e9052ea5984b6577a21e845e',
+        ),
+      );
+    });
+
+    test('uses minimal ID prefixes when timestamps collide', () {
       final items = [
-        NegentropyItem.fromHex(
-          timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-        ),
+        for (var i = 0; i < 40; i++)
+          NegentropyItem(timestamp: 1700000000, id: _id(i)),
       ];
-      final msg = NegentropyEncoder.createInitialMessage(
-        items,
-        NegentropyEncoder.idSize,
+      final msg = NegentropyEncoder.createInitialMessage(items);
+      expect(
+        NegentropyEncoder.bytesToHex(msg),
+        equals(
+          '6186aacfe201011f01d3a291a13bdbbeb688fe4cc887490b0501012f013fa762'
+          '0c1c5d8ea725f9108aeaf0e3e90101450178df7268a706b6e4c1c4a4b6f1fde7'
+          'd501014d01332bd0d364a1fa4bbd02ebaa5cb67dcf010168015fe304b8584ee2'
+          '855a6e920dbcf4749d01017c01c53c0157c33f9daf1c30c235a5675f8f01018f'
+          '01eee7e11a36e2a542730dce9bcc18a71c01019d011b716da103785d9b2dfea6'
+          '88dcff74850101bb0147f429640cd3b84a1fbd8c2250308b5d0101bd01b67cb5'
+          '757a57df84ba13fb802c75dd380101c5017b717ab4b889d84ff3959ffea49912'
+          'a60101db0184c7dac297950e8a907cd6d62efc4db60101e5011c5852a1e50dde'
+          'c660884334b4d878840102e7cf0138175aae4678cc025c5e508d6c02868c0101'
+          'f2013fa8bc22ac8d2b55f1fbec0f8ceb7991000001373a6e8fb77cfad502c265'
+          '359d45e7e0',
+        ),
       );
-      expect(msg[0], equals(NegentropyEncoder.protocolVersion));
-      expect(msg.length, greaterThan(1));
     });
 
-    test('creates initial message with fingerprint mode', () {
-      final items = [
-        NegentropyItem.fromHex(
-          timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    test('rejects an unknown protocol version', () {
+      expect(
+        () => NegentropyEncoder.reconcile(
+          Uint8List.fromList([0x62, 0x00, 0x00, 0x02, 0x00]),
+          [],
         ),
-        NegentropyItem.fromHex(
-          timestamp: 2000,
-          idHex:
-              'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
-        ),
-      ];
-      final msg = NegentropyEncoder.createInitialMessage(
-        items,
-        NegentropyEncoder.idSize,
+        throwsArgumentError,
       );
-      expect(msg[0], equals(NegentropyEncoder.protocolVersion));
-      // Should contain fingerprint (16 bytes) plus overhead
-      expect(msg.length, greaterThanOrEqualTo(1 + 16));
     });
 
-    test('sorts items by timestamp then id', () {
-      final items = [
-        NegentropyItem.fromHex(
-          timestamp: 2000,
-          idHex:
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    test('rejects an unknown mode', () {
+      expect(
+        () => NegentropyEncoder.reconcile(
+          Uint8List.fromList([0x61, 0x00, 0x00, 0x07]),
+          [],
         ),
-        NegentropyItem.fromHex(
-          timestamp: 1000,
-          idHex:
-              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-        ),
-        NegentropyItem.fromHex(
-          timestamp: 1000,
-          idHex:
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        ),
-      ];
-      // createInitialMessage sorts internally
-      final msg = NegentropyEncoder.createInitialMessage(
-        items,
-        NegentropyEncoder.idSize,
+        throwsArgumentError,
       );
-      expect(msg[0], equals(NegentropyEncoder.protocolVersion));
+    });
+
+    test('rejects a truncated ID list', () {
+      expect(
+        () => NegentropyEncoder.reconcile(
+          Uint8List.fromList([0x61, 0x00, 0x00, 0x02, 0x02, 0xAA]),
+          [],
+        ),
+        throwsArgumentError,
+      );
     });
   });
 
   group('NegentropyEncoder Reconcile', () {
-    test('reconcile with matching fingerprints returns empty lists', () {
-      final id1 =
-          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-      final id2 =
-          'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
-
-      final localItems = [
-        NegentropyItem.fromHex(timestamp: 1000, idHex: id1),
-        NegentropyItem.fromHex(timestamp: 2000, idHex: id2),
-      ];
-
-      // Create message from same items (simulating relay has same data)
-      final relayItems = [
-        NegentropyItem.fromHex(timestamp: 1000, idHex: id1),
-        NegentropyItem.fromHex(timestamp: 2000, idHex: id2),
-      ];
-
-      final relayMsg = NegentropyEncoder.createInitialMessage(
-        relayItems,
-        NegentropyEncoder.idSize,
-      );
-      final (response, needIds, haveIds) = NegentropyEncoder.reconcile(
-        relayMsg,
-        localItems,
-      );
-
-      // When fingerprints match, no IDs needed
-      expect(needIds, isEmpty);
-      expect(haveIds, isEmpty);
+    test('identical sets converge with nothing to exchange', () {
+      final result = _syncToCompletion(_items(3), _items(3));
+      expect(result.needIds, isEmpty);
+      expect(result.haveIds, isEmpty);
     });
 
-    test('reconcile detects missing local IDs (needIds)', () {
-      final id1 =
-          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-      final id2 =
-          'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+    test('reports IDs only the responder has as needIds', () {
+      final result = _syncToCompletion(_items(1), _items(3));
 
-      // Local has only id1
-      final localItems = [NegentropyItem.fromHex(timestamp: 1000, idHex: id1)];
-
-      // Relay has both
-      final relayItems = [
-        NegentropyItem.fromHex(timestamp: 1000, idHex: id1),
-        NegentropyItem.fromHex(timestamp: 2000, idHex: id2),
-      ];
-
-      final relayMsg = NegentropyEncoder.createInitialMessage(
-        relayItems,
-        NegentropyEncoder.idSize,
+      expect(result.haveIds, isEmpty);
+      expect(
+        result.needIds.toSet(),
+        equals({
+          NegentropyEncoder.bytesToHex(_id(1)),
+          NegentropyEncoder.bytesToHex(_id(2)),
+        }),
       );
-      NegentropyEncoder.reconcile(relayMsg, localItems);
-
-      // Fingerprints won't match, but full reconciliation needs multiple rounds
-      // Initial message just sends fingerprint, doesn't reveal individual IDs yet
-      expect(true, isTrue);
     });
 
-    test('reconcile with empty local items', () {
-      final localItems = <NegentropyItem>[];
+    test('reports IDs only the initiator has as haveIds', () {
+      final result = _syncToCompletion(_items(3), _items(1));
 
-      final relayItems = [
-        NegentropyItem.fromHex(
-          timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      expect(result.needIds, isEmpty);
+      expect(
+        result.haveIds.toSet(),
+        equals({
+          NegentropyEncoder.bytesToHex(_id(1)),
+          NegentropyEncoder.bytesToHex(_id(2)),
+        }),
+      );
+    });
+
+    test('empty initiator needs everything', () {
+      final result = _syncToCompletion([], _items(5));
+      expect(result.haveIds, isEmpty);
+      expect(result.needIds, hasLength(5));
+    });
+
+    test('empty responder needs nothing back', () {
+      final result = _syncToCompletion(_items(5), []);
+      expect(result.needIds, isEmpty);
+      expect(result.haveIds, hasLength(5));
+    });
+
+    // ndk#718: against a relay holding 53 of 236 cached events the answer is
+    // 183 to send and 0 to fetch.
+    test('large partially overlapping sets reconcile exactly', () {
+      final local = _items(236);
+      final remote = [for (var i = 0; i < 53; i++) local[i * 4]];
+
+      final result = _syncToCompletion(local, remote);
+
+      expect(result.needIds, isEmpty);
+      expect(result.haveIds, hasLength(183));
+      expect(
+        result.haveIds.toSet(),
+        equals(
+          local
+              .where((item) => !remote.contains(item))
+              .map((item) => NegentropyEncoder.bytesToHex(item.id))
+              .toSet(),
         ),
-      ];
-
-      final relayMsg = NegentropyEncoder.createInitialMessage(
-        relayItems,
-        NegentropyEncoder.idSize,
       );
-      final (response, needIds, haveIds) = NegentropyEncoder.reconcile(
-        relayMsg,
-        localItems,
-      );
-
-      // Should produce a valid response
-      expect(response[0], equals(NegentropyEncoder.protocolVersion));
     });
 
-    test('reconcile with empty relay items', () {
-      final localItems = [
-        NegentropyItem.fromHex(
-          timestamp: 1000,
-          idHex:
-              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-        ),
+    test('sets differing at both ends reconcile exactly', () {
+      final local = _items(50);
+      final remote = [
+        ..._items(50).skip(20),
+        for (var i = 0; i < 10; i++)
+          NegentropyItem(timestamp: 1800000000 + i, id: _id(200 + i)),
       ];
 
-      final relayItems = <NegentropyItem>[];
+      final result = _syncToCompletion(local, remote);
 
-      final relayMsg = NegentropyEncoder.createInitialMessage(
-        relayItems,
-        NegentropyEncoder.idSize,
-      );
-      final (response, needIds, haveIds) = NegentropyEncoder.reconcile(
-        relayMsg,
-        localItems,
-      );
+      expect(result.needIds, hasLength(10));
+      expect(result.haveIds, hasLength(20));
+    });
 
-      // Should produce a valid response
-      expect(response[0], equals(NegentropyEncoder.protocolVersion));
+    test('sets sharing a timestamp reconcile exactly', () {
+      final local = [
+        for (var i = 0; i < 60; i++)
+          NegentropyItem(timestamp: 1700000000, id: _id(i)),
+      ];
+      final remote = [
+        for (var i = 20; i < 80; i++)
+          NegentropyItem(timestamp: 1700000000, id: _id(i)),
+      ];
+
+      final result = _syncToCompletion(local, remote);
+
+      expect(result.haveIds, hasLength(20));
+      expect(result.needIds, hasLength(20));
+    });
+
+    test('duplicate local items do not confuse reconciliation', () {
+      final local = [..._items(5), ..._items(5)];
+      final result = _syncToCompletion(local, _items(5));
+
+      expect(result.needIds, isEmpty);
+      expect(result.haveIds, isEmpty);
+    });
+
+    test('random set pairs reconcile exactly', () {
+      final random = Random(0x77);
+
+      for (var trial = 0; trial < 40; trial++) {
+        final universe = [
+          for (var i = 0; i < 250; i++)
+            NegentropyItem(
+              // A small timestamp spread guarantees collisions, which is what
+              // exercises the ID-prefix bounds.
+              timestamp: 1700000000 + random.nextInt(20),
+              id: _id(i),
+            ),
+        ];
+
+        final local = <NegentropyItem>[];
+        final remote = <NegentropyItem>[];
+        for (final item in universe) {
+          if (random.nextInt(3) != 0) local.add(item);
+          if (random.nextInt(3) != 0) remote.add(item);
+        }
+
+        final localIds = local.map((i) => i.id).map(NegentropyEncoder.bytesToHex);
+        final remoteIds = remote
+            .map((i) => i.id)
+            .map(NegentropyEncoder.bytesToHex);
+
+        final result = _syncToCompletion(local, remote);
+
+        expect(
+          result.haveIds.toSet(),
+          equals(localIds.toSet().difference(remoteIds.toSet())),
+          reason: 'trial $trial haveIds',
+        );
+        expect(
+          result.needIds.toSet(),
+          equals(remoteIds.toSet().difference(localIds.toSet())),
+          reason: 'trial $trial needIds',
+        );
+      }
+    });
+
+    test('a converged reconciliation returns only the version byte', () {
+      final message = NegentropyEncoder.createInitialMessage(_items(3));
+      final response = NegentropyEncoder.respond(message, _items(3));
+      final (next, _, _) = NegentropyEncoder.reconcile(response, _items(3));
+
+      expect(next, equals([NegentropyEncoder.protocolVersion]));
     });
   });
 
@@ -368,50 +618,6 @@ void main() {
       final (decoded, consumed) = NegentropyEncoder.decodeVarint(data, 2);
       expect(decoded, equals(300));
       expect(consumed, equals(2));
-    });
-  });
-
-  group('NegentropyEncoder Fingerprint XOR Properties', () {
-    test('XOR is commutative (order independent)', () {
-      final id1 = Uint8List(32);
-      final id2 = Uint8List(32);
-      final id3 = Uint8List(32);
-      id1[0] = 1;
-      id2[0] = 2;
-      id3[0] = 3;
-
-      final fp1 = NegentropyEncoder.calculateFingerprint([id1, id2, id3]);
-      final fp2 = NegentropyEncoder.calculateFingerprint([id3, id1, id2]);
-      final fp3 = NegentropyEncoder.calculateFingerprint([id2, id3, id1]);
-
-      expect(fp1, equals(fp2));
-      expect(fp2, equals(fp3));
-    });
-
-    test('same ID twice cancels out (XOR property)', () {
-      final id1 = Uint8List(32);
-      final id2 = Uint8List(32);
-      id1[0] = 1;
-      id2[0] = 2;
-
-      // [id1, id2] should NOT equal [id1, id2, id1, id1] because count differs
-      final fp1 = NegentropyEncoder.calculateFingerprint([id1, id2]);
-      final fp2 = NegentropyEncoder.calculateFingerprint([id1, id2, id1, id1]);
-
-      // Different counts = different fingerprints
-      expect(fp1, isNot(equals(fp2)));
-    });
-
-    test('fingerprint includes count', () {
-      final id = Uint8List(32);
-      id[0] = 1;
-
-      // Same IDs but different counts
-      final fp1 = NegentropyEncoder.calculateFingerprint([id]);
-      final fp2 = NegentropyEncoder.calculateFingerprint([id, id]);
-
-      // XOR of same ID = 0, but counts differ (1 vs 2)
-      expect(fp1, isNot(equals(fp2)));
     });
   });
 


### PR DESCRIPTION
Nip77.reconcile returned wrong have/need sets without erroring because the codec did not implement the wire format relays speak.

Fixes #718 