### PR TITLE
ci: stop running analyze and format twice per push

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -2,8 +2,13 @@ name: analyze
 
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,8 +2,13 @@ name: format
 
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dart-format:


### PR DESCRIPTION
Both workflows triggered on push and pull_request without a branch filter, so every push to a non-fork PR branch produced two identical runs. Limit push to master and add a concurrency group that cancels superseded runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated analysis now runs for updates to the master branch, pull requests, and manual triggers.
  * Formatting checks now run for updates to the master branch.
  * Superseded workflow runs are automatically canceled to reduce redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->