### PR TITLE
fix(cli): avoid wallet startup network work

### DIFF
--- a/packages/ndk/bin/ndk.dart
+++ b/packages/ndk/bin/ndk.dart
@@ -25,7 +25,5 @@ Future<void> main(List<String> args) async {
   );
 
   final exitCode = await app.run(args);
-  if (exitCode != 0) {
-    exit(exitCode);
-  }
+  exit(exitCode);
 }

--- a/packages/ndk/lib/data_layer/repositories/wallets/sembast_wallets_repo.dart
+++ b/packages/ndk/lib/data_layer/repositories/wallets/sembast_wallets_repo.dart
@@ -36,6 +36,9 @@ class SembastWalletsRepo extends WalletsRepo {
     _keyValueStore = sembast.stringMapStoreFactory.store('key_values');
   }
 
+  /// Closes the underlying database.
+  Future<void> close() => _database.close();
+
   Future<void> initializeWalletDefaults() async {
     final receiving = await _keyValueStore
         .record(defaultWalletForReceivingKey)

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -216,18 +216,20 @@ class Initialization {
       cacheManager: _ndkConfig.cache,
       pendingDelivery: pendingBroadcastDelivery,
     );
-    _relayConnectivitySubscription = relayManager.relayConnectivityChanges
-        .listen(_handleRelayConnectivityUpdate);
-    pendingBroadcastDelivery.startPeriodicRetry(
-      connectedRelayUrls: () =>
-          relayManager.connectedRelays.map((relay) => relay.url),
-      reconnectRelay: (relayUrl) => relayManager.reconnectRelay(
-        relayUrl,
-        connectionSource: ConnectionSource.explicit,
-        force: true,
-      ),
-      retryInterval: _ndkConfig.pendingDeliveryRetryInterval,
-    );
+    if (_ndkConfig.pendingDeliveryRetriesEnabled) {
+      _relayConnectivitySubscription = relayManager.relayConnectivityChanges
+          .listen(_handleRelayConnectivityUpdate);
+      pendingBroadcastDelivery.startPeriodicRetry(
+        connectedRelayUrls: () =>
+            relayManager.connectedRelays.map((relay) => relay.url),
+        reconnectRelay: (relayUrl) => relayManager.reconnectRelay(
+          relayUrl,
+          connectionSource: ConnectionSource.explicit,
+          force: true,
+        ),
+        retryInterval: _ndkConfig.pendingDeliveryRetryInterval,
+      );
+    }
 
     // Initialize nwc and cashu before walletsOperationsRepo since they are dependencies
     nwc = Nwc(

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -91,6 +91,13 @@ class NdkConfig {
   /// Interval for retrying pending broadcast deliveries while relays remain connected.
   Duration pendingDeliveryRetryInterval;
 
+  /// Whether persisted broadcast deliveries are retried automatically in the
+  /// background.
+  ///
+  /// Disable this for short-lived clients such as command-line tools that
+  /// should only perform the network work requested by the current command.
+  bool pendingDeliveryRetriesEnabled;
+
   /// Default trusted providers for NIP-85 trusted assertions.
   List<Nip85TrustedProvider> defaultTrustedProviders;
 
@@ -143,6 +150,7 @@ class NdkConfig {
     this.eagerAuth = false,
     this.authCallbackTimeout = RequestDefaults.DEFAULT_AUTH_CALLBACK_TIMEOUT,
     this.pendingDeliveryRetryInterval = const Duration(seconds: 15),
+    this.pendingDeliveryRetriesEnabled = true,
     this.defaultTrustedProviders = DEFAULT_NIP85_PROVIDERS,
     this.cacheEvictionEnabled = false,
     this.cacheEvictionPolicy = const EvictionPolicy(),

--- a/packages/ndk/lib/src/cli/accounts/accounts_cli_command.dart
+++ b/packages/ndk/lib/src/cli/accounts/accounts_cli_command.dart
@@ -10,7 +10,7 @@ import '../cli_command.dart';
 ///
 /// Identities are persisted in plaintext at [CliAccountsStore.defaultPath].
 /// See [CliAccountRecord] for the security trade-off.
-class AccountsCliCommand implements CliCommand {
+class AccountsCliCommand extends CliCommand {
   @override
   String get name => 'accounts';
 

--- a/packages/ndk/lib/src/cli/blossom/blossom_cli_command.dart
+++ b/packages/ndk/lib/src/cli/blossom/blossom_cli_command.dart
@@ -10,7 +10,7 @@ import '../cli_command.dart';
 ///
 /// Sub-commands:
 ///   upload, download, delete, list, mirror, check, servers
-class BlossomCliCommand implements CliCommand {
+class BlossomCliCommand extends CliCommand {
   @override
   String get name => 'blossom';
 

--- a/packages/ndk/lib/src/cli/broadcast/broadcast_cli_command.dart
+++ b/packages/ndk/lib/src/cli/broadcast/broadcast_cli_command.dart
@@ -13,7 +13,7 @@ import '../cli_command.dart';
 ///
 /// Accepts pre-signed events (sent as-is) or unsigned events that are signed
 /// with either `--privkey` or the active account from `ndk accounts login`.
-class BroadcastCliCommand implements CliCommand {
+class BroadcastCliCommand extends CliCommand {
   @override
   String get name => 'broadcast';
 

--- a/packages/ndk/lib/src/cli/cli_command.dart
+++ b/packages/ndk/lib/src/cli/cli_command.dart
@@ -8,6 +8,12 @@ abstract class CliCommand {
   String get description;
   String get usage;
 
+  /// Whether persisted accounts should be restored before this command runs.
+  ///
+  /// Commands that do not use NDK accounts should opt out so a persisted
+  /// remote signer cannot introduce unrelated network work at startup.
+  bool get restoreAccountsOnStartup => true;
+
   Future<int> run(
     List<String> args,
     Ndk ndk,

--- a/packages/ndk/lib/src/cli/files/files_cli_command.dart
+++ b/packages/ndk/lib/src/cli/files/files_cli_command.dart
@@ -10,7 +10,7 @@ import '../cli_command.dart';
 /// mirror of [Ndk.files]).
 ///
 /// Sub-commands: `upload`, `download`, `delete`, `check`.
-class FilesCliCommand implements CliCommand {
+class FilesCliCommand extends CliCommand {
   @override
   String get name => 'files';
 

--- a/packages/ndk/lib/src/cli/ndk_cli_app.dart
+++ b/packages/ndk/lib/src/cli/ndk_cli_app.dart
@@ -56,7 +56,8 @@ class NdkCliApp {
     final ndk = _createNdk(walletsRepo, cache, globalOptions.logLevel);
     try {
       final accountsStore = await CliAccountsStore.load();
-      if (accountsStore.records.isNotEmpty) {
+      if (command.restoreAccountsOnStartup &&
+          accountsStore.records.isNotEmpty) {
         await restoreAccountsIntoNdk(ndk: ndk, store: accountsStore);
       }
       return await command.run(
@@ -74,6 +75,8 @@ class NdkCliApp {
       } catch (e) {
         // ignore
       }
+      await cache.close();
+      await walletsRepo.close();
     }
   }
 
@@ -110,7 +113,7 @@ class NdkCliApp {
     return null;
   }
 
-  Future<WalletsRepo> _createWalletsRepo() {
+  Future<SembastWalletsRepo> _createWalletsRepo() {
     return SembastWalletsRepo.create(filename: 'wallets_db.db');
   }
 
@@ -136,6 +139,7 @@ class NdkCliApp {
         eventVerifier: _CliEventVerifier(),
         bootstrapRelays: const [],
         logLevel: logLevel,
+        pendingDeliveryRetriesEnabled: false,
       ),
     );
   }

--- a/packages/ndk/lib/src/cli/req_cli_command.dart
+++ b/packages/ndk/lib/src/cli/req_cli_command.dart
@@ -9,7 +9,7 @@ import 'package:ndk/shared/helpers/relay_helper.dart';
 import 'cli_accounts_store.dart';
 import 'cli_command.dart';
 
-class ReqCliCommand implements CliCommand {
+class ReqCliCommand extends CliCommand {
   @override
   String get name => 'req';
 

--- a/packages/ndk/lib/src/cli/wallets/wallets_cli_command.dart
+++ b/packages/ndk/lib/src/cli/wallets/wallets_cli_command.dart
@@ -7,7 +7,7 @@ import 'package:ndk/ndk.dart';
 import '../cli_accounts_store.dart';
 import '../cli_command.dart';
 
-class WalletsCliCommand implements CliCommand {
+class WalletsCliCommand extends CliCommand {
   @override
   String get name => 'wallets';
 
@@ -18,6 +18,9 @@ class WalletsCliCommand implements CliCommand {
   @override
   String get usage =>
       'wallets <list|add|remove|receive|send|balance|budget> [args]';
+
+  @override
+  bool get restoreAccountsOnStartup => false;
 
   @override
   Future<int> run(

--- a/packages/ndk/lib/src/cli/zaps/zaps_cli_command.dart
+++ b/packages/ndk/lib/src/cli/zaps/zaps_cli_command.dart
@@ -12,7 +12,7 @@ import '../cli_command.dart';
 /// - `invoice`  fetch a lightning/zap invoice (no payment)
 /// - `zap`      pay a zap from a stored NWC sending wallet
 /// - `receipts` list zap receipts for a recipient pubkey
-class ZapsCliCommand implements CliCommand {
+class ZapsCliCommand extends CliCommand {
   @override
   String get name => 'zaps';
 

--- a/packages/ndk/test/presentation_layer/pending_delivery_retry_config_test.dart
+++ b/packages/ndk/test/presentation_layer/pending_delivery_retry_config_test.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:ndk/ndk.dart';
+import 'package:ndk/src/cli/wallets/wallets_cli_command.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_event_verifier.dart';
+
+void main() {
+  test('wallet commands do not restore unrelated remote signer accounts', () {
+    expect(WalletsCliCommand().restoreAccountsOnStartup, isFalse);
+  });
+
+  test('pending delivery retries can be disabled for short-lived clients',
+      () async {
+    final cache = MemCacheManager();
+    await cache.saveRelayDeliveryTarget(
+      const RelayDeliveryTarget(
+        eventId: 'pending-event',
+        relayUrl: 'not-a-relay',
+        reason: RelayDeliveryReason.explicit,
+      ),
+    );
+
+    final ndk = Ndk(
+      NdkConfig(
+        eventVerifier: MockEventVerifier(),
+        cache: cache,
+        bootstrapRelays: const [],
+        pendingDeliveryRetriesEnabled: false,
+      ),
+    );
+    var connectivityUpdates = 0;
+    final subscription = ndk.relays.relayConnectivityChanges.listen(
+      (_) => connectivityUpdates++,
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(connectivityUpdates, 0);
+
+    await subscription.cancel();
+    await ndk.destroy();
+  });
+}


### PR DESCRIPTION
## Summary

- make background pending-delivery retries configurable and disable them for one-shot CLI runs
- skip persisted account restoration for wallet commands so unrelated bunker relays are not contacted
- close CLI-owned Sembast databases and terminate with the command exit code

## Testing

- dart analyze on changed production and test files
- dart test test/presentation_layer/pending_delivery_retry_config_test.dart test/usecases/pending_broadcast_delivery_test.dart
- dart bin/ndk.dart wallets
- dart bin/ndk.dart wallets list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration to enable or disable automatic background retries for pending broadcast deliveries; enabled by default.
  - Added support for closing wallet storage cleanly.
  - CLI commands can now control whether saved accounts are restored at startup.

- **Bug Fixes**
  - Wallet-related commands no longer restore unrelated remote signer accounts.
  - CLI shutdown now consistently completes with the command’s exit status and closes local resources.

- **Tests**
  - Added coverage for configurable delivery retries and account restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->