### PR TITLE
fix(release): publish from package tags

### DIFF
--- a/.github/workflows/prerelease-publish.yaml
+++ b/.github/workflows/prerelease-publish.yaml
@@ -19,6 +19,7 @@ jobs:
   publish-packages:
     name: Publish packages
     permissions:
+      actions: write
       contents: write
       id-token: write # Required for authentication using OIDC
     runs-on: [ubuntu-latest]
@@ -52,18 +53,17 @@ jobs:
           PACKAGE_NAME: ${{ inputs.package_name }}
         run: melos publish -y --no-dry-run --scope="$PACKAGE_NAME"
 
-      - name: Create release tag
+      - name: Create NDK release tag
+        if: inputs.package_name == 'ndk'
         env:
-          PACKAGE_NAME: ${{ inputs.package_name }}
           PACKAGE_VERSION: ${{ inputs.package_version }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$PACKAGE_NAME" = "ndk" ]; then
-            release_tag="v$PACKAGE_VERSION"
-          else
-            release_tag="$PACKAGE_NAME-v$PACKAGE_VERSION"
-          fi
+          release_tag="v$PACKAGE_VERSION"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git tag -a "$release_tag" "$COMMIT_SHA" -m "Release $release_tag"
           git push origin "$release_tag"
+          gh workflow run release.yml --ref "$release_tag"
+          gh workflow run deploy-docs.yml --ref "$release_tag"

--- a/.github/workflows/prerelease-tag.yaml
+++ b/.github/workflows/prerelease-tag.yaml
@@ -30,11 +30,12 @@ jobs:
         uses: bluefireteam/melos-action@v3
         with:
           melos-version: "8.3.0"
+          tag: true
       - name: Publish changed packages
         run: |
           melos exec -c 1 --no-published --no-private -- \
           gh workflow run prerelease-publish.yaml \
-          --ref master \
+          --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION \
           -f package_name=\$MELOS_PACKAGE_NAME \
           -f package_version=\$MELOS_PACKAGE_VERSION \
           -f commit_sha=$GITHUB_SHA

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -10,12 +10,14 @@ order: 100
 
 Complete releases have two distinct stages, in this order:
 
-1. Prepare and merge the package release PR. This publishes packages to
-   pub.dev.
-2. After publication succeeds, automation tags the release commit. NDK uses a
-   plain tag such as `v0.9.2`; other packages use tags such as
-   `ndk_flutter-v0.9.0`. An NDK `vX.Y.Z` tag creates the GitHub release and
-   builds its Android, CLI, and web artifacts.
+1. Prepare and merge the package release PR. Automation creates a
+   package-scoped tag such as `ndk-v0.9.2`, which pub.dev uses to authenticate
+   the publication workflow, and then publishes the package.
+2. After NDK publication succeeds, automation also creates the plain release
+   tag, such as `v0.9.2`, and dispatches the tag-based release and documentation
+   workflows. They create the GitHub release and build its Android, CLI, and
+   web artifacts. For other packages, the package-scoped tag is the release
+   tag.
 
 ## 1. Publish packages to pub.dev
 
@@ -49,9 +51,11 @@ NDK version and all generated dependent-package constraint updates before
 merging the PR. If several package versions change, the title lists each exact
 package/version pair.
 
-Merging that release PR creates package tags and publishes every changed,
-publishable package to pub.dev. Preparing the PR performs only a publish dry
-run; it does not publish anything.
+Merging that release PR creates package-scoped authentication tags and
+publishes every changed, publishable package to pub.dev. Each publication
+workflow must run from its package tag because pub.dev's trusted publisher is
+configured to accept tag identities. Preparing the PR performs only a publish
+dry run; it does not publish anything.
 
 !!!
 Do not use `graduate-prerelease` to change `0.9.1-dev.N` into `0.9.2`.
@@ -62,8 +66,9 @@ the `0.9.2` release.
 ## 2. Verify the GitHub release and artifacts
 
 After pub.dev publication succeeds, the package workflow creates `v0.9.2` on
-the release commit. That tag starts the sample-app release workflow. It creates
-a draft GitHub release using the matching section from
+the release commit and dispatches the sample-app release and documentation
+workflows from that tag. The release workflow creates a draft GitHub release
+using the matching section from
 `packages/ndk/CHANGELOG.md`, builds and uploads the Android APKs and
 cross-platform CLI archives, and deploys the sample web app. After every job
 succeeds, the workflow publishes the GitHub release automatically.


### PR DESCRIPTION
## Summary

- create package-scoped tags before publishing so pub.dev receives a tag-based OIDC identity
- dispatch each publisher from its package tag
- create the plain NDK tag only after publication succeeds
- explicitly dispatch release and docs workflows because tags pushed with GITHUB_TOKEN do not trigger other workflows
- document the authentication and release sequence

## Verification

- recovered ndk 0.9.3 using the same tag-based publication path
- confirmed ndk 0.9.3 on pub.dev
- confirmed v0.9.3 points to release commit 6f21a710
- git diff --check