### PR TITLE
fix(release): always title PRs with NDK

### DIFF
--- a/.github/scripts/release-pr-title.sh
+++ b/.github/scripts/release-pr-title.sh
@@ -1,55 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_sha="${1:?usage: release-pr-title.sh BASE_SHA [HEAD_SHA] [PRIMARY_PACKAGE]}"
-head_sha="${2:-HEAD}"
-primary_package="${3:-ndk}"
-fallback_target=""
-fallback_version=""
-selected_target=""
-selected_version=""
+head_sha="${1:-HEAD}"
+release_kind="${2:?usage: release-pr-title.sh [HEAD_SHA] RELEASE_KIND}"
 
-while IFS= read -r pubspec; do
-  [[ -n "$pubspec" ]] || continue
-
-  if ! git diff --unified=0 "$base_sha" "$head_sha" -- "$pubspec" \
-    | grep -Eq '^\+version:[[:space:]]'; then
-    continue
-  fi
-
-  package_name=$(git show "$head_sha:$pubspec" | awk '$1 == "name:" { print $2; exit }')
-  package_version=$(git show "$head_sha:$pubspec" | awk '$1 == "version:" { print $2; exit }')
-  if [[ -z "$package_name" || -z "$package_version" ]]; then
-    echo "Could not read package name and version from $pubspec." >&2
-    exit 1
-  fi
-
-  if [[ -z "$fallback_target" ]]; then
-    fallback_target="$package_name $package_version"
-    fallback_version="$package_version"
-  fi
-  if [[ "$package_name" == "$primary_package" ]]; then
-    selected_target="$package_name $package_version"
-    selected_version="$package_version"
-  fi
-done < <(git diff --name-only "$base_sha" "$head_sha" -- '**/pubspec.yaml')
-
-if [[ -z "$fallback_target" ]]; then
-  echo "No package version changes found since $base_sha." >&2
+if [[ "$release_kind" != "release" && "$release_kind" != "prerelease" ]]; then
+  echo "Release kind must be 'release' or 'prerelease'." >&2
   exit 1
 fi
 
-if [[ -z "$selected_target" ]]; then
-  selected_target="$fallback_target"
-  selected_version="$fallback_version"
+ndk_version=$(
+  git show "$head_sha:packages/ndk/pubspec.yaml" \
+    | awk '$1 == "version:" { print $2; exit }'
+)
+if [[ -z "$ndk_version" ]]; then
+  echo "Could not read the NDK version from $head_sha." >&2
+  exit 1
 fi
 
-release_kind=release
-version_core="${selected_version%%+*}"
-if [[ "$version_core" == *-* ]]; then
-  release_kind=prerelease
-fi
-
-pr_title="chore(${release_kind}): publish ${selected_target}"
+pr_title="chore(${release_kind}): publish ndk ${ndk_version}"
 echo "$pr_title"
 echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prerelease-manual.yaml
+++ b/.github/workflows/prerelease-manual.yaml
@@ -121,8 +121,8 @@ jobs:
       - name: Build versioned release PR title
         id: release_pr
         env:
-          PRIMARY_PACKAGE: ${{ inputs.release_mode == 'exact' && inputs.exact_package || 'ndk' }}
-        run: bash .github/scripts/release-pr-title.sh "$GITHUB_SHA" HEAD "$PRIMARY_PACKAGE"
+          RELEASE_KIND: ${{ (inputs.release_mode == 'development-prerelease' || (inputs.release_mode == 'exact' && contains(inputs.exact_version, '-'))) && 'prerelease' || 'release' }}
+        run: bash .github/scripts/release-pr-title.sh HEAD "$RELEASE_KIND"
 
       - name: Validate and create release PR
         uses: bluefireteam/melos-action@v3

--- a/.github/workflows/prerelease-prepare.yaml
+++ b/.github/workflows/prerelease-prepare.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build versioned prerelease PR title
         id: release_pr
-        run: bash .github/scripts/release-pr-title.sh "$GITHUB_SHA"
+        run: bash .github/scripts/release-pr-title.sh HEAD prerelease
 
       - name: Validate and create development prerelease PR
         uses: bluefireteam/melos-action@v3

--- a/doc/library-development/publish.md
+++ b/doc/library-development/publish.md
@@ -48,8 +48,9 @@ The workflow opens a versioned PR named
 `chore(prerelease): publish ndk 0.9.3-dev.0`. Replace the generated
 `Stable release.` changelog stub with the actual release notes. Then review the
 NDK version and all generated dependent-package constraint updates before
-merging the PR. The title shows only the primary package and omits dependent
-packages that will also be published.
+merging the PR. The title shows only the current main `ndk` version and omits
+other workspace packages that will also be published, even when a release run
+only changes one of those other packages.
 
 Merging that release PR creates package-scoped authentication tags and
 publishes every changed, publishable package to pub.dev. Each publication


### PR DESCRIPTION
## Summary
- always read the PR title version from the main `packages/ndk` package
- derive `release` versus `prerelease` from the workflow mode
- remove changed-package fallback that incorrectly selected `ndk_drift`
- document that other published workspace packages are omitted

## Validation
- reproduced PR #785 as `chore(prerelease): publish ndk 0.9.3`
- validated full-release title output
- actionlint on both release preparation workflows
- Bash syntax check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release documentation to clarify that release PR titles display the current `ndk` version only, even when other workspace packages are also published.

* **Release Workflow**
  * Standardized release and prerelease PR titles to use the selected release type and current `ndk` version.
  * Improved version detection to use the specified revision consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->