### PR TITLE
fix: kind not allowed is a permanet failure

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/broadcast/delivery_policy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/delivery_policy.dart
@@ -56,6 +56,10 @@ class DeliveryPolicy {
     'policy violation',
   ];
 
+  static final RegExp _kindNotAllowedPattern = RegExp(
+    r'\bkind(?:\s+\d+)?\s+is\s+not\s+allowed\b',
+  );
+
   final DeliveryPolicyKind kind;
 
   const DeliveryPolicy._(this.kind);
@@ -177,7 +181,8 @@ class DeliveryPolicy {
       }
     }
 
-    return _permanentFailureMarkers.any(normalized.contains);
+    return _permanentFailureMarkers.any(normalized.contains) ||
+        _kindNotAllowedPattern.hasMatch(normalized);
   }
 
   static String? _machineReadablePrefix(String normalizedMessage) {

--- a/packages/ndk/test/usecases/broadcast_delivery_policy_test.dart
+++ b/packages/ndk/test/usecases/broadcast_delivery_policy_test.dart
@@ -209,6 +209,17 @@ void main() {
             relayUrl: 'wss://relay.example',
             okReceived: false,
             broadcastSuccessful: false,
+            msg: 'kind 1059 is not allowed on this relay',
+          ),
+        ),
+        RelayDeliveryState.permanentFailure,
+      );
+      expect(
+        policy.resolveNextState(
+          RelayBroadcastResponse(
+            relayUrl: 'wss://relay.example',
+            okReceived: false,
+            broadcastSuccessful: false,
             msg: 'restricted: not allowed to write',
           ),
         ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of relay responses indicating that an event kind is not allowed.
  * Such responses are now recognized as permanent delivery failures, preventing unnecessary retry attempts.

* **Tests**
  * Added coverage for relay responses that reject specific event kinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->