### PR TITLE
feat(accounts): add accountsStream

### DIFF
--- a/doc/usecases/accounts.md
+++ b/doc/usecases/accounts.md
@@ -48,6 +48,27 @@ await ndk.accounts.loginWithBunkerConnection(
 Store the `BunkerConnection` details locally to re-establish the connection in future sessions. Use `bunkerConnection.toJson()` to serialize and `BunkerConnection.fromJson()` to restore. Without storing these, users will need to re-authenticate each time.
 !!!
 
+### Reacting to changes
+
+```dart watch the logged in account
+ndk.accounts.authStateChanges.listen((account) {
+    // account is null when logged out
+});
+```
+
+```dart watch the list of accounts
+ndk.accounts.accountsStream.listen((accounts) {
+    // pubkey -> Account, emitted on every add and remove
+});
+```
+
+`accountsStream` emits the current accounts on subscription, then an unmodifiable
+snapshot each time an account is added or removed. `switchAccount` changes the
+logged in account but not the list, so it only fires `authStateChanges`.
+
+The `ndk.accounts.accounts` map is a read-only view of the same data, for when you
+need a synchronous read instead of a stream.
+
 ## When to use
 
 Use it to log in an account.

--- a/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
+++ b/packages/ndk/lib/domain_layer/usecases/accounts/accounts.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../entities/account.dart';
@@ -14,23 +15,39 @@ class Accounts {
   /// Factory for creating EventSigner instances
   final LocalEventSignerFactory eventSignerFactory;
 
-  /// pubKey -> Account
-  final Map<String, Account> accounts = {};
+  final Map<String, Account> _accounts = {};
   String? _loggedPubkey;
+
+  static const _accountsEquality = MapEquality<String, Account>();
 
   /// Stream controller for authentication state changes
   final _stateController = BehaviorSubject<Account?>();
 
+  /// Stream controller for the known accounts
+  final _accountsController = BehaviorSubject<Map<String, Account>>.seeded(
+    UnmodifiableMapView(<String, Account>{}),
+  );
+
   /// Creates a new Accounts instance with the given event signer factory
   Accounts(this.eventSignerFactory);
+
+  /// pubKey -> Account, read-only view, listen to [accountsStream] for changes
+  /// Same instance until the accounts actually change, so every mutation of
+  /// [_accounts] has to go through [_notifyAccountsChange]
+  Map<String, Account> get accounts => _accountsController.value;
 
   /// Stream of authentication state changes
   /// Emits the current Account when logged in, or null when logged out
   Stream<Account?> get authStateChanges => _stateController.stream;
 
+  /// Stream of the known accounts, pubKey -> Account
+  /// Emits the current accounts on subscription, then an unmodifiable snapshot
+  /// every time an account is added, replaced or removed
+  Stream<Map<String, Account>> get accountsStream => _accountsController.stream;
+
   /// adds a new Account and sets the logged pubkey
   void loginPrivateKey({required String pubkey, required String privkey}) {
-    if (accounts.containsKey(pubkey)) {
+    if (_accounts.containsKey(pubkey)) {
       throw Exception("Cannot login, pubkey already logged in");
     }
     addAccount(
@@ -44,12 +61,12 @@ class Accounts {
 
   /// do we have the account for this pubkey?
   bool hasAccount(String pubkey) {
-    return accounts.containsKey(pubkey);
+    return _accounts.containsKey(pubkey);
   }
 
   /// adds a new read-only Account and sets the logged pubkey
   void loginPublicKey({required String pubkey}) {
-    if (accounts.containsKey(pubkey)) {
+    if (_accounts.containsKey(pubkey)) {
       throw Exception("Cannot login, pubkey already logged in");
     }
     addAccount(
@@ -64,7 +81,7 @@ class Accounts {
   /// adds a new read-only Account and sets the logged pubkey
   void loginExternalSigner({required EventSigner signer}) {
     final pubkey = signer.getPublicKey();
-    if (accounts.containsKey(pubkey)) {
+    if (_accounts.containsKey(pubkey)) {
       throw Exception("Cannot login, pubkey already logged in");
     }
     addAccount(
@@ -126,15 +143,16 @@ class Accounts {
 
   void logout() {
     if (_loggedPubkey != null) {
-      accounts.remove(_loggedPubkey);
+      _accounts.remove(_loggedPubkey);
       _loggedPubkey = null;
+      _notifyAccountsChange();
       _notifyAuthStateChange();
     }
   }
 
   /// set logged account
   void switchAccount({required String pubkey}) {
-    if (pubkey.isNotEmpty && accounts.containsKey(pubkey)) {
+    if (pubkey.isNotEmpty && _accounts.containsKey(pubkey)) {
       _loggedPubkey = pubkey;
       _notifyAuthStateChange();
     } else {
@@ -148,21 +166,21 @@ class Accounts {
     required AccountType type,
     required EventSigner signer,
   }) {
-    accounts[pubkey] = Account(type: type, pubkey: pubkey, signer: signer);
-  }
-
-  // /// clears the logged pubkey
-  void _clearLoggedPubkey() {
-    _loggedPubkey = null;
-    _notifyAuthStateChange();
+    _accounts[pubkey] = Account(type: type, pubkey: pubkey, signer: signer);
+    _notifyAccountsChange();
   }
 
   /// removes an Account
   void removeAccount({required String pubkey}) {
-    if (_loggedPubkey == pubkey) {
-      _clearLoggedPubkey();
+    final wasLoggedIn = _loggedPubkey == pubkey;
+    if (wasLoggedIn) {
+      _loggedPubkey = null;
     }
-    accounts.remove(pubkey);
+    _accounts.remove(pubkey);
+    _notifyAccountsChange();
+    if (wasLoggedIn) {
+      _notifyAuthStateChange();
+    }
   }
 
   /// low-level method, should not be used directly in most cases, use broadcast instead which calls signing on the signer
@@ -176,7 +194,7 @@ class Accounts {
 
   /// returns currently logged in account
   Account? getLoggedAccount() {
-    return _loggedPubkey != null ? accounts[_loggedPubkey] : null;
+    return _loggedPubkey != null ? _accounts[_loggedPubkey] : null;
   }
 
   /// is currently logged in account able to sign events
@@ -203,8 +221,17 @@ class Accounts {
     _stateController.add(getLoggedAccount());
   }
 
+  /// Notifies listeners of accounts changes, no-op if nothing actually changed
+  void _notifyAccountsChange() {
+    if (_accountsEquality.equals(_accountsController.value, _accounts)) {
+      return;
+    }
+    _accountsController.add(UnmodifiableMapView(Map.of(_accounts)));
+  }
+
   /// Dispose of resources
   Future<void> dispose() async {
     await _stateController.close();
+    await _accountsController.close();
   }
 }

--- a/packages/ndk/test/usecases/accounts_test.dart
+++ b/packages/ndk/test/usecases/accounts_test.dart
@@ -202,6 +202,98 @@ void main() async {
       await expectation;
     });
 
+    test('accountsStream emits on every change', () async {
+      final ndk = Ndk.emptyBootstrapRelaysConfig();
+
+      final expectation = expectLater(
+        ndk.accounts.accountsStream,
+        emitsInOrder([
+          isEmpty,
+          {key0.publicKey: anything},
+          {key0.publicKey: anything, key1.publicKey: anything},
+          {key1.publicKey: anything},
+          isEmpty,
+        ]),
+      );
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: key0.publicKey,
+        privkey: key0.privateKey!,
+      );
+      ndk.accounts.loginPublicKey(pubkey: key1.publicKey);
+      ndk.accounts.removeAccount(pubkey: key0.publicKey);
+      ndk.accounts.removeAccount(pubkey: key1.publicKey);
+
+      await expectation;
+    });
+
+    test('accountsStream does not emit when nothing changed', () async {
+      final ndk = Ndk.emptyBootstrapRelaysConfig();
+      final emitted = <Map<String, Account>>[];
+      final sub = ndk.accounts.accountsStream.listen(emitted.add);
+
+      ndk.accounts.loginPublicKey(pubkey: key0.publicKey);
+      ndk.accounts.removeAccount(pubkey: key1.publicKey);
+      ndk.accounts.switchAccount(pubkey: key0.publicKey);
+
+      await Future.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(emitted, hasLength(2));
+    });
+
+    test('logout and removeAccount notify in the same order', () async {
+      for (final removeLoggedAccount in [
+        (Accounts a) => a.logout(),
+        (Accounts a) => a.removeAccount(pubkey: key0.publicKey),
+      ]) {
+        final ndk = Ndk.emptyBootstrapRelaysConfig();
+        final order = <String>[];
+
+        ndk.accounts.accountsStream.listen((_) => order.add('accounts'));
+        ndk.accounts.authStateChanges.listen((_) => order.add('auth'));
+
+        ndk.accounts.loginPublicKey(pubkey: key0.publicKey);
+        await Future.delayed(Duration.zero);
+        order.clear();
+
+        removeLoggedAccount(ndk.accounts);
+        await Future.delayed(Duration.zero);
+
+        expect(order, ['accounts', 'auth']);
+        await ndk.destroy();
+      }
+    });
+
+    test('emitted accounts are unmodifiable snapshots', () async {
+      final ndk = Ndk.emptyBootstrapRelaysConfig();
+
+      ndk.accounts.loginPublicKey(pubkey: key0.publicKey);
+      final snapshot = await ndk.accounts.accountsStream.first;
+
+      expect(() => snapshot.clear(), throwsUnsupportedError);
+      expect(() => ndk.accounts.accounts.clear(), throwsUnsupportedError);
+
+      ndk.accounts.removeAccount(pubkey: key0.publicKey);
+      expect(snapshot, hasLength(1));
+      expect(ndk.accounts.accounts, isEmpty);
+    });
+
+    test('accounts is the last emitted snapshot', () async {
+      final ndk = Ndk.emptyBootstrapRelaysConfig();
+
+      ndk.accounts.loginPublicKey(pubkey: key0.publicKey);
+      expect(
+          ndk.accounts.accounts, same(await ndk.accounts.accountsStream.first));
+
+      final before = ndk.accounts.accounts;
+      ndk.accounts.removeAccount(pubkey: key1.publicKey);
+      expect(ndk.accounts.accounts, same(before));
+
+      ndk.accounts.removeAccount(pubkey: key0.publicKey);
+      expect(ndk.accounts.accounts, isNot(same(before)));
+    });
+
     test("dispose closes stream", () async {
       final ndk = Ndk.emptyBootstrapRelaysConfig();
       final stream = ndk.accounts.authStateChanges;


### PR DESCRIPTION
Callers had no way to know when the account list changed. accountsStream emits the current accounts on subscription, then an unmodifiable snapshot on every add and remove. Nothing is emitted when a call leaves the map unchanged, so switchAccount only fires authStateChanges.

The accounts map moves behind a read-only getter, which is what makes the stream authoritative: it can no longer be mutated from the outside.

logout and removeAccount now settle all state before notifying, and both emit accountsStream before authStateChanges. removeAccount used to announce the logged out account before removing it from the map.

BREAKING CHANGE: Accounts.accounts is an unmodifiable view, use addAccount and removeAccount to change it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `accountsStream` for observing account list changes.
  - The stream provides an initial snapshot and emits updated, read-only snapshots when accounts are added or removed.
  - Exposed `accounts` as a read-only synchronous view of the current account data.
  - Account changes are reported before corresponding logout or removal authentication events.

- **Documentation**
  - Added guidance for monitoring logged-in account changes and account list updates.
  - Documented stream behavior, account switching events, and read-only account access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->