### PR TITLE
fix: add timeout to nwc makeHoldInvoice

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nwc/nwc.dart
@@ -467,6 +467,7 @@ class Nwc {
     String? descriptionHash,
     int? expiry,
     required String paymentHash,
+    Duration? timeout,
   }) async {
     return _executeRequest<MakeInvoiceResponse>(
       connection,
@@ -477,6 +478,7 @@ class Nwc {
         expiry: expiry,
         paymentHash: paymentHash,
       ),
+      timeout: timeout,
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added an optional timeout setting for hold invoice requests.
  * Callers can now extend or reduce the request duration instead of relying on the default timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->