### PR TITLE
fix(release): isolate version generation

### DIFF
--- a/packages/ndk/tool/update_version.dart
+++ b/packages/ndk/tool/update_version.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+void main() {
+  final pubspec = File('pubspec.yaml').readAsStringSync();
+  final match = RegExp(
+    r'^version:\s*(.*?)\s*(?:#.*)?$',
+    multiLine: true,
+  ).firstMatch(pubspec);
+
+  if (match == null) {
+    stderr.writeln('pubspec.yaml does not have a version defined.');
+    exitCode = 1;
+    return;
+  }
+
+  var version = match.group(1)!;
+  if (version.length >= 2 &&
+      ((version.startsWith("'") && version.endsWith("'")) ||
+          (version.startsWith('"') && version.endsWith('"')))) {
+    version = version.substring(1, version.length - 1);
+  }
+  if (!RegExp(r'^[0-9A-Za-z.+-]+$').hasMatch(version)) {
+    stderr.writeln('Unsupported version in pubspec.yaml: $version');
+    exitCode = 1;
+    return;
+  }
+
+  File('lib/src/version.dart').writeAsStringSync('''
+// Generated code. Do not modify.
+const packageVersion = '$version';
+''');
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ melos:
     version:
       hooks:
         preCommit: |
-          melos exec --fail-fast --scope="ndk" -- "dart run build_runner build --delete-conflicting-outputs"
+          melos exec --fail-fast --scope="ndk" -- "dart run tool/update_version.dart"
           git add packages/ndk/lib/src/version.dart
 
   scripts:


### PR DESCRIPTION
Replace the full build_runner invocation in the Melos version hook with a focused Dart generator. This keeps lib/src/version.dart synchronized with pubspec.yaml without modifying or deleting checked-in Mockito outputs during publish validation.\n\nVerified in a fresh clone: only lib/src/version.dart changes, dart analyze passes, and git diff --check passes.