### PR TITLE
fix: paginate each relay of a relay set on its own

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
+++ b/packages/ndk/lib/domain_layer/usecases/requests/requests.dart
@@ -546,12 +546,14 @@ class Requests {
           final pageFilter = filter.clone();
           pageFilter.until = state.currentUntil;
 
+          // no relaySet: it takes precedence over explicitRelays in the relay
+          // sets engine, which would send this page to the whole set with the
+          // `until` of a single relay
           final response = requestNostrEvent(
             NdkRequest.query(
               '$name-page-${Helpers.getRandomString(5)}',
               name: name,
               filters: [pageFilter],
-              relaySet: relaySet,
               cacheRead: false, // Don't read from cache for subsequent pages
               cacheWrite: cacheWrite,
               timeoutDuration: timeout,

--- a/packages/ndk/test/usecases/fetched_ranges/fetched_ranges_integration_test.dart
+++ b/packages/ndk/test/usecases/fetched_ranges/fetched_ranges_integration_test.dart
@@ -97,8 +97,7 @@ void main() async {
         expect(
           relayFetchedRanges.ranges.first.since,
           equals(textNotes[key1]!.createdAt),
-          reason:
-              'Range since should start at the oldest event received, the '
+          reason: 'Range since should start at the oldest event received, the '
               'relay may have truncated anything older',
         );
         expect(
@@ -354,9 +353,8 @@ void main() async {
           limit: 10,
         );
 
-        final events = await ndk.requests
-            .query(filter: filter, cacheRead: false)
-            .future;
+        final events =
+            await ndk.requests.query(filter: filter, cacheRead: false).future;
 
         await Future.delayed(const Duration(milliseconds: 100));
 
@@ -367,9 +365,8 @@ void main() async {
         expect(relayFetchedRanges!.ranges.length, equals(1));
 
         final range = relayFetchedRanges.ranges.first;
-        final oldestReturned = events
-            .map((e) => e.createdAt)
-            .reduce((a, b) => a < b ? a : b);
+        final oldestReturned =
+            events.map((e) => e.createdAt).reduce((a, b) => a < b ? a : b);
 
         expect(
           oldestReturned,
@@ -379,8 +376,7 @@ void main() async {
         expect(
           range.since,
           equals(oldestReturned),
-          reason:
-              'range must start at the oldest returned event, the 20 older '
+          reason: 'range must start at the oldest returned event, the 20 older '
               'events were never fetched',
         );
         expect(
@@ -465,9 +461,8 @@ void main() async {
           limit: 50,
         );
 
-        final events = await ndk.requests
-            .query(filter: filter, cacheRead: false)
-            .future;
+        final events =
+            await ndk.requests.query(filter: filter, cacheRead: false).future;
 
         expect(
           events.length,
@@ -483,9 +478,8 @@ void main() async {
         expect(relayFetchedRanges, isNotNull);
         expect(relayFetchedRanges!.ranges.length, equals(1));
 
-        final oldestReturned = events
-            .map((e) => e.createdAt)
-            .reduce((a, b) => a < b ? a : b);
+        final oldestReturned =
+            events.map((e) => e.createdAt).reduce((a, b) => a < b ? a : b);
 
         expect(
           oldestReturned,

--- a/packages/ndk/test/usecases/paginated_query_test.dart
+++ b/packages/ndk/test/usecases/paginated_query_test.dart
@@ -319,5 +319,85 @@ void main() async {
 
       await relay2.stopServer();
     });
+
+    test('paginates each relay of a relay set independently', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // relay 1 holds more history than a page can carry, relay 2 a single much
+      // older event, so a page bound to the whole set would drag relay 1 past
+      // the events it has left
+      final relay1Timestamps = [
+        now,
+        now - 1000,
+        now - 2000,
+        now - 3000,
+        now - 4000,
+      ];
+      final relay2Timestamps = [now, now - 9000];
+
+      Future<Nip01Event> signedEventAt(int createdAt) async => signer.sign(
+            Nip01Event(
+              kind: Nip01Event.kTextNodeKind,
+              pubKey: key1.publicKey,
+              content: "Event at $createdAt",
+              tags: [],
+              createdAt: createdAt,
+            ),
+          );
+
+      final relay2 = MockRelay(
+        name: "relay 2",
+        explicitPort: 6072,
+        maxEventsPerRequest: 2,
+      );
+      await relay2.startServer();
+
+      try {
+        for (final ts in relay1Timestamps) {
+          final response = ndk.broadcast.broadcast(
+            nostrEvent: await signedEventAt(ts),
+            specificRelays: [relay1.url],
+          );
+          await response.broadcastDoneFuture;
+        }
+
+        for (final ts in relay2Timestamps) {
+          final response = ndk.broadcast.broadcast(
+            nostrEvent: await signedEventAt(ts),
+            specificRelays: [relay2.url],
+          );
+          await response.broadcastDoneFuture;
+        }
+
+        await ndk.config.cache.clearAll();
+
+        final relaySet = RelaySet(
+          name: "pagination",
+          pubKey: key1.publicKey,
+          relaysMap: {relay1.url: [], relay2.url: []},
+          direction: RelayDirection.outbox,
+          fallbackToBootstrapRelays: false,
+        );
+
+        final query = ndk.requests.query(
+          filter: Filter(
+            kinds: [Nip01Event.kTextNodeKind],
+            authors: [key1.publicKey],
+          ),
+          relaySet: relaySet,
+          paginate: true,
+        );
+
+        final events = await query.future;
+
+        final createdAt = events.map((e) => e.createdAt).toSet();
+        expect(
+          createdAt,
+          equals({...relay1Timestamps, ...relay2Timestamps}),
+        );
+      } finally {
+        await relay2.stopServer();
+      }
+    });
   });
 }


### PR DESCRIPTION
A page was opened with both the relay set and the single relay it was for. The relay sets engine reads the relay set first and never looks at explicitRelays, so every page went to the whole set with the `until` of one relay. That relay's cursor then jumped to the oldest event any relay in the set returned, past the events it had left to serve.