### PR TITLE
fix(release): version generated PR titles

### DIFF
--- a/.github/scripts/release-pr-title.sh
+++ b/.github/scripts/release-pr-title.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_sha="${1:?usage: release-pr-title.sh BASE_SHA [HEAD_SHA]}"
+head_sha="${2:-HEAD}"
+release_kind=release
+targets=()
+
+while IFS= read -r pubspec; do
+  [[ -n "$pubspec" ]] || continue
+
+  if ! git diff --unified=0 "$base_sha" "$head_sha" -- "$pubspec" \
+    | grep -Eq '^\+version:[[:space:]]'; then
+    continue
+  fi
+
+  package_name=$(git show "$head_sha:$pubspec" | awk '$1 == "name:" { print $2; exit }')
+  package_version=$(git show "$head_sha:$pubspec" | awk '$1 == "version:" { print $2; exit }')
+  if [[ -z "$package_name" || -z "$package_version" ]]; then
+    echo "Could not read package name and version from $pubspec." >&2
+    exit 1
+  fi
+
+  targets+=("$package_name $package_version")
+  version_core="${package_version%%+*}"
+  if [[ "$version_core" == *-* ]]; then
+    release_kind=prerelease
+  fi
+done < <(git diff --name-only "$base_sha" "$head_sha" -- '**/pubspec.yaml')
+
+if (( ${#targets[@]} == 0 )); then
+  echo "No package version changes found since $base_sha." >&2
+  exit 1
+fi
+
+target_list="${targets[0]}"
+for target in "${targets[@]:1}"; do
+  target_list+=", $target"
+done
+
+pr_title="chore(${release_kind}): publish ${target_list}"
+echo "$pr_title"
+echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prerelease-manual.yaml
+++ b/.github/workflows/prerelease-manual.yaml
@@ -118,6 +118,10 @@ jobs:
             git commit --amend --no-edit
           fi
 
+      - name: Build versioned release PR title
+        id: release_pr
+        run: bash .github/scripts/release-pr-title.sh "$GITHUB_SHA"
+
       - name: Validate and create release PR
         uses: bluefireteam/melos-action@v3
         with:
@@ -125,3 +129,4 @@ jobs:
           run-bootstrap: false
           publish-dry-run: true
           create-pr: true
+          pr-title: ${{ steps.release_pr.outputs.pr_title }}

--- a/.github/workflows/prerelease-prepare.yaml
+++ b/.github/workflows/prerelease-prepare.yaml
@@ -56,13 +56,38 @@ jobs:
           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
           architecture: x64 # optional, x64 or arm64
 
-      - name: Run Melos
+      - name: Prepare development prerelease changes
         uses: bluefireteam/melos-action@v3
         with:
           run-versioning: false
           melos-version: "8.3.0"
           run-versioning-prerelease: true
+          publish-dry-run: false
+          create-pr: false
+          git-email: "github-actions[bot]@users.noreply.github.com"
+          git-name: "github-actions[bot]"
+
+      - name: Keep the documentation version aligned with NDK
+        run: |
+          ndk_version=$(awk '$1 == "version:" { print $2; exit }' packages/ndk/pubspec.yaml)
+          sed -i -E "s/^  label: .*/  label: v${ndk_version}/" doc/retype.yml
+
+          if ! git diff --quiet -- doc/retype.yml; then
+            git add doc/retype.yml
+            git commit --amend --no-edit
+          fi
+
+      - name: Build versioned prerelease PR title
+        id: release_pr
+        run: bash .github/scripts/release-pr-title.sh "$GITHUB_SHA"
+
+      - name: Validate and create development prerelease PR
+        uses: bluefireteam/melos-action@v3
+        with:
+          melos-version: "8.3.0"
+          run-bootstrap: false
           publish-dry-run: true
           create-pr: true
+          pr-title: ${{ steps.release_pr.outputs.pr_title }}
           git-email: "github-actions[bot]@users.noreply.github.com"
           git-name: "github-actions[bot]"

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -40,10 +40,14 @@ Run the workflow with:
 - `exact_package`: `ndk`
 - `exact_version`: `0.9.2`
 
-The workflow opens a PR named `chore(release): Publish packages`. Replace the
-generated `Stable release.` changelog stub with the actual `0.9.2` release
-notes. Then review the NDK version and all generated dependent-package
-constraint updates before merging the PR.
+The workflow opens a versioned PR named
+`chore(release): publish ndk 0.9.2`. Development versions instead use
+`chore(prerelease)`, for example
+`chore(prerelease): publish ndk 0.9.3-dev.0`. Replace the generated
+`Stable release.` changelog stub with the actual release notes. Then review the
+NDK version and all generated dependent-package constraint updates before
+merging the PR. If several package versions change, the title lists each exact
+package/version pair.
 
 Merging that release PR creates package tags and publishes every changed,
 publishable package to pub.dev. Preparing the PR performs only a publish dry


### PR DESCRIPTION
## Summary
- distinguish stable release PRs from development prerelease PRs
- include every changed package and exact version in generated PR titles
- align the documentation version in automatic prerelease branches
- document the title convention

## Validation
- actionlint on both modified workflows
- YAML syntax parsing
- bash syntax check
- stable title test: `chore(release): publish ndk 0.9.3`
- prerelease title test with exact versions for four packages