### PR TITLE
fix(release): show only primary package

### DIFF
--- a/.github/scripts/release-pr-title.sh
+++ b/.github/scripts/release-pr-title.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_sha="${1:?usage: release-pr-title.sh BASE_SHA [HEAD_SHA]}"
+base_sha="${1:?usage: release-pr-title.sh BASE_SHA [HEAD_SHA] [PRIMARY_PACKAGE]}"
 head_sha="${2:-HEAD}"
-release_kind=release
-targets=()
+primary_package="${3:-ndk}"
+fallback_target=""
+fallback_version=""
+selected_target=""
+selected_version=""
 
 while IFS= read -r pubspec; do
   [[ -n "$pubspec" ]] || continue
@@ -21,23 +24,32 @@ while IFS= read -r pubspec; do
     exit 1
   fi
 
-  targets+=("$package_name $package_version")
-  version_core="${package_version%%+*}"
-  if [[ "$version_core" == *-* ]]; then
-    release_kind=prerelease
+  if [[ -z "$fallback_target" ]]; then
+    fallback_target="$package_name $package_version"
+    fallback_version="$package_version"
+  fi
+  if [[ "$package_name" == "$primary_package" ]]; then
+    selected_target="$package_name $package_version"
+    selected_version="$package_version"
   fi
 done < <(git diff --name-only "$base_sha" "$head_sha" -- '**/pubspec.yaml')
 
-if (( ${#targets[@]} == 0 )); then
+if [[ -z "$fallback_target" ]]; then
   echo "No package version changes found since $base_sha." >&2
   exit 1
 fi
 
-target_list="${targets[0]}"
-for target in "${targets[@]:1}"; do
-  target_list+=", $target"
-done
+if [[ -z "$selected_target" ]]; then
+  selected_target="$fallback_target"
+  selected_version="$fallback_version"
+fi
 
-pr_title="chore(${release_kind}): publish ${target_list}"
+release_kind=release
+version_core="${selected_version%%+*}"
+if [[ "$version_core" == *-* ]]; then
+  release_kind=prerelease
+fi
+
+pr_title="chore(${release_kind}): publish ${selected_target}"
 echo "$pr_title"
 echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prerelease-manual.yaml
+++ b/.github/workflows/prerelease-manual.yaml
@@ -120,7 +120,9 @@ jobs:
 
       - name: Build versioned release PR title
         id: release_pr
-        run: bash .github/scripts/release-pr-title.sh "$GITHUB_SHA"
+        env:
+          PRIMARY_PACKAGE: ${{ inputs.release_mode == 'exact' && inputs.exact_package || 'ndk' }}
+        run: bash .github/scripts/release-pr-title.sh "$GITHUB_SHA" HEAD "$PRIMARY_PACKAGE"
 
       - name: Validate and create release PR
         uses: bluefireteam/melos-action@v3

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -48,8 +48,8 @@ The workflow opens a versioned PR named
 `chore(prerelease): publish ndk 0.9.3-dev.0`. Replace the generated
 `Stable release.` changelog stub with the actual release notes. Then review the
 NDK version and all generated dependent-package constraint updates before
-merging the PR. If several package versions change, the title lists each exact
-package/version pair.
+merging the PR. The title shows only the primary package and omits dependent
+packages that will also be published.
 
 Merging that release PR creates package-scoped authentication tags and
 publishes every changed, publishable package to pub.dev. Each publication


### PR DESCRIPTION
## Summary
- show only the main `ndk` package and exact version in generated release PR titles
- omit dependent packages that are published as a consequence of the NDK bump
- retain the explicitly selected package for exact non-NDK release runs
- clarify the behavior in the publishing guide

## Validation
- actionlint on release preparation workflows
- Bash syntax check
- stable NDK title test
- multi-package development prerelease title test
- exact non-NDK fallback test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated publishing guidance to clarify that release pull request titles display the primary package, while dependent packages are omitted from the title.

* **Chores**
  * Improved release pull request title generation to select the configured primary package when available, with a fallback to another changed package.
  * Release mode now determines the primary package used when creating release pull request titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->