### PR TITLE
fix: multiple instances with dedicated GlobalState

### DIFF
--- a/packages/ndk/CHANGELOG.md
+++ b/packages/ndk/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.9.1-dev.1
 
+ - **FIX**: isolate relay, request, broadcast, and authentication state per NDK instance.
  - **FEAT**: publishDmRelays.
  - **FEAT**: allow explicit dm relay discovery.
  - **FEAT**: add explicit legacy nip04 dms.

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
@@ -82,7 +82,7 @@ class JitEngine with Logger implements NetworkEngine {
       }
 
       if ((filter.authors != null && filter.authors!.isNotEmpty)) {
-        RelayJitPubkeyStrategy.handleRequest(
+        await RelayJitPubkeyStrategy.handleRequest(
           globalState: globalState,
           relayManager: relayManagerLight,
           requestState: requestState,
@@ -102,7 +102,7 @@ class JitEngine with Logger implements NetworkEngine {
       }
 
       if (filter.pTags?.isNotEmpty != null && filter.pTags!.isNotEmpty) {
-        RelayJitPubkeyStrategy.handleRequest(
+        await RelayJitPubkeyStrategy.handleRequest(
           relayManager: relayManagerLight,
           globalState: globalState,
           requestState: requestState,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
@@ -196,57 +196,63 @@ class RelayJitPubkeyStrategy with Logger {
       }
     }
 
-    // connect to the new found relays and send out the request
+    // Start every candidate immediately. Awaiting inside this loop would make
+    // an unreachable relay consume the full connection timeout before the next
+    // useful candidate is even attempted.
+    final connectionAttempts = <Future<void>>[];
     for (final relayCandidate in relayRanking.ranking) {
       if (relayCandidate.score <= 0) {
         continue;
       }
-      // check if the relayCandidate is already connected
-      bool alreadyConnected = connectedRelays.any(
-        (element) => element.url == relayCandidate.relayUrl,
-      );
-
-      if (!alreadyConnected) {
-        final success = await relayManger.connectRelay(
-          dirtyUrl: relayCandidate.relayUrl,
-          connectionSource: ConnectionSource.pubkeyStrategy,
+      connectionAttempts.add(() async {
+        // check if the relayCandidate is already connected
+        final alreadyConnected = connectedRelays.any(
+          (element) => element.url == relayCandidate.relayUrl,
         );
-        if (!success.first) {
-          markCandidateUnavailable(relayCandidate);
-          Logger.log.w(
-            () =>
-                "Could not connect to relay: ${relayCandidate.relayUrl} - errorHandling",
+
+        if (!alreadyConnected) {
+          final success = await relayManger.connectRelay(
+            dirtyUrl: relayCandidate.relayUrl,
+            connectionSource: ConnectionSource.pubkeyStrategy,
           );
-          continue;
+          if (!success.first) {
+            markCandidateUnavailable(relayCandidate);
+            Logger.log.w(
+              () =>
+                  "Could not connect to relay: ${relayCandidate.relayUrl} - errorHandling",
+            );
+            return;
+          }
         }
-      }
 
-      final myRelayConnectivity = globalState
-          .relays[RelayConnectionKey.anonymous(relayCandidate.relayUrl)];
-      if (myRelayConnectivity
-          is! RelayConnectivity<JitEngineRelayConnectivityData>) {
-        markCandidateUnavailable(relayCandidate);
-        continue;
-      }
+        final myRelayConnectivity = globalState
+            .relays[RelayConnectionKey.anonymous(relayCandidate.relayUrl)];
+        if (myRelayConnectivity
+            is! RelayConnectivity<JitEngineRelayConnectivityData>) {
+          markCandidateUnavailable(relayCandidate);
+          return;
+        }
 
-      myRelayConnectivity.specificEngineData!.addPubkeysToAssignedPubkeys(
-        relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
-        direction,
-      );
+        myRelayConnectivity.specificEngineData!.addPubkeysToAssignedPubkeys(
+          relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
+          direction,
+        );
 
-      _sendRequestToSocket(
-        myRelayConnectivity,
-        requestState,
-        [
-          _splitFilter(
-            filter,
-            relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
-          ),
-        ],
-        globalState,
-        relayManger,
-      );
+        _sendRequestToSocket(
+          myRelayConnectivity,
+          requestState,
+          [
+            _splitFilter(
+              filter,
+              relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
+            ),
+          ],
+          globalState,
+          relayManger,
+        );
+      }());
     }
+    await Future.wait(connectionAttempts);
 
     return unresolvedByPubkey.values
         .where((pubkey) => pubkey.missingCoverage > 0)

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
@@ -35,7 +35,7 @@ import '../../user_relay_lists/user_relay_lists.dart';
 ///
 
 class RelayJitPubkeyStrategy with Logger {
-  static void handleRequest({
+  static Future<void> handleRequest({
     required RequestState requestState,
     required GlobalState globalState,
 
@@ -52,7 +52,7 @@ class RelayJitPubkeyStrategy with Logger {
     required ReadWriteMarker direction,
     required List<String> ignoreRelays,
     required RelayManager relayManager,
-  }) {
+  }) async {
     List<String> combindedPubkeys = [
       ...?filter.authors,
       ...?filter.pTags,
@@ -109,7 +109,7 @@ class RelayJitPubkeyStrategy with Logger {
       return;
     }
 
-    _findRelaysForUnresolvedPubkeys(
+    final unresolvedPubkeys = await _findRelaysForUnresolvedPubkeys(
       requestState: requestState,
       globalState: globalState,
       relayManger: relayManager,
@@ -123,7 +123,9 @@ class RelayJitPubkeyStrategy with Logger {
       closeOnEOSE: closeOnEOSE,
     );
 
-    _removeFullyCoveredPubkeys(coveragePubkeys);
+    coveragePubkeys
+      ..clear()
+      ..addAll(unresolvedPubkeys);
 
     if (coveragePubkeys.isEmpty) {
       // we are done
@@ -148,7 +150,7 @@ class RelayJitPubkeyStrategy with Logger {
   // looks in nip65 data for not covered pubkeys
   // the result is relay candidates
   // connects to these candidates and sends out the request
-  static void _findRelaysForUnresolvedPubkeys({
+  static Future<List<CoveragePubkey>> _findRelaysForUnresolvedPubkeys({
     required RelayManager relayManger,
     required RequestState requestState,
     required GlobalState globalState,
@@ -179,9 +181,20 @@ class RelayJitPubkeyStrategy with Logger {
       ignoreRelays: ignoreRelays,
     );
 
-    // update coveragePubkeys to the not found ones
-    // this is need so early on so the not found pubkeys can be blasted to all connected relays
-    coveragePubkeys = relayRanking.notCoveredPubkeys;
+    final unresolvedByPubkey = {
+      for (final pubkey in relayRanking.notCoveredPubkeys)
+        pubkey.pubkey: pubkey,
+    };
+
+    void markCandidateUnavailable(RelayRanking relayCandidate) {
+      for (final coveredPubkey in relayCandidate.coveredPubkeys) {
+        final unresolved = unresolvedByPubkey.putIfAbsent(
+          coveredPubkey.pubkey,
+          () => CoveragePubkey(coveredPubkey.pubkey, desiredCoverage, 0),
+        );
+        unresolved.missingCoverage++;
+      }
+    }
 
     // connect to the new found relays and send out the request
     for (final relayCandidate in relayRanking.ranking) {
@@ -194,84 +207,50 @@ class RelayJitPubkeyStrategy with Logger {
       );
 
       if (!alreadyConnected) {
-        relayManger
-            .connectRelay(
+        final success = await relayManger.connectRelay(
           dirtyUrl: relayCandidate.relayUrl,
           connectionSource: ConnectionSource.pubkeyStrategy,
-        )
-            .then((success) {
-          if (success.first) {
-            final myRelayConnectivity =
-                globalState.relays[RelayConnectionKey.anonymous(
-              relayCandidate.relayUrl,
-            )] as RelayConnectivity<JitEngineRelayConnectivityData>;
-            // add assigned pubkeys
-            myRelayConnectivity.specificEngineData!.addPubkeysToAssignedPubkeys(
-              relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
-              direction,
-            );
-
-            // send out the request
-            _sendRequestToSocket(
-              myRelayConnectivity,
-              requestState,
-              [
-                _splitFilter(
-                  filter,
-                  relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
-                ),
-              ],
-              globalState,
-              relayManger,
-            );
-          }
-
-          if (!success.first) {
-            Logger.log.w(
-              () =>
-                  "Could not connect to relay: ${relayCandidate.relayUrl} - errorHandling",
-            );
-            // _connectionErrorHandling(
-            //   errorRelay: newRelay,
-            //   requestState: requestState,
-            //   filter: filter,
-            //   connectedRelays: connectedRelays,
-            //   cacheManager: cacheManager,
-            //   desiredCoverage: desiredCoverage,
-            //   direction: direction,
-            //   ignoreRelays: ignoreRelays,
-            //   closeOnEOSE: closeOnEOSE,
-
-            // );
-          }
-        });
+        );
+        if (!success.first) {
+          markCandidateUnavailable(relayCandidate);
+          Logger.log.w(
+            () =>
+                "Could not connect to relay: ${relayCandidate.relayUrl} - errorHandling",
+          );
+          continue;
+        }
       }
 
-      if (alreadyConnected) {
-        final myRelayConnectivity =
-            globalState.relays[RelayConnectionKey.anonymous(
-          relayCandidate.relayUrl,
-        )] as RelayConnectivity<JitEngineRelayConnectivityData>;
-
-        myRelayConnectivity.specificEngineData!.addPubkeysToAssignedPubkeys(
-          relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
-          direction,
-        );
-
-        _sendRequestToSocket(
-          myRelayConnectivity,
-          requestState,
-          [
-            _splitFilter(
-              filter,
-              relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
-            ),
-          ],
-          globalState,
-          relayManger,
-        );
+      final myRelayConnectivity = globalState
+          .relays[RelayConnectionKey.anonymous(relayCandidate.relayUrl)];
+      if (myRelayConnectivity
+          is! RelayConnectivity<JitEngineRelayConnectivityData>) {
+        markCandidateUnavailable(relayCandidate);
+        continue;
       }
+
+      myRelayConnectivity.specificEngineData!.addPubkeysToAssignedPubkeys(
+        relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
+        direction,
+      );
+
+      _sendRequestToSocket(
+        myRelayConnectivity,
+        requestState,
+        [
+          _splitFilter(
+            filter,
+            relayCandidate.coveredPubkeys.map((e) => e.pubkey).toList(),
+          ),
+        ],
+        globalState,
+        relayManger,
+      );
     }
+
+    return unresolvedByPubkey.values
+        .where((pubkey) => pubkey.missingCoverage > 0)
+        .toList();
   }
 
   // adds the relay to ignoreRelays and retries the request for assigned pubkeys to this relay
@@ -325,8 +304,8 @@ void _sendRequestToSocket(
   GlobalState globalState,
   RelayManager relayManager,
 ) {
-  if (globalState.inFlightRequests[requestState.id] == null) {
-    globalState.inFlightRequests[requestState.id] = requestState;
+  if (!identical(globalState.inFlightRequests[requestState.id], requestState)) {
+    return;
   }
   // link the request id to the relay
   relayManager.registerRelayRequest(

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart
@@ -166,11 +166,28 @@ class RelayJitPubkeyStrategy with Logger {
   }) async {
     /// ### resolve not covered pubkeys ###
     // look in nip65 data for not covered pubkeys
-    List<UserRelayList> nip65Data =
-        await UserRelayLists.getUserRelayListCacheLatest(
-      pubkeys: coveragePubkeys.map((e) => e.pubkey).toList(),
-      cacheManager: cacheManager,
-    );
+    late final List<UserRelayList> nip65Data;
+    try {
+      nip65Data = await UserRelayLists.getUserRelayListCacheLatest(
+        pubkeys: coveragePubkeys.map((e) => e.pubkey).toList(),
+        cacheManager: cacheManager,
+      );
+    } catch (error, stackTrace) {
+      Logger.log.w(
+        () => "Could not load relay lists; falling back to bootstrap relays",
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return coveragePubkeys
+          .map(
+            (pubkey) => CoveragePubkey(
+              pubkey.pubkey,
+              pubkey.desiredCoverage,
+              pubkey.missingCoverage,
+            ),
+          )
+          .toList();
+    }
 
     // by finding the best relays to connect and send out the request
     RelayRankingResult relayRanking = rankRelays(

--- a/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
+++ b/packages/ndk/lib/domain_layer/usecases/nip05/nip_05.dart
@@ -6,9 +6,10 @@ import '../../repositories/nip_05_repo.dart';
 
 /// usecase to handle Nip05 operations (verify and fetch)
 class Nip05Usecase {
-  // Static map to keep track of in-flight requests
-  static final Map<String, Future<Nip05>> _inFlightRequests = {};
-  static final Map<String, Future<Nip05ResolveResult>> _inFlightResolves = {};
+  // Keep request deduplication local to this use case/NDK instance. Different
+  // instances may use different repositories and caches for the same NIP-05.
+  final Map<String, Future<Nip05>> _inFlightRequests = {};
+  final Map<String, Future<Nip05ResolveResult>> _inFlightResolves = {};
 
   final CacheManager _database;
   final Nip05Repository _nip05Repository;

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1401,24 +1401,14 @@ class RelayManager<T> {
     return logged != null && logged.signer.canSign() ? logged : null;
   }
 
-  /// Handles OK auth-required for broadcasts by authenticating and re-sending the EVENT
-  ///
-  /// This is the last place that still authenticates in place, because
-  /// BroadcastState is keyed by relay url and cannot yet track an event across
-  /// two connections. It goes away with the broadcast lot.
+  /// Handles OK auth-required for broadcasts by moving the retry onto an
+  /// account-bound connection, authenticating it once, and re-sending EVENT.
+  /// Concurrent broadcasts share [authenticateConnection], avoiding duplicate
+  /// AUTH events whose identical ids used to overwrite each other's callbacks.
   void _handleBroadcastAuthRequired(
     String eventId,
     RelayConnectivity relayConnectivity,
   ) {
-    final challenge = _lastChallengePerConnection[relayConnectivity.key];
-    if (challenge == null) {
-      Logger.log.w(
-        () =>
-            "Received OK auth-required but no challenge stored for ${relayConnectivity.url}",
-      );
-      return;
-    }
-
     final broadcastState = globalState.inFlightBroadcasts[eventId];
     if (broadcastState == null) {
       Logger.log.w(
@@ -1455,54 +1445,42 @@ class RelayManager<T> {
       return;
     }
 
-    Logger.log.d(
-      () =>
-          "AUTH required for EVENT $eventId on ${relayConnectivity.url}, authenticating...",
+    final boundKey = RelayConnectionKey.authenticated(
+      relayConnectivity.url,
+      account.pubkey,
     );
 
-    // Create AUTH event
-    final auth = AuthEvent(
-      pubKey: account.pubkey,
-      tags: [
-        ["relay", relayConnectivity.url],
-        ["challenge", challenge],
-      ],
-    );
-
-    // Sign and send AUTH, then re-send EVENT on OK
-    final generation = _generationOf(relayConnectivity.key);
-    account.signer.sign(auth).then((signedAuth) {
-      if (_generationOf(relayConnectivity.key) != generation) {
+    Future<void> retryOnBoundConnection() async {
+      final bound = await openConnectionAs(
+        relayConnectivity.url,
+        account!,
+        connectionSource: relayConnectivity.relay.connectionSource,
+      );
+      if (bound == null ||
+          globalState.inFlightBroadcasts[eventId] != broadcastState) {
+        failBroadcast(eventId, relayConnectivity.url, 'auth connection failed');
         return;
       }
 
-      _registerPendingAuth(
-        authEventId: signedAuth.id,
-        key: relayConnectivity.key,
-        onResult: (accepted) {
-          if (!accepted) {
-            return;
-          }
-          Logger.log.d(
-            () =>
-                "AUTH OK received, re-sending EVENT $eventId to ${relayConnectivity.url}",
-          );
-          send(
-            relayConnectivity,
-            ClientMsg(ClientMsgType.kEvent, event: eventToResend),
-          );
-        },
-      );
+      // Some relays challenge immediately; others only after seeing EVENT on
+      // the bound socket. Trigger the latter, then the next auth-required OK
+      // enters this method with the bound key and authenticates below.
+      if (relayConnectivity.key != boundKey &&
+          !_authenticatedConnections.contains(boundKey)) {
+        send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
+        return;
+      }
 
-      send(
-        relayConnectivity,
-        ClientMsg(ClientMsgType.kAuth, event: signedAuth),
-      );
-      Logger.log.d(
-        () =>
-            "AUTH sent for ${account!.pubkey.substring(0, 8)} to ${relayConnectivity.url}, waiting for OK...",
-      );
-    });
+      final accepted = await authenticateConnection(boundKey);
+      if (!accepted ||
+          globalState.inFlightBroadcasts[eventId] != broadcastState) {
+        failBroadcast(eventId, relayConnectivity.url, 'authentication failed');
+        return;
+      }
+      send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
+    }
+
+    unawaited(retryOnBoundConnection());
   }
 
   void _checkNetworkClose(RequestState state) {

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1451,33 +1451,65 @@ class RelayManager<T> {
     );
 
     Future<void> retryOnBoundConnection() async {
-      final bound = await openConnectionAs(
-        relayConnectivity.url,
-        account!,
-        connectionSource: relayConnectivity.relay.connectionSource,
-      );
-      if (bound == null ||
-          globalState.inFlightBroadcasts[eventId] != broadcastState) {
-        failBroadcast(eventId, relayConnectivity.url, 'auth connection failed');
-        return;
-      }
+      try {
+        final bound = await openConnectionAs(
+          relayConnectivity.url,
+          account!,
+          connectionSource: relayConnectivity.relay.connectionSource,
+        );
+        if (!identical(
+          globalState.inFlightBroadcasts[eventId],
+          broadcastState,
+        )) {
+          return;
+        }
+        if (bound == null) {
+          failBroadcast(
+            eventId,
+            relayConnectivity.url,
+            'auth connection failed',
+          );
+          return;
+        }
 
-      // Some relays challenge immediately; others only after seeing EVENT on
-      // the bound socket. Trigger the latter, then the next auth-required OK
-      // enters this method with the bound key and authenticates below.
-      if (relayConnectivity.key != boundKey &&
-          !_authenticatedConnections.contains(boundKey)) {
+        // Some relays challenge immediately; others only after seeing EVENT on
+        // the bound socket. Trigger the latter, then the next auth-required OK
+        // enters this method with the bound key and authenticates below.
+        if (relayConnectivity.key != boundKey &&
+            !_authenticatedConnections.contains(boundKey)) {
+          send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
+          return;
+        }
+
+        final accepted = await authenticateConnection(boundKey);
+        if (!identical(
+          globalState.inFlightBroadcasts[eventId],
+          broadcastState,
+        )) {
+          return;
+        }
+        if (!accepted) {
+          failBroadcast(
+            eventId,
+            relayConnectivity.url,
+            'authentication failed',
+          );
+          return;
+        }
         send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
-        return;
+      } catch (error, stackTrace) {
+        Logger.log.e(
+          () => "Broadcast auth retry failed for $eventId",
+          error: error,
+          stackTrace: stackTrace,
+        );
+        if (identical(
+          globalState.inFlightBroadcasts[eventId],
+          broadcastState,
+        )) {
+          failBroadcast(eventId, relayConnectivity.url, 'auth retry failed');
+        }
       }
-
-      final accepted = await authenticateConnection(boundKey);
-      if (!accepted ||
-          globalState.inFlightBroadcasts[eventId] != broadcastState) {
-        failBroadcast(eventId, relayConnectivity.url, 'authentication failed');
-        return;
-      }
-      send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
     }
 
     unawaited(retryOnBoundConnection());

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1477,7 +1477,10 @@ class RelayManager<T> {
         // enters this method with the bound key and authenticates below.
         if (relayConnectivity.key != boundKey &&
             !_authenticatedConnections.contains(boundKey)) {
-          send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
+          await sendOrThrow(
+            bound,
+            ClientMsg(ClientMsgType.kEvent, event: eventToResend),
+          );
           return;
         }
 
@@ -1496,7 +1499,10 @@ class RelayManager<T> {
           );
           return;
         }
-        send(bound, ClientMsg(ClientMsgType.kEvent, event: eventToResend));
+        await sendOrThrow(
+          bound,
+          ClientMsg(ClientMsgType.kEvent, event: eventToResend),
+        );
       } catch (error, stackTrace) {
         Logger.log.e(
           () => "Broadcast auth retry failed for $eventId",

--- a/packages/ndk/lib/presentation_layer/ndk.dart
+++ b/packages/ndk/lib/presentation_layer/ndk.dart
@@ -37,23 +37,24 @@ import 'ndk_config.dart';
 /// Main entry point for the NDK (Nostr Development Kit) library.
 ///
 /// This file contains the primary class [Ndk] which provides access to various
-/// Nostr-related functionalities/usecases and manages the global state of the application.
+/// Nostr-related functionalities/usecases and manages the state of this NDK instance.
 class Ndk {
   /// Configuration for the NDK instance
   final NdkConfig config;
 
-  /// Global state shared across the application
-  static final GlobalState _globalState = GlobalState();
+  /// Request, broadcast, and relay state owned by this NDK instance.
+  final GlobalState _globalState;
 
   /// Internal initialization object for setting up repositories and usecases
-  final Initialization _initialization;
+  late final Initialization _initialization;
 
   /// Creates a new instance of [Ndk] with the given [config]
-  Ndk(this.config)
-      : _initialization = Initialization(
-          ndkConfig: config,
-          globalState: _globalState,
-        );
+  Ndk(this.config) : _globalState = GlobalState() {
+    _initialization = Initialization(
+      ndkConfig: config,
+      globalState: _globalState,
+    );
+  }
 
   /// Creates a new instance of [Ndk] with default configuration
   Ndk.defaultConfig()

--- a/packages/ndk/test/multiple_ndk_instances_test.dart
+++ b/packages/ndk/test/multiple_ndk_instances_test.dart
@@ -1,0 +1,299 @@
+import 'dart:async';
+
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:test/test.dart';
+
+import 'mocks/mock_relay.dart';
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+  String reason = 'condition never became true',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+  fail(reason);
+}
+
+Ndk _createNdk({List<String> bootstrapRelays = const []}) => Ndk(
+      NdkConfig(
+        cache: MemCacheManager(),
+        eventVerifier: Bip340EventVerifier(),
+        bootstrapRelays: bootstrapRelays,
+      ),
+    );
+
+void main() {
+  group('multiple NDK instances', () {
+    test('own independent runtime state', () async {
+      final first = _createNdk();
+      final second = _createNdk();
+
+      expect(first.relays.globalState, isNot(same(second.relays.globalState)));
+
+      first.relays.globalState.blockedRelays.add('wss://blocked.example');
+      expect(second.relays.globalState.blockedRelays, isEmpty);
+
+      await first.destroy();
+      await second.destroy();
+    });
+
+    test(
+      'destroying one instance leaves the other subscribed and connected',
+      () async {
+        final relay = MockRelay(name: 'multiple-ndk-lifecycle');
+        await relay.startServer();
+
+        final first = _createNdk(bootstrapRelays: [relay.url]);
+        final second = _createNdk(bootstrapRelays: [relay.url]);
+        var secondDestroyed = false;
+
+        try {
+          await Future.wait([
+            first.relays.seedRelaysConnected,
+            second.relays.seedRelaysConnected,
+          ]);
+          await _waitUntil(
+            () => relay.connectedClientCount == 2,
+            reason: 'each NDK instance did not open its own relay connection',
+          );
+
+          final key = Bip340.generatePrivateKey();
+          final receivedByFirst = Completer<Nip01Event>();
+          final firstSubscription = first.requests.subscription(
+            id: 'same-subscription-id',
+            filter: Filter(
+              kinds: [Nip01Event.kTextNodeKind],
+              authors: [key.publicKey],
+            ),
+            explicitRelays: [relay.url],
+          );
+          firstSubscription.stream.listen((event) {
+            if (!receivedByFirst.isCompleted) receivedByFirst.complete(event);
+          });
+
+          second.requests.subscription(
+            id: 'same-subscription-id',
+            filter: Filter(
+              kinds: [Nip01Event.kTextNodeKind],
+              authors: [key.publicKey],
+            ),
+            explicitRelays: [relay.url],
+          );
+
+          await _waitUntil(
+            () => relay.activeSubscriptionCount == 2,
+            reason: 'both NDK subscriptions were not registered',
+          );
+
+          secondDestroyed = true;
+          await second.destroy();
+
+          await _waitUntil(
+            () =>
+                relay.connectedClientCount == 1 &&
+                relay.activeSubscriptionCount == 1,
+            reason: 'destroying the second NDK affected the first NDK runtime',
+          );
+
+          first
+              .relays
+              .globalState
+              .relays[RelayConnectionKey.anonymous(relay.url)]!
+              .relay
+              .lastConnectTry = 0;
+          await relay.closeClientSockets();
+          await _waitUntil(
+            () =>
+                relay.connectedClientCount == 1 &&
+                relay.activeSubscriptionCount == 1,
+            reason: 'the destroyed NDK reconnected or the live NDK did not',
+          );
+
+          final event = Nip01Utils.signWithPrivateKey(
+            event: Nip01Event(
+              pubKey: key.publicKey,
+              kind: Nip01Event.kTextNodeKind,
+              tags: const [],
+              content: 'first instance remains live',
+            ),
+            privateKey: key.privateKey!,
+          );
+          await first.broadcast.broadcast(
+              nostrEvent: event,
+              specificRelays: [relay.url]).broadcastDoneFuture;
+
+          expect(
+            (await receivedByFirst.future.timeout(const Duration(seconds: 2)))
+                .id,
+            event.id,
+          );
+        } finally {
+          if (!secondDestroyed) await second.destroy();
+          await first.destroy();
+          await relay.stopServer();
+        }
+      },
+    );
+
+    test('broadcast acknowledgements cannot cross instances', () async {
+      final acceptingRelay = MockRelay(name: 'multiple-ndk-accept');
+      final rejectingRelay = MockRelay(
+        name: 'multiple-ndk-reject',
+        rejectFirstEventPublishes: 1,
+        rejectEventMessage: 'blocked: test rejection',
+      );
+      await acceptingRelay.startServer(
+        delayResponse: const Duration(milliseconds: 300),
+      );
+      await rejectingRelay.startServer();
+
+      final first = _createNdk(bootstrapRelays: [acceptingRelay.url]);
+      final second = _createNdk(bootstrapRelays: [rejectingRelay.url]);
+
+      try {
+        await Future.wait([
+          first.relays.seedRelaysConnected,
+          second.relays.seedRelaysConnected,
+        ]);
+
+        final key = Bip340.generatePrivateKey();
+        final event = Nip01Utils.signWithPrivateKey(
+          event: Nip01Event(
+            pubKey: key.publicKey,
+            kind: Nip01Event.kTextNodeKind,
+            tags: const [],
+            content: 'same event, independent broadcasts',
+          ),
+          privateKey: key.privateKey!,
+        );
+
+        final accepted = first.broadcast.broadcast(
+          nostrEvent: event,
+          specificRelays: [acceptingRelay.url],
+          timeout: const Duration(seconds: 2),
+        );
+        final rejected = second.broadcast.broadcast(
+          nostrEvent: event,
+          specificRelays: [rejectingRelay.url],
+          timeout: const Duration(seconds: 2),
+        );
+
+        final results = await Future.wait([
+          accepted.broadcastDoneFuture,
+          rejected.broadcastDoneFuture,
+        ]);
+
+        expect(results[0], hasLength(1));
+        expect(results[0].single.relayUrl, acceptingRelay.url);
+        expect(results[0].single.broadcastSuccessful, isTrue);
+        expect(results[1], hasLength(1));
+        expect(results[1].single.relayUrl, rejectingRelay.url);
+        expect(results[1].single.broadcastSuccessful, isFalse);
+      } finally {
+        await first.destroy();
+        await second.destroy();
+        await acceptingRelay.stopServer();
+        await rejectingRelay.stopServer();
+      }
+    });
+
+    test('NIP-42 authentication uses each instance account', () async {
+      final relay = MockRelay(
+        name: 'multiple-ndk-auth',
+        requireAuthForRequests: true,
+        signEvents: false,
+        challengePerConnection: true,
+      );
+      final noteKey = Bip340.generatePrivateKey();
+      final note = Nip01Utils.signWithPrivateKey(
+        event: Nip01Event(
+          pubKey: noteKey.publicKey,
+          kind: Nip01Event.kTextNodeKind,
+          tags: const [],
+          content: 'authenticated result',
+        ),
+        privateKey: noteKey.privateKey!,
+      );
+      await relay.startServer(textNotes: {noteKey: note});
+
+      final firstKey = Bip340.generatePrivateKey();
+      final secondKey = Bip340.generatePrivateKey();
+      final first = _createNdk(bootstrapRelays: [relay.url]);
+      final second = _createNdk(bootstrapRelays: [relay.url]);
+
+      try {
+        first.accounts.loginPrivateKey(
+          pubkey: firstKey.publicKey,
+          privkey: firstKey.privateKey!,
+        );
+        second.accounts.loginPrivateKey(
+          pubkey: secondKey.publicKey,
+          privkey: secondKey.privateKey!,
+        );
+
+        await Future.wait([
+          first.relays.seedRelaysConnected,
+          second.relays.seedRelaysConnected,
+        ]);
+
+        final results = await Future.wait([
+          first.requests.query(
+            filter: Filter(ids: [note.id]),
+            explicitRelays: [relay.url],
+            authenticateAs: [first.accounts.getLoggedAccount()!],
+          ).future,
+          second.requests.query(
+            filter: Filter(ids: [note.id]),
+            explicitRelays: [relay.url],
+            authenticateAs: [second.accounts.getLoggedAccount()!],
+          ).future,
+        ]);
+
+        expect(results[0].map((event) => event.id), contains(note.id));
+        expect(results[1].map((event) => event.id), contains(note.id));
+        expect(relay.connectionsAuthenticatedAs(firstKey.publicKey), 1);
+        expect(relay.connectionsAuthenticatedAs(secondKey.publicKey), 1);
+
+        final firstConnectionKeys = first.relays.globalState.relays.keys;
+        final secondConnectionKeys = second.relays.globalState.relays.keys;
+        expect(
+          firstConnectionKeys,
+          contains(RelayConnectionKey.authenticated(
+            relay.url,
+            firstKey.publicKey,
+          )),
+        );
+        expect(
+          firstConnectionKeys,
+          isNot(contains(RelayConnectionKey.authenticated(
+            relay.url,
+            secondKey.publicKey,
+          ))),
+        );
+        expect(
+          secondConnectionKeys,
+          contains(RelayConnectionKey.authenticated(
+            relay.url,
+            secondKey.publicKey,
+          )),
+        );
+        expect(
+          secondConnectionKeys,
+          isNot(contains(RelayConnectionKey.authenticated(
+            relay.url,
+            firstKey.publicKey,
+          ))),
+        );
+      } finally {
+        await first.destroy();
+        await second.destroy();
+        await relay.stopServer();
+      }
+    });
+  });
+}

--- a/packages/ndk/test/multiple_ndk_instances_test.dart
+++ b/packages/ndk/test/multiple_ndk_instances_test.dart
@@ -108,6 +108,10 @@ void main() {
               .lastConnectTry = 0;
           await relay.closeClientSockets();
           await _waitUntil(
+            () => relay.connectedClientCount == 0,
+            reason: 'the relay never observed the closed client sockets',
+          );
+          await _waitUntil(
             () =>
                 relay.connectedClientCount == 1 &&
                 relay.activeSubscriptionCount == 1,

--- a/packages/ndk/test/usecases/jit_engine/relay_jit_connection_test.dart
+++ b/packages/ndk/test/usecases/jit_engine/relay_jit_connection_test.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
 import 'package:ndk/data_layer/repositories/nostr_transport/websocket_nostr_transport_factory.dart';
+import 'package:ndk/domain_layer/entities/connection_source.dart';
 import 'package:ndk/domain_layer/entities/global_state.dart';
+import 'package:ndk/domain_layer/entities/jit_engine_relay_connectivity_data.dart';
+import 'package:ndk/domain_layer/entities/relay_connectivity.dart';
 import 'package:ndk/domain_layer/entities/request_state.dart';
 import 'package:ndk/domain_layer/entities/user_relay_list.dart';
 import 'package:ndk/domain_layer/repositories/nostr_transport.dart';
@@ -290,7 +293,67 @@ void main() async {
       delayedTransport.open();
       await handling;
     });
+
+    test('blasts to bootstrap relays when relay-list cache throws', () async {
+      final fallbackUrl = 'ws://fallback.example';
+      final fallbackTransport = _ControlledTransport(open: true);
+      final factory = _ControlledTransportFactory({
+        fallbackUrl: fallbackTransport,
+      });
+      addTearDown(fallbackTransport.close);
+
+      final globalState = GlobalState();
+      final relayManager = RelayManager<JitEngineRelayConnectivityData>(
+        bootstrapRelays: const [],
+        globalState: globalState,
+        nostrTransportFactory: factory,
+        engineAdditionalDataFactory: JitEngineRelayConnectivityDataFactory(),
+      );
+      final connected = await relayManager.connectRelay(
+        dirtyUrl: fallbackUrl,
+        connectionSource: ConnectionSource.pubkeyStrategy,
+      );
+      expect(connected.first, isTrue);
+
+      final requestState = RequestState(
+        NdkRequest.query(
+          'cache-error-fallback',
+          timeoutDuration: const Duration(seconds: 2),
+          filters: [
+            Filter(authors: [key1.publicKey])
+          ],
+        ),
+      );
+      globalState.inFlightRequests[requestState.id] = requestState;
+
+      await RelayJitPubkeyStrategy.handleRequest(
+        requestState: requestState,
+        globalState: globalState,
+        filter: requestState.unresolvedFilters.single,
+        connectedRelays: relayManager.connectedAnonymousRelays
+            .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
+            .toList(),
+        bootstrapRelays: [fallbackUrl],
+        cacheManager: _ThrowingUserRelayListCache(),
+        desiredCoverage: 1,
+        closeOnEOSE: true,
+        direction: ReadWriteMarker.writeOnly,
+        ignoreRelays: const [],
+        relayManager: relayManager,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fallbackTransport.sentData, hasLength(1));
+      expect(fallbackTransport.sentData.single, contains('"REQ"'));
+      expect(fallbackTransport.sentData.single, contains(key1.publicKey));
+    });
   });
+}
+
+class _ThrowingUserRelayListCache extends MemCacheManager {
+  @override
+  Future<UserRelayList?> loadUserRelayList(String pubKey) =>
+      Future.error(StateError('cache unavailable'));
 }
 
 class _ControlledTransportFactory implements NostrTransportFactory {
@@ -313,6 +376,7 @@ class _ControlledTransportFactory implements NostrTransportFactory {
 class _ControlledTransport implements NostrTransport {
   final StreamController<dynamic> _messages = StreamController.broadcast();
   final Completer<void> _ready = Completer<void>();
+  final List<dynamic> sentData = [];
   bool _open;
 
   _ControlledTransport({required bool open}) : _open = open {
@@ -364,5 +428,5 @@ class _ControlledTransport implements NostrTransport {
       _messages.stream.listen(onData, onError: onError, onDone: onDone);
 
   @override
-  void send(dynamic data) {}
+  void send(dynamic data) => sentData.add(data);
 }

--- a/packages/ndk/test/usecases/jit_engine/relay_jit_connection_test.dart
+++ b/packages/ndk/test/usecases/jit_engine/relay_jit_connection_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:ndk/data_layer/repositories/nostr_transport/websocket_nostr_transport_factory.dart';
 import 'package:ndk/domain_layer/entities/global_state.dart';
 import 'package:ndk/domain_layer/entities/request_state.dart';
 import 'package:ndk/domain_layer/entities/user_relay_list.dart';
 import 'package:ndk/domain_layer/repositories/nostr_transport.dart';
+import 'package:ndk/domain_layer/usecases/jit_engine/relay_jit_request_strategies/relay_jit_pubkey_strategy.dart';
 import 'package:ndk/domain_layer/usecases/relay_manager.dart';
 import 'package:ndk/ndk.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
@@ -216,5 +219,150 @@ void main() async {
         await stopServers();
       },
     );
+
+    test('starts relay candidate connections concurrently', () async {
+      final delayedUrl = 'ws://delayed.example';
+      final immediateUrl = 'ws://immediate.example';
+      final delayedTransport = _ControlledTransport(open: false);
+      final immediateTransport = _ControlledTransport(open: true);
+      final factory = _ControlledTransportFactory({
+        delayedUrl: delayedTransport,
+        immediateUrl: immediateTransport,
+      });
+      addTearDown(() async {
+        await delayedTransport.close();
+        await immediateTransport.close();
+      });
+
+      final relayLists = [
+        Nip65.fromMap(key1.publicKey, {
+          delayedUrl: ReadWriteMarker.readWrite,
+        }),
+        Nip65.fromMap(key2.publicKey, {
+          delayedUrl: ReadWriteMarker.readWrite,
+        }),
+        Nip65.fromMap(key3.publicKey, {
+          immediateUrl: ReadWriteMarker.readWrite,
+        }),
+      ];
+      final cacheManager = MemCacheManager();
+      await cacheManager.saveUserRelayLists(
+        relayLists.map(UserRelayList.fromNip65).toList(),
+      );
+
+      final globalState = GlobalState();
+      final relayManager = RelayManager(
+        bootstrapRelays: const [],
+        globalState: globalState,
+        nostrTransportFactory: factory,
+      );
+      final requestState = RequestState(
+        NdkRequest.query(
+          'concurrent-candidates',
+          timeoutDuration: const Duration(seconds: 2),
+          filters: [
+            Filter(authors: [
+              key1.publicKey,
+              key2.publicKey,
+              key3.publicKey,
+            ]),
+          ],
+        ),
+      );
+
+      final handling = RelayJitPubkeyStrategy.handleRequest(
+        requestState: requestState,
+        globalState: globalState,
+        filter: requestState.unresolvedFilters.single,
+        connectedRelays: const [],
+        bootstrapRelays: const [],
+        cacheManager: cacheManager,
+        desiredCoverage: 1,
+        closeOnEOSE: true,
+        direction: ReadWriteMarker.writeOnly,
+        ignoreRelays: const [],
+        relayManager: relayManager,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(factory.startedUrls, containsAll([delayedUrl, immediateUrl]));
+
+      delayedTransport.open();
+      await handling;
+    });
   });
+}
+
+class _ControlledTransportFactory implements NostrTransportFactory {
+  final Map<String, _ControlledTransport> transports;
+  final List<String> startedUrls = [];
+
+  _ControlledTransportFactory(this.transports);
+
+  @override
+  NostrTransport call(
+    String url, {
+    Function? onReconnect,
+    Function(int?, Object?, String?)? onDisconnect,
+  }) {
+    startedUrls.add(url);
+    return transports[url]!;
+  }
+}
+
+class _ControlledTransport implements NostrTransport {
+  final StreamController<dynamic> _messages = StreamController.broadcast();
+  final Completer<void> _ready = Completer<void>();
+  bool _open;
+
+  _ControlledTransport({required bool open}) : _open = open {
+    ready = _ready.future;
+    if (open) {
+      _ready.complete();
+    }
+  }
+
+  void open() {
+    _open = true;
+    if (!_ready.isCompleted) {
+      _ready.complete();
+    }
+  }
+
+  @override
+  late Future<void> ready;
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    if (!_ready.isCompleted) {
+      _ready.complete();
+    }
+    if (!_messages.isClosed) {
+      await _messages.close();
+    }
+  }
+
+  @override
+  int? closeCode() => null;
+
+  @override
+  String? closeReason() => null;
+
+  @override
+  bool isConnecting() => !_open;
+
+  @override
+  bool isOpen() => _open;
+
+  @override
+  StreamSubscription listen(
+    void Function(dynamic) onData, {
+    Function? onError,
+    void Function()? onDone,
+  }) =>
+      _messages.stream.listen(onData, onError: onError, onDone: onDone);
+
+  @override
+  void send(dynamic data) {}
 }

--- a/packages/ndk/test/usecases/nip42_auth_test.dart
+++ b/packages/ndk/test/usecases/nip42_auth_test.dart
@@ -155,6 +155,77 @@ void authTests(NdkEngine engine) {
     );
 
     test(
+      'concurrent gift wraps share authenticated retry without losing one',
+      timeout: const Timeout(Duration(seconds: 5)),
+      () async {
+        final senderKey = Bip340.generatePrivateKey();
+        final recipientKey = Bip340.generatePrivateKey();
+        final relay = MockRelay(
+          name: "concurrent gift wrap auth relay",
+          requireAuthForEvents: true,
+        );
+        await relay.startServer();
+
+        final ndk = Ndk(
+          NdkConfig(
+            eventVerifier: MockEventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay.url],
+            defaultBroadcastTimeout: const Duration(seconds: 2),
+            engine: engine,
+          ),
+        );
+        addTearDown(() async {
+          await ndk.destroy();
+          await relay.stopServer();
+        });
+        ndk.accounts.loginPrivateKey(
+          pubkey: senderKey.publicKey,
+          privkey: senderKey.privateKey!,
+        );
+
+        Future<Nip01Event> wrap(String content) async {
+          final rumor = await ndk.giftWrap.createRumor(
+            content: content,
+            kind: Nip01Event.kTextNodeKind,
+            tags: [
+              ["p", recipientKey.publicKey],
+            ],
+          );
+          return ndk.giftWrap.toGiftWrap(
+            rumor: rumor,
+            recipientPubkey: recipientKey.publicKey,
+          );
+        }
+
+        final wraps = await Future.wait([wrap('one'), wrap('two')]);
+        final broadcasts = wraps
+            .map(
+              (event) => ndk.broadcast.broadcast(
+                  nostrEvent: event,
+                  specificRelays: [relay.url]).broadcastDoneFuture,
+            )
+            .toList();
+        final results = await Future.wait(broadcasts);
+
+        expect(
+          results.every(
+            (result) => result.any((response) => response.broadcastSuccessful),
+          ),
+          isTrue,
+        );
+        for (final event in wraps) {
+          expect(
+            relay.receivedEvents
+                .where((received) => received.id == event.id)
+                .length,
+            greaterThanOrEqualTo(2),
+          );
+        }
+      },
+    );
+
+    test(
       'request should complete when relay requires auth but sends no challenge',
       timeout: const Timeout(Duration(seconds: 5)),
       () async {


### PR DESCRIPTION
fixes #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Isolated relay, request, broadcast, and authentication state between separate NDK instances.
  - Improved relay discovery, connectivity validation, and fallback handling for author- and tag-based requests.
  - Fixed authentication-required broadcasts to retry reliably and resend events correctly.
  - Prevented duplicate in-flight NIP-05 requests from being shared across instances.
  - Improved concurrent relay connection handling for targeted requests.

- **Tests**
  - Added coverage for independent multi-instance behavior, concurrent authenticated broadcasts, relay connection timing, and fallback request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->