### PR TITLE
chore: remove unused ascii_qr dependency

### DIFF
--- a/packages/ndk/example/nwc/make_hold_invoice.dart
+++ b/packages/ndk/example/nwc/make_hold_invoice.dart
@@ -56,19 +56,6 @@ void main() async {
         "Hold invoice created successfully. Invoice: $invoice Payment Hash: ${makeResponse.paymentHash}",
       );
 
-      // if (invoice.isNotEmpty) {
-      // print("\nScan QR Code to pay/hold:");
-      // try {
-      //   final asciiQr = AsciiQrGenerator.generate(
-      //     invoice.toUpperCase(),
-      //   );
-      //   print(asciiQr.toString());
-      // } catch (e) {
-      //   print("Error generating ASCII QR code: $e");
-      // }
-      //   print("\nOr copy Bolt11 invoice:\n$invoice\n");
-      // }
-
       final duration = makeResponse.expiresAt! -
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
       print(

--- a/packages/ndk/pubspec.yaml
+++ b/packages/ndk/pubspec.yaml
@@ -40,7 +40,6 @@ dependencies:
   cryptography: ^2.9.0
   meta: ">=1.10.0 <2.0.0"
   xxh3: ^1.2.0
-  ascii_qr: ^1.0.1 # Add ascii_qr dependency
   cbor: ^6.3.7
   bip39_mnemonic: ^4.0.1
   hooks: ^1.0.0

--- a/packages/sample-app/pubspec.lock
+++ b/packages/sample-app/pubspec.lock
@@ -25,14 +25,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
-  ascii_qr:
-    dependency: transitive
-    description:
-      name: ascii_qr
-      sha256: "2046e400a0fa4ea0de5df44c87b992cdd1f76403bb15e64513b89263598750ae"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   async:
     dependency: transitive
     description:


### PR DESCRIPTION
The `ascii_qr` dependency was never used: the only reference left was a commented-out block in the NWC hold invoice example. Removed the dependency, the dead comment block, and the resulting transitive entry in the sample-app lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed unused QR code generation support from the hold invoice example and package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->