### PR TITLE
feat: add optional maxFeeMsat to pay_invoice (NIP-47 max_fee)

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/nwc/consts/error_code.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/consts/error_code.dart
@@ -29,6 +29,10 @@ enum ErrorCode {
   ),
   unauthorized('UNAUTHORIZED', 'This public key has no wallet connected.'),
   internal('INTERNAL', 'An internal error.'),
+  feeLimitExceeded(
+    'FEE_LIMIT_EXCEEDED',
+    'No route fit the max_fee budget and no payment was attempted.',
+  ),
   other('OTHER', 'Other error.');
 
   final String value;

--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
@@ -506,11 +506,12 @@ class Nwc {
   Future<PayInvoiceResponse> payInvoice(
     NwcConnection connection, {
     required String invoice,
+    int? maxFeeMsat,
     Duration? timeout,
   }) async {
     return _executeRequest<PayInvoiceResponse>(
       connection,
-      PayInvoiceRequest(invoice: invoice),
+      PayInvoiceRequest(invoice: invoice, maxFeeMsat: maxFeeMsat),
       timeout: timeout,
     );
   }

--- a/packages/ndk/lib/domain_layer/usecases/nwc/requests/pay_invoice.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/requests/pay_invoice.dart
@@ -5,15 +5,20 @@ import 'nwc_request.dart';
 // Subclass for requests to pay a bolt11 invoice
 class PayInvoiceRequest extends NwcRequest {
   final String invoice;
+  final int? maxFeeSat;
 
-  const PayInvoiceRequest({required this.invoice})
-      : super(method: NwcMethod.PAY_INVOICE);
+  const PayInvoiceRequest({required this.invoice, int? maxFeeMsat})
+      : maxFeeSat = maxFeeMsat == null ? null : maxFeeMsat ~/ 1000,
+        super(method: NwcMethod.PAY_INVOICE);
 
   @override
   Map<String, dynamic> toMap() {
     return {
       ...super.toMap(),
-      'params': {'invoice': invoice},
+      'params': {
+        'invoice': invoice,
+        if (maxFeeSat != null) 'max_fee': maxFeeSat! * 1000,
+      },
     };
   }
 }


### PR DESCRIPTION
Implements the `max_fee` parameter proposed for NIP-47 pay_invoice. Also adds the `FEE_LIMIT_EXCEEDED` error code.

Wallets that support the parameter will not send payments whose routing fee exceeds the budget; wallets that don't implement it ignore the parameter per spec.

https://github.com/nostr-protocol/nips/pull/2444