### PR TITLE
feat(cache): add loadHiddenEvents

### DIFF
--- a/doc/guides/cache-behavior.md
+++ b/doc/guides/cache-behavior.md
@@ -29,6 +29,19 @@ When NDK reads events from cache, it applies these visibility rules:
 
 App-facing reads return the current logical state, not raw historical storage.
 
+## Reading hidden events
+
+Hidden events stay in the cache, and `loadHiddenEvents` is the read that returns them. This is what an app needs to show previous versions of an addressable event, or the content behind a deletion.
+
+```dart
+final versions = await ndk.config.cache.loadHiddenEvents(
+  coordinates: ['30023:$pubKey:my-article'],
+  reasons: {HiddenEventReason.superseded},
+);
+```
+
+Eviction sweeps exactly these events, so keep `sweepSuperseded` and `sweepDeleted` disabled if your app shows history.
+
 ## Event sources vs delivery targets
 
 These are different concepts:

--- a/packages/drift/lib/src/drift_cache_manager.dart
+++ b/packages/drift/lib/src/drift_cache_manager.dart
@@ -18,8 +18,8 @@ import 'package:ndk/domain_layer/entities/wallet/wallet_transaction.dart';
 import 'package:ndk/domain_layer/entities/wallet/wallet_type.dart';
 import 'package:ndk/domain_layer/repositories/wallets_repo.dart';
 import 'package:ndk/ndk.dart';
-import 'package:ndk/shared/nips/nip01/event_kind_classification.dart';
 import 'package:ndk/shared/nips/nip01/event_eviction_planner.dart';
+import 'package:ndk/shared/nips/nip01/event_visibility_resolver.dart';
 
 import 'database/database.dart';
 
@@ -36,6 +36,10 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
   final NdkCacheDatabase _db;
   String? _defaultWalletIdForReceiving;
   String? _defaultWalletIdForSending;
+
+  late final EventVisibilityResolver _visibility = EventVisibilityResolver(
+    _loadRawEvents,
+  );
 
   DriftCacheManager(this._db) {
     unawaited(_initializeWalletDefaults());
@@ -143,6 +147,63 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
     String? search,
     int? limit,
   }) async {
+    var events = await _loadRawEvents(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+    );
+
+    events = await _visibility.filterVisible(events);
+    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    if (limit != null && limit > 0 && events.length > limit) {
+      events = events.take(limit).toList();
+    }
+
+    return events;
+  }
+
+  @override
+  Future<List<HiddenEvent>> loadHiddenEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    List<String>? coordinates,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+    Set<HiddenEventReason> reasons = kAllHiddenEventReasons,
+  }) {
+    return _visibility.loadHiddenEvents(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      coordinates: coordinates,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+      limit: limit,
+      reasons: reasons,
+    );
+  }
+
+  Future<List<Nip01Event>> _loadRawEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+  }) async {
     var query = _db.select(_db.events);
 
     // Build WHERE clause
@@ -210,14 +271,6 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
         });
       }).toList();
     }
-
-    final deletionRows = await (_db.select(
-      _db.events,
-    )..where((t) => t.kind.equals(5))).get();
-    final deletions = deletionRows.map(_eventFromRow).toList();
-
-    events = _applyEventVisibilityRules(events, deletions);
-    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     if (limit != null && limit > 0 && events.length > limit) {
       events = events.take(limit).toList();
@@ -494,79 +547,6 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
       tags: tags,
       sources: sources,
     );
-  }
-
-  List<Nip01Event> _applyEventVisibilityRules(
-    List<Nip01Event> events,
-    List<Nip01Event> deletions,
-  ) {
-    final visible = <Nip01Event>[];
-    final replaceableWinners = <String, Nip01Event>{};
-    final now = Nip01Event.secondsSinceEpoch();
-
-    for (final event in events) {
-      if (_isExpired(event, now)) continue;
-      if (_isDeletedByAuthor(event, deletions)) continue;
-
-      final coordinateKey = _coordinateKey(event);
-      if (coordinateKey == null) {
-        visible.add(event);
-        continue;
-      }
-
-      final current = replaceableWinners[coordinateKey];
-      if (current == null || _isMoreRecentReplaceable(event, current)) {
-        replaceableWinners[coordinateKey] = event;
-      }
-    }
-
-    visible.addAll(replaceableWinners.values);
-    return visible;
-  }
-
-  bool _isDeletedByAuthor(Nip01Event target, List<Nip01Event> deletions) {
-    if (target.kind == 5) return false;
-
-    // Addressable/replaceable events are deleted by coordinate (`a` tag), so a
-    // later version published after the deletion stays visible (NIP-09 only
-    // deletes coordinate matches with created_at <= the deletion).
-    final coordinate = _coordinateKey(target);
-
-    for (final deletion in deletions) {
-      if (deletion.pubKey != target.pubKey) continue;
-      if (deletion.getTags('e').contains(target.id.toLowerCase())) {
-        return true;
-      }
-      if (coordinate != null &&
-          deletion.createdAt >= target.createdAt &&
-          deletion.getTags('a').contains(coordinate)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  bool _isExpired(Nip01Event event, int now) {
-    final expirationValue = event.getFirstTag('expiration');
-    if (expirationValue == null) return false;
-    final expiration = int.tryParse(expirationValue);
-    if (expiration == null) return false;
-    return expiration <= now;
-  }
-
-  String? _coordinateKey(Nip01Event event) {
-    if (!EventKindClassification.isReplaceableKind(event.kind)) return null;
-    final dTag = event.getDtag() ?? '';
-    return '${event.kind}:${event.pubKey}:$dTag';
-  }
-
-  bool _isMoreRecentReplaceable(Nip01Event candidate, Nip01Event current) {
-    if (candidate.createdAt != current.createdAt) {
-      return candidate.createdAt > current.createdAt;
-    }
-
-    return candidate.id.compareTo(current.id) < 0;
   }
 
   Future<Nip01Event?> _loadLatestVisibleEvent({

--- a/packages/ndk/lib/data_layer/repositories/cache_manager/mem_cache_manager.dart
+++ b/packages/ndk/lib/data_layer/repositories/cache_manager/mem_cache_manager.dart
@@ -7,6 +7,7 @@ import '../../../domain_layer/entities/cache_eviction.dart';
 import '../../../domain_layer/entities/contact_list.dart';
 import '../../../domain_layer/entities/event_cache_records.dart';
 import '../../../domain_layer/entities/filter_fetched_ranges.dart';
+import '../../../domain_layer/entities/hidden_event.dart';
 import '../../../domain_layer/entities/metadata.dart';
 import '../../../domain_layer/entities/nip_65.dart';
 import '../../../domain_layer/entities/nip_01_event.dart';
@@ -15,8 +16,8 @@ import '../../../domain_layer/entities/relay_set.dart';
 import '../../../domain_layer/entities/user_relay_list.dart';
 import '../../../domain_layer/entities/wallet/wallet.dart';
 import '../../../domain_layer/repositories/cache_manager.dart';
-import '../../../shared/nips/nip01/event_kind_classification.dart';
 import '../../../shared/nips/nip01/event_eviction_planner.dart';
+import '../../../shared/nips/nip01/event_visibility_resolver.dart';
 
 /// In memory database implementation
 /// benefits: very fast
@@ -70,6 +71,10 @@ class MemCacheManager implements CacheManager {
   /// In memory storage for filter fetched range records
   /// Key is filterHash:relayUrl:rangeStart
   Map<String, FilterFetchedRangeRecord> filterFetchedRangeRecords = {};
+
+  late final EventVisibilityResolver _visibility = EventVisibilityResolver(
+    _loadRawEvents,
+  );
 
   @override
   Future<void> saveUserRelayList(UserRelayList userRelayList) async {
@@ -614,6 +619,56 @@ class MemCacheManager implements CacheManager {
     );
   }
 
+  @override
+  Future<List<HiddenEvent>> loadHiddenEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    List<String>? coordinates,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+    Set<HiddenEventReason> reasons = kAllHiddenEventReasons,
+  }) {
+    return _visibility.loadHiddenEvents(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      coordinates: coordinates,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+      limit: limit,
+      reasons: reasons,
+    );
+  }
+
+  Future<List<Nip01Event>> _loadRawEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+  }) {
+    return _loadEventsInternal(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+      limit: limit,
+      applyVisibilityRules: false,
+    );
+  }
+
   Future<List<Nip01Event>> _loadEventsInternal({
     List<String>? ids,
     List<String>? pubKeys,
@@ -687,7 +742,7 @@ class MemCacheManager implements CacheManager {
     }
 
     if (applyVisibilityRules) {
-      result = _applyEventVisibilityRules(result);
+      result = await _visibility.filterVisible(result);
     }
 
     result.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -1046,81 +1101,6 @@ class MemCacheManager implements CacheManager {
 
   String _eventSourceKey(String eventId, String relayUrl) {
     return '$eventId|$relayUrl';
-  }
-
-  List<Nip01Event> _applyEventVisibilityRules(List<Nip01Event> events) {
-    final visible = <Nip01Event>[];
-    final replaceableWinners = <String, Nip01Event>{};
-    final now = Nip01Event.secondsSinceEpoch();
-
-    for (final event in events) {
-      if (_isExpired(event, now)) continue;
-      if (_isDeletedByAuthor(event)) continue;
-
-      final coordinateKey = _coordinateKey(event);
-      if (coordinateKey == null) {
-        visible.add(event);
-        continue;
-      }
-
-      final current = replaceableWinners[coordinateKey];
-      if (current == null || _isMoreRecentReplaceable(event, current)) {
-        replaceableWinners[coordinateKey] = event;
-      }
-    }
-
-    visible.addAll(replaceableWinners.values);
-    return visible;
-  }
-
-  bool _isDeletedByAuthor(Nip01Event target) {
-    if (target.kind == 5) return false;
-
-    // Addressable/replaceable events are deleted by coordinate (`a` tag), so a
-    // later version published after the deletion stays visible (NIP-09 only
-    // deletes coordinate matches with created_at <= the deletion).
-    final coordinate = _coordinateKey(target);
-
-    for (final event in events.values) {
-      if (event.kind != 5) continue;
-      if (event.pubKey != target.pubKey) continue;
-      if (event.getTags('e').contains(target.id.toLowerCase())) {
-        return true;
-      }
-      if (coordinate != null &&
-          event.createdAt >= target.createdAt &&
-          event.getTags('a').contains(coordinate)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  bool _isExpired(Nip01Event event, int now) {
-    final expirationValue = event.getFirstTag('expiration');
-    if (expirationValue == null) return false;
-    final expiration = int.tryParse(expirationValue);
-    if (expiration == null) return false;
-    return expiration <= now;
-  }
-
-  String? _coordinateKey(Nip01Event event) {
-    if (!_isReplaceableKind(event.kind)) return null;
-    final dTag = event.getDtag() ?? '';
-    return '${event.kind}:${event.pubKey}:$dTag';
-  }
-
-  bool _isReplaceableKind(int kind) {
-    return EventKindClassification.isReplaceableKind(kind);
-  }
-
-  bool _isMoreRecentReplaceable(Nip01Event candidate, Nip01Event current) {
-    if (candidate.createdAt != current.createdAt) {
-      return candidate.createdAt > current.createdAt;
-    }
-
-    return candidate.id.compareTo(current.id) < 0;
   }
 
   Future<Nip01Event?> _loadLatestVisibleEvent({

--- a/packages/ndk/lib/data_layer/repositories/cache_manager/sembast_cache_manager.dart
+++ b/packages/ndk/lib/data_layer/repositories/cache_manager/sembast_cache_manager.dart
@@ -2,8 +2,8 @@ import 'package:ndk/entities.dart';
 import 'package:ndk/ndk.dart';
 import 'package:sembast/sembast.dart' as sembast;
 
-import '../../../shared/nips/nip01/event_kind_classification.dart';
 import '../../../shared/nips/nip01/event_eviction_planner.dart';
+import '../../../shared/nips/nip01/event_visibility_resolver.dart';
 import '../../../shared/nips/nip01/helpers.dart';
 import 'ndk_extensions.dart';
 
@@ -59,6 +59,10 @@ class SembastCacheManager extends CacheManager {
   late final sembast.StoreRef<String, Map<String, Object?>> _proofStore;
   late final sembast.StoreRef<String, Map<String, Object?>> _mintInfoStore;
   late final sembast.StoreRef<String, Map<String, Object?>> _secretCounterStore;
+
+  late final EventVisibilityResolver _visibility = EventVisibilityResolver(
+    _loadRawEvents,
+  );
 
   SembastCacheManager(this._database) {
     _eventsStore = sembast.stringMapStoreFactory.store('events');
@@ -485,6 +489,56 @@ class SembastCacheManager extends CacheManager {
     );
   }
 
+  @override
+  Future<List<HiddenEvent>> loadHiddenEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    List<String>? coordinates,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+    Set<HiddenEventReason> reasons = kAllHiddenEventReasons,
+  }) {
+    return _visibility.loadHiddenEvents(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      coordinates: coordinates,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+      limit: limit,
+      reasons: reasons,
+    );
+  }
+
+  Future<List<Nip01Event>> _loadRawEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+  }) {
+    return _loadEventsInternal(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+      limit: limit,
+      applyVisibilityRules: false,
+    );
+  }
+
   Future<List<Nip01Event>> _loadEventsInternal({
     List<String>? ids,
     List<String>? pubKeys,
@@ -539,9 +593,8 @@ class SembastCacheManager extends CacheManager {
         .map((record) => Nip01EventExtension.fromJsonStorage(record.value))
         .toList();
 
-    final visibleEvents = applyVisibilityRules
-        ? await _applyEventVisibilityRules(events)
-        : events;
+    final visibleEvents =
+        applyVisibilityRules ? await _visibility.filterVisible(events) : events;
 
     // Filter by tags if specified (done in memory since Sembast doesn't support complex tag filtering)
     if (tags != null && tags.isNotEmpty) {
@@ -963,95 +1016,6 @@ class SembastCacheManager extends CacheManager {
     final keys = userRelayLists.map((u) => u.pubKey).toList();
     final values = userRelayLists.map((u) => u.toJsonForStorage()).toList();
     await _relayListStore.records(keys).put(_database, values);
-  }
-
-  Future<List<Nip01Event>> _applyEventVisibilityRules(
-    List<Nip01Event> events,
-  ) async {
-    final visible = <Nip01Event>[];
-    final replaceableWinners = <String, Nip01Event>{};
-    final now = Nip01Event.secondsSinceEpoch();
-    final deletionEvents = await _loadDeletionEvents();
-
-    for (final event in events) {
-      if (_isExpired(event, now)) continue;
-      if (_isDeletedByAuthor(event, deletionEvents)) continue;
-
-      final coordinateKey = _coordinateKey(event);
-      if (coordinateKey == null) {
-        visible.add(event);
-        continue;
-      }
-
-      final current = replaceableWinners[coordinateKey];
-      if (current == null || _isMoreRecentReplaceable(event, current)) {
-        replaceableWinners[coordinateKey] = event;
-      }
-    }
-
-    visible.addAll(replaceableWinners.values);
-    return visible;
-  }
-
-  bool _isDeletedByAuthor(Nip01Event target, List<Nip01Event> deletionEvents) {
-    if (target.kind == 5) return false;
-
-    // Addressable/replaceable events are deleted by coordinate (`a` tag), so a
-    // later version published after the deletion stays visible (NIP-09 only
-    // deletes coordinate matches with created_at <= the deletion).
-    final coordinate = _coordinateKey(target);
-
-    for (final event in deletionEvents) {
-      if (event.kind != 5) continue;
-      if (event.pubKey != target.pubKey) continue;
-      if (event.getTags('e').contains(target.id.toLowerCase())) {
-        return true;
-      }
-      if (coordinate != null &&
-          event.createdAt >= target.createdAt &&
-          event.getTags('a').contains(coordinate)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  Future<List<Nip01Event>> _loadDeletionEvents() async {
-    final records = await _eventsStore.find(
-      _database,
-      finder: sembast.Finder(filter: sembast.Filter.equals('kind', 5)),
-    );
-
-    return records
-        .map((record) => Nip01EventExtension.fromJsonStorage(record.value))
-        .toList();
-  }
-
-  bool _isExpired(Nip01Event event, int now) {
-    final expirationValue = event.getFirstTag('expiration');
-    if (expirationValue == null) return false;
-    final expiration = int.tryParse(expirationValue);
-    if (expiration == null) return false;
-    return expiration <= now;
-  }
-
-  String? _coordinateKey(Nip01Event event) {
-    if (!_isReplaceableKind(event.kind)) return null;
-    final dTag = event.getDtag() ?? '';
-    return '${event.kind}:${event.pubKey}:$dTag';
-  }
-
-  bool _isReplaceableKind(int kind) {
-    return EventKindClassification.isReplaceableKind(kind);
-  }
-
-  bool _isMoreRecentReplaceable(Nip01Event candidate, Nip01Event current) {
-    if (candidate.createdAt != current.createdAt) {
-      return candidate.createdAt > current.createdAt;
-    }
-
-    return candidate.id.compareTo(current.id) < 0;
   }
 
   @override

--- a/packages/ndk/lib/data_layer/repositories/cache_manager/sembast_cache_manager.dart
+++ b/packages/ndk/lib/data_layer/repositories/cache_manager/sembast_cache_manager.dart
@@ -584,7 +584,9 @@ class SembastCacheManager extends CacheManager {
 
     final finder = sembast.Finder(
       filter: filters.isNotEmpty ? sembast.Filter.and(filters) : null,
-      limit: limit,
+      // Pushing the limit down here would spend it on events the visibility
+      // rules and the tag filter below then remove.
+      limit: applyVisibilityRules ? null : limit,
       sortOrders: [sembast.SortOrder('created_at', false)],
     );
 
@@ -593,12 +595,12 @@ class SembastCacheManager extends CacheManager {
         .map((record) => Nip01EventExtension.fromJsonStorage(record.value))
         .toList();
 
-    final visibleEvents =
+    var result =
         applyVisibilityRules ? await _visibility.filterVisible(events) : events;
 
     // Filter by tags if specified (done in memory since Sembast doesn't support complex tag filtering)
     if (tags != null && tags.isNotEmpty) {
-      return visibleEvents.where((event) {
+      result = result.where((event) {
         return tags.entries.every((tagEntry) {
           var tagName = tagEntry.key;
           final tagValues = tagEntry.value;
@@ -622,7 +624,11 @@ class SembastCacheManager extends CacheManager {
       }).toList();
     }
 
-    return visibleEvents;
+    if (limit != null && limit > 0 && result.length > limit) {
+      result = result.take(limit).toList();
+    }
+
+    return result;
   }
 
   @override

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -469,15 +469,19 @@ class EventCacheStateRecord {
   /// Accepts NIP-01 `a` tag values, whose d-tag segment is present but empty
   /// for non addressable kinds. Returns null when [coordinate] is malformed or
   /// names a kind that has no conflict domain.
+  ///
+  /// Only the pubkey is case folded: NIP-01 mandates lowercase hex there, while
+  /// a d-tag is an arbitrary string relays match byte for byte.
   static String? normalizeConflictKey(String coordinate) {
     final parts = coordinate.split(':');
     if (parts.length < 2) return null;
     final kind = int.tryParse(parts[0]);
     if (kind == null || parts[1].isEmpty) return null;
+    final pubKey = parts[1].toLowerCase();
 
     if (EventKindClassification.isParameterizedReplaceableKind(kind)) {
       final dTag = parts.length > 2 ? parts.sublist(2).join(':') : '';
-      return '$kind:${parts[1]}:$dTag';
+      return '$kind:$pubKey:$dTag';
     }
     if (!EventKindClassification.isReplaceableKind(kind)) return null;
     // A non addressable kind has no d-tag, so only an empty trailing segment
@@ -485,7 +489,25 @@ class EventCacheStateRecord {
     if (parts.length > 3 || (parts.length == 3 && parts[2].isNotEmpty)) {
       return null;
     }
-    return '$kind:${parts[1]}';
+    return '$kind:$pubKey';
+  }
+
+  /// Whether [deletion] covers [conflictKey] through one of its `a` tags.
+  ///
+  /// Reads the tags directly because [Nip01Event.getTags] lowercases values,
+  /// which would drop the case of the d-tag carried by the coordinate.
+  static bool deletionCoversConflictKey(
+    Nip01Event deletion,
+    String conflictKey,
+  ) {
+    for (final tag in deletion.tags) {
+      if (tag.length > 1 &&
+          tag[0] == 'a' &&
+          normalizeConflictKey(tag[1].trim()) == conflictKey) {
+        return true;
+      }
+    }
+    return false;
   }
 
   Map<String, dynamic> toJson() {
@@ -588,26 +610,14 @@ class EventCacheStateRecord {
       target.getDtag(),
     );
 
-    // A non addressable replaceable kind is written both as `kind:pubkey` and
-    // with a trailing empty d-tag segment, so accept either spelling.
-    final coordinates = switch (replaceableConflictKey) {
-      null => const <String>[],
-      final key
-          when EventKindClassification.isParameterizedReplaceableKind(
-            target.kind,
-          ) =>
-        [key],
-      final key => [key, '$key:'],
-    };
-
     for (final event in deletionEvents) {
       if (event.pubKey != target.pubKey) continue;
       if (event.getTags('e').contains(target.id.toLowerCase())) {
         return event;
       }
-      if (coordinates.isNotEmpty &&
+      if (replaceableConflictKey != null &&
           event.createdAt >= target.createdAt &&
-          event.getTags('a').any(coordinates.contains)) {
+          deletionCoversConflictKey(event, replaceableConflictKey)) {
         return event;
       }
     }

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -494,8 +494,8 @@ class EventCacheStateRecord {
 
   /// Whether [deletion] covers [conflictKey] through one of its `a` tags.
   ///
-  /// Reads the tags directly because [Nip01Event.getTags] lowercases values,
-  /// which would drop the case of the d-tag carried by the coordinate.
+  /// Reads the tags directly because [Nip01Event.getTags] trims and lowercases
+  /// values, which would drop bytes of the d-tag carried by the coordinate.
   static bool deletionCoversConflictKey(
     Nip01Event deletion,
     String conflictKey,
@@ -503,7 +503,7 @@ class EventCacheStateRecord {
     for (final tag in deletion.tags) {
       if (tag.length > 1 &&
           tag[0] == 'a' &&
-          normalizeConflictKey(tag[1].trim()) == conflictKey) {
+          normalizeConflictKey(tag[1]) == conflictKey) {
         return true;
       }
     }

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -480,6 +480,11 @@ class EventCacheStateRecord {
       return '$kind:${parts[1]}:$dTag';
     }
     if (!EventKindClassification.isReplaceableKind(kind)) return null;
+    // A non addressable kind has no d-tag, so only an empty trailing segment
+    // is a spelling of the same domain. Anything else is a different request.
+    if (parts.length > 3 || (parts.length == 3 && parts[2].isNotEmpty)) {
+      return null;
+    }
     return '$kind:${parts[1]}';
   }
 

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -458,6 +458,31 @@ class EventCacheStateRecord {
   bool isExpiredAt(int timestamp) =>
       expirationAt != null && expirationAt! <= timestamp;
 
+  /// The NIP-01 conflict domain of [event]: `kind:pubkey:d-tag` for addressable
+  /// kinds, `kind:pubkey` for other replaceable kinds, null for the rest.
+  static String? conflictKeyFor(Nip01Event event) =>
+      _buildReplaceableConflictKey(event, event.getDtag());
+
+  /// Normalizes a caller supplied conflict domain so it compares equal to
+  /// [conflictKeyFor].
+  ///
+  /// Accepts NIP-01 `a` tag values, whose d-tag segment is present but empty
+  /// for non addressable kinds. Returns null when [coordinate] is malformed or
+  /// names a kind that has no conflict domain.
+  static String? normalizeConflictKey(String coordinate) {
+    final parts = coordinate.split(':');
+    if (parts.length < 2) return null;
+    final kind = int.tryParse(parts[0]);
+    if (kind == null || parts[1].isEmpty) return null;
+
+    if (EventKindClassification.isParameterizedReplaceableKind(kind)) {
+      final dTag = parts.length > 2 ? parts.sublist(2).join(':') : '';
+      return '$kind:${parts[1]}:$dTag';
+    }
+    if (!EventKindClassification.isReplaceableKind(kind)) return null;
+    return '$kind:${parts[1]}';
+  }
+
   Map<String, dynamic> toJson() {
     return {
       'eventId': eventId,
@@ -558,14 +583,26 @@ class EventCacheStateRecord {
       target.getDtag(),
     );
 
+    // A non addressable replaceable kind is written both as `kind:pubkey` and
+    // with a trailing empty d-tag segment, so accept either spelling.
+    final coordinates = switch (replaceableConflictKey) {
+      null => const <String>[],
+      final key
+          when EventKindClassification.isParameterizedReplaceableKind(
+            target.kind,
+          ) =>
+        [key],
+      final key => [key, '$key:'],
+    };
+
     for (final event in deletionEvents) {
       if (event.pubKey != target.pubKey) continue;
       if (event.getTags('e').contains(target.id.toLowerCase())) {
         return event;
       }
-      if (replaceableConflictKey != null &&
+      if (coordinates.isNotEmpty &&
           event.createdAt >= target.createdAt &&
-          event.getTags('a').contains(replaceableConflictKey)) {
+          event.getTags('a').any(coordinates.contains)) {
         return event;
       }
     }

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -470,14 +470,15 @@ class EventCacheStateRecord {
   /// for non addressable kinds. Returns null when [coordinate] is malformed or
   /// names a kind that has no conflict domain.
   ///
-  /// Only the pubkey is case folded: NIP-01 mandates lowercase hex there, while
-  /// a d-tag is an arbitrary string relays match byte for byte.
+  /// Only the kind is parsed. NIP-01 mandates lowercase hex for the pubkey and
+  /// leaves the d-tag an arbitrary string, so both compare byte for byte the
+  /// way a relay compares them.
   static String? normalizeConflictKey(String coordinate) {
     final parts = coordinate.split(':');
     if (parts.length < 2) return null;
     final kind = int.tryParse(parts[0]);
     if (kind == null || parts[1].isEmpty) return null;
-    final pubKey = parts[1].toLowerCase();
+    final pubKey = parts[1];
 
     if (EventKindClassification.isParameterizedReplaceableKind(kind)) {
       final dTag = parts.length > 2 ? parts.sublist(2).join(':') : '';

--- a/packages/ndk/lib/domain_layer/entities/hidden_event.dart
+++ b/packages/ndk/lib/domain_layer/entities/hidden_event.dart
@@ -1,0 +1,56 @@
+import 'event_cache_records.dart';
+import 'nip_01_event.dart';
+
+/// Why a cached event is not returned by visible cache reads.
+enum HiddenEventReason {
+  /// A newer event won the replaceable/addressable conflict domain.
+  superseded,
+
+  /// The author published a NIP-09 deletion covering this event.
+  deleted,
+
+  /// The NIP-40 `expiration` timestamp has passed.
+  expired,
+}
+
+/// Every reason, the default for hidden event queries.
+const kAllHiddenEventReasons = <HiddenEventReason>{
+  HiddenEventReason.superseded,
+  HiddenEventReason.deleted,
+  HiddenEventReason.expired,
+};
+
+/// A cached event that visible reads hide, paired with the cache state that
+/// explains why it is hidden.
+///
+/// `reasons` is never empty. `superseded` is reported only when the event is
+/// neither deleted nor expired, because those two answer the question better:
+/// a deleted or expired event never wins its conflict domain, so it is always
+/// non-current as well.
+class HiddenEvent {
+  final Nip01Event event;
+  final EventCacheStateRecord state;
+  final Set<HiddenEventReason> reasons;
+
+  const HiddenEvent({
+    required this.event,
+    required this.state,
+    required this.reasons,
+  });
+
+  bool get isSuperseded => reasons.contains(HiddenEventReason.superseded);
+
+  bool get isDeleted => reasons.contains(HiddenEventReason.deleted);
+
+  bool get isExpired => reasons.contains(HiddenEventReason.expired);
+
+  /// Id of the NIP-09 event that deleted this one, when [isDeleted].
+  String? get deletedByEventId => state.deletedByEventId;
+
+  @override
+  String toString() {
+    final names = reasons.map((reason) => reason.name).toList()..sort();
+    return 'HiddenEvent{id: ${event.id}, kind: ${event.kind}, '
+        'reasons: ${names.join(',')}}';
+  }
+}

--- a/packages/ndk/lib/domain_layer/repositories/cache_manager.dart
+++ b/packages/ndk/lib/domain_layer/repositories/cache_manager.dart
@@ -5,6 +5,7 @@ import '../entities/cache_eviction.dart';
 import '../entities/contact_list.dart';
 import '../entities/event_cache_records.dart';
 import '../entities/filter_fetched_ranges.dart';
+import '../entities/hidden_event.dart';
 import '../entities/metadata.dart';
 import '../entities/nip_01_event.dart';
 import '../entities/nip_05.dart';
@@ -24,7 +25,8 @@ import '../entities/user_relay_list.dart';
 ///
 /// Backend authors should treat this class as a behavior contract, not just a
 /// list of CRUD methods. The most important behavioral expectations are:
-/// - [loadEvents] returns *visible* events only
+/// - [loadEvents] returns *visible* events only, [loadHiddenEvents] is the only
+///   read that returns superseded, deleted or expired rows
 /// - metadata/contact list loaders are convenience views over the generic event
 ///   store, not separate authoritative silos
 /// - provenance and delivery targets are separate concerns
@@ -152,6 +154,44 @@ abstract class CacheManager {
     String? search,
     int? limit,
   });
+
+  /// Loads the events [loadEvents] hides, newest first.
+  ///
+  /// A superseded version of a replaceable event, an author-deleted event and
+  /// an expired event all stay stored, and [loadEvents] never returns them.
+  /// This read exposes them, which is what an app needs to show the edit
+  /// history of an addressable event or the content behind a deletion.
+  ///
+  /// Filters combine with AND and behave like the [loadEvents] ones, with two
+  /// additions:
+  /// - [coordinates]: replaceable conflict domains, `kind:pubkey:d-tag` for
+  ///   addressable kinds and `kind:pubkey` for other replaceable kinds. A
+  ///   trailing empty d-tag is accepted, so a NIP-01 `a` tag value can be
+  ///   passed as is.
+  /// - [reasons]: which hidden categories to return. Pass a single reason to
+  ///   ask a precise question, for example only `superseded` to list previous
+  ///   versions without resurfacing deleted content.
+  ///
+  /// [limit] applies after hidden events are selected, unlike the pre-filter
+  /// limit some backends push into their query for visible reads.
+  ///
+  /// Eviction removes exactly these rows: [EvictionPolicy] sweeps superseded
+  /// and deleted events by default. An app that shows history must disable
+  /// those two sweeps, otherwise what it wants to display is swept in the
+  /// background.
+  Future<List<HiddenEvent>> loadHiddenEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    List<String>? coordinates,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+    Set<HiddenEventReason> reasons = kAllHiddenEventReasons,
+  });
+
   Future<void> removeEvent(String id);
 
   /// Remove events from cache with flexible filtering.

--- a/packages/ndk/lib/domain_layer/usecases/metadatas/metadatas.dart
+++ b/packages/ndk/lib/domain_layer/usecases/metadatas/metadatas.dart
@@ -169,20 +169,22 @@ class Metadatas {
     Iterable<String>? specificRelays,
   }) async {
     _checkSigner();
-    Nip01Event? event = await _refreshMetadataEvent();
-    if (event != null) {
-      Map<String, dynamic> map = json.decode(event.content);
-      map.addAll(metadata.content);
-      event = Nip01Event(
-        pubKey: event.pubKey,
-        kind: event.kind,
-        tags: event.tags,
-        content: json.encode(map),
-        createdAt: Helpers.now,
-      );
-    } else {
-      event = metadata.toEvent();
-    }
+    final Nip01Event? loaded = await _refreshMetadataEvent();
+
+    final Map<String, dynamic> content =
+        loaded != null && Helpers.isNotBlank(loaded.content)
+            ? json.decode(loaded.content) as Map<String, dynamic>
+            : <String, dynamic>{};
+    content.addAll(metadata.content);
+
+    final event = Nip01Event(
+      pubKey: _signer.getPublicKey(),
+      kind: Metadata.kKind,
+      tags: loaded?.tags ?? metadata.tags,
+      content: json.encode(content),
+      createdAt: Helpers.now,
+    );
+
     final bResult = _broadcast.broadcast(
       nostrEvent: event,
       specificRelays: specificRelays,
@@ -190,11 +192,13 @@ class Metadatas {
 
     await bResult.broadcastDoneFuture;
 
-    metadata.updatedAt = Helpers.now;
-    metadata.refreshedTimestamp = Helpers.now;
-    await _cacheManager.saveEvent(metadata.toEvent());
+    // caching anything but the published event leaves two kind:0 competing for
+    // the same replaceable slot, where the id tie-break can hide the published one
+    await _cacheManager.saveEvent(event);
 
-    return metadata;
+    final broadcasted = Metadata.fromEvent(event);
+    broadcasted.refreshedTimestamp = Helpers.now;
+    return broadcasted;
   }
 
   /// *******************************************************************************************************************

--- a/packages/ndk/lib/entities.dart
+++ b/packages/ndk/lib/entities.dart
@@ -13,6 +13,7 @@ export 'domain_layer/entities/event_filter.dart';
 export 'domain_layer/entities/event_cache_records.dart';
 export 'domain_layer/entities/filter.dart';
 export 'domain_layer/entities/global_state.dart';
+export 'domain_layer/entities/hidden_event.dart';
 export 'domain_layer/entities/metadata.dart';
 export 'domain_layer/entities/nip_01_event.dart';
 export 'domain_layer/entities/nip_05.dart';

--- a/packages/ndk/lib/ndk.dart
+++ b/packages/ndk/lib/ndk.dart
@@ -52,6 +52,7 @@ export 'domain_layer/entities/file_hash_progress.dart';
 export 'domain_layer/entities/cache_eviction.dart';
 export 'domain_layer/entities/event_cache_records.dart';
 export 'domain_layer/entities/event_delivery_inspection.dart';
+export 'domain_layer/entities/hidden_event.dart';
 export 'domain_layer/entities/nip_17_conversation.dart';
 export 'domain_layer/entities/nip_17_message.dart';
 export 'domain_layer/entities/nip_17_file_message.dart';

--- a/packages/ndk/lib/shared/nips/nip01/event_eviction_planner.dart
+++ b/packages/ndk/lib/shared/nips/nip01/event_eviction_planner.dart
@@ -380,16 +380,16 @@ class EventEvictionPlanner {
     // Addressable/replaceable events are deleted by coordinate (`a` tag), so a
     // later version published after the deletion stays visible (NIP-09 only
     // deletes coordinate matches with created_at <= the deletion).
-    final coordinate = _coordinateKey(target);
+    final conflictKey = EventCacheStateRecord.conflictKeyFor(target);
 
     for (final event in deletionEvents) {
       if (event.pubKey != target.pubKey) continue;
       if (event.getTags('e').contains(target.id.toLowerCase())) {
         return true;
       }
-      if (coordinate != null &&
+      if (conflictKey != null &&
           event.createdAt >= target.createdAt &&
-          event.getTags('a').contains(coordinate)) {
+          EventCacheStateRecord.deletionCoversConflictKey(event, conflictKey)) {
         return true;
       }
     }

--- a/packages/ndk/lib/shared/nips/nip01/event_visibility_resolver.dart
+++ b/packages/ndk/lib/shared/nips/nip01/event_visibility_resolver.dart
@@ -28,9 +28,9 @@ typedef RawEventLoader = Future<List<Nip01Event>> Function({
 /// event id. So the resolver runs one extra raw read to fetch that context,
 /// then classifies the candidates against it.
 class EventVisibilityResolver {
-  /// Above this many distinct authors, the context read stops constraining
-  /// authors: a huge `inList` costs more than the wider scan it saves.
-  static const _maxAuthorScope = 100;
+  /// Maximum authors per context read, keeping each query scoped without
+  /// creating an excessively large `inList`.
+  static const _authorBatchSize = 100;
 
   final RawEventLoader _loadRawEvents;
 
@@ -178,10 +178,17 @@ class EventVisibilityResolver {
       }
     }
 
-    final context = await _loadRawEvents(
-      pubKeys: authors.length <= _maxAuthorScope ? authors.toList() : null,
-      kinds: contextKinds.toList(),
-    );
+    final authorList = authors.toList();
+    final context = <Nip01Event>[];
+    for (var start = 0; start < authorList.length; start += _authorBatchSize) {
+      final end = (start + _authorBatchSize).clamp(0, authorList.length);
+      context.addAll(
+        await _loadRawEvents(
+          pubKeys: authorList.sublist(start, end),
+          kinds: contextKinds.toList(),
+        ),
+      );
+    }
 
     final byId = <String, Nip01Event>{};
     for (final event in candidates) {

--- a/packages/ndk/lib/shared/nips/nip01/event_visibility_resolver.dart
+++ b/packages/ndk/lib/shared/nips/nip01/event_visibility_resolver.dart
@@ -1,0 +1,200 @@
+import '../../../domain_layer/entities/event_cache_records.dart';
+import '../../../domain_layer/entities/hidden_event.dart';
+import '../../../domain_layer/entities/nip_01_event.dart';
+import '../nip09/deletion.dart';
+import 'event_kind_classification.dart';
+
+/// Raw cache read used by [EventVisibilityResolver].
+///
+/// Implementations must apply the given filters and nothing else: no visibility
+/// rules, no implicit limit.
+typedef RawEventLoader = Future<List<Nip01Event>> Function({
+  List<String>? ids,
+  List<String>? pubKeys,
+  List<int>? kinds,
+  Map<String, List<String>>? tags,
+  int? since,
+  int? until,
+  String? search,
+  int? limit,
+});
+
+/// Decides which cached events are visible, and why the others are not.
+///
+/// Visibility cannot be decided from a query result alone: the winner of a
+/// conflict domain and the NIP-09 deletion that covers an event can both sit
+/// outside it. Grouping only what a filter returned makes an old version look
+/// current whenever the filter excluded its successor, for example a read by
+/// event id. So the resolver runs one extra raw read to fetch that context,
+/// then classifies the candidates against it.
+class EventVisibilityResolver {
+  /// Above this many distinct authors, the context read stops constraining
+  /// authors: a huge `inList` costs more than the wider scan it saves.
+  static const _maxAuthorScope = 100;
+
+  final RawEventLoader _loadRawEvents;
+
+  EventVisibilityResolver(this._loadRawEvents);
+
+  /// Keeps the candidates that are currently visible, in the given order.
+  Future<List<Nip01Event>> filterVisible(
+    List<Nip01Event> candidates, {
+    int? now,
+  }) async {
+    if (candidates.isEmpty) return <Nip01Event>[];
+    final currentTime = now ?? Nip01Event.secondsSinceEpoch();
+    final state = await _resolveState(candidates);
+
+    final visible = <Nip01Event>[];
+    for (final event in candidates) {
+      final record = state[event.id];
+      if (record != null && hiddenReasons(record, currentTime).isNotEmpty) {
+        continue;
+      }
+      visible.add(event);
+    }
+    return visible;
+  }
+
+  /// Implements `CacheManager.loadHiddenEvents` on top of a raw loader.
+  Future<List<HiddenEvent>> loadHiddenEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    List<String>? coordinates,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+    Set<HiddenEventReason> reasons = kAllHiddenEventReasons,
+    int? now,
+  }) async {
+    if (reasons.isEmpty) return <HiddenEvent>[];
+
+    Set<String>? wantedConflictKeys;
+    var queryPubKeys = pubKeys;
+    var queryKinds = kinds;
+
+    if (coordinates != null) {
+      wantedConflictKeys = {};
+      final coordinateAuthors = <String>{};
+      final coordinateKinds = <int>{};
+      for (final coordinate in coordinates) {
+        final key = EventCacheStateRecord.normalizeConflictKey(coordinate);
+        if (key == null) continue;
+        wantedConflictKeys.add(key);
+        final parts = coordinate.split(':');
+        coordinateKinds.add(int.parse(parts[0]));
+        coordinateAuthors.add(parts[1]);
+      }
+      if (wantedConflictKeys.isEmpty) return <HiddenEvent>[];
+
+      // Filters combine with AND, so an explicit pubKeys/kinds is already at
+      // least as narrow as the coordinates it is combined with.
+      queryPubKeys ??= coordinateAuthors.toList();
+      queryKinds ??= coordinateKinds.toList();
+    }
+
+    final candidates = await _loadRawEvents(
+      ids: ids,
+      pubKeys: queryPubKeys,
+      kinds: queryKinds,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+    );
+    if (candidates.isEmpty) return <HiddenEvent>[];
+
+    final currentTime = now ?? Nip01Event.secondsSinceEpoch();
+    final state = await _resolveState(candidates);
+
+    final hidden = <HiddenEvent>[];
+    for (final event in candidates) {
+      if (wantedConflictKeys != null &&
+          !wantedConflictKeys.contains(
+            EventCacheStateRecord.conflictKeyFor(event),
+          )) {
+        continue;
+      }
+
+      final record = state[event.id];
+      if (record == null) continue;
+
+      final eventReasons = hiddenReasons(record, currentTime);
+      if (eventReasons.isEmpty) continue;
+      if (!eventReasons.any(reasons.contains)) continue;
+
+      hidden.add(
+        HiddenEvent(event: event, state: record, reasons: eventReasons),
+      );
+    }
+
+    hidden.sort((a, b) {
+      final byTime = b.event.createdAt.compareTo(a.event.createdAt);
+      return byTime != 0 ? byTime : a.event.id.compareTo(b.event.id);
+    });
+
+    if (limit != null && limit > 0 && hidden.length > limit) {
+      return hidden.take(limit).toList();
+    }
+    return hidden;
+  }
+
+  /// Why visible reads hide the event behind [record], empty when they do not.
+  ///
+  /// `superseded` is reported only for an event that is neither deleted nor
+  /// expired: those two exclude an event from winning its conflict domain, so
+  /// they would otherwise always come with a redundant `superseded`.
+  static Set<HiddenEventReason> hiddenReasons(
+    EventCacheStateRecord record,
+    int now,
+  ) {
+    final reasons = <HiddenEventReason>{};
+    if (record.isExpiredAt(now)) {
+      reasons.add(HiddenEventReason.expired);
+    }
+    if (record.isDeleted) {
+      reasons.add(HiddenEventReason.deleted);
+    }
+    if (reasons.isEmpty &&
+        !record.isCurrent &&
+        EventKindClassification.isReplaceableKind(record.kind)) {
+      reasons.add(HiddenEventReason.superseded);
+    }
+    return reasons;
+  }
+
+  Future<Map<String, EventCacheStateRecord>> _resolveState(
+    List<Nip01Event> candidates,
+  ) async {
+    final authors = <String>{};
+    final contextKinds = <int>{Deletion.kKind};
+    for (final event in candidates) {
+      authors.add(event.pubKey);
+      if (EventKindClassification.isReplaceableKind(event.kind)) {
+        contextKinds.add(event.kind);
+      }
+    }
+
+    final context = await _loadRawEvents(
+      pubKeys: authors.length <= _maxAuthorScope ? authors.toList() : null,
+      kinds: contextKinds.toList(),
+    );
+
+    final byId = <String, Nip01Event>{};
+    for (final event in candidates) {
+      byId[event.id] = event;
+    }
+    for (final event in context) {
+      byId[event.id] = event;
+    }
+
+    return {
+      for (final record
+          in EventCacheStateRecord.buildForEvents(byId.values.toList()))
+        record.eventId: record,
+    };
+  }
+}

--- a/packages/ndk/test/shared/nips/nip01/event_visibility_resolver_test.dart
+++ b/packages/ndk/test/shared/nips/nip01/event_visibility_resolver_test.dart
@@ -1,0 +1,42 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/event_visibility_resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('context reads keep author scope above one batch', () async {
+    final candidates = List.generate(
+      101,
+      (index) => Nip01Event(
+        pubKey: 'author-$index',
+        kind: 1,
+        tags: const [],
+        content: 'note-$index',
+        createdAt: index,
+      ),
+    );
+    final requestedAuthorBatches = <List<String>>[];
+    final resolver = EventVisibilityResolver(({
+      ids,
+      pubKeys,
+      kinds,
+      tags,
+      since,
+      until,
+      search,
+      limit,
+    }) async {
+      requestedAuthorBatches.add(pubKeys!);
+      return <Nip01Event>[];
+    });
+
+    await resolver.filterVisible(candidates, now: 1000);
+
+    expect(requestedAuthorBatches, hasLength(2));
+    expect(requestedAuthorBatches.first, hasLength(100));
+    expect(requestedAuthorBatches.last, hasLength(1));
+    expect(
+      requestedAuthorBatches.expand((batch) => batch).toSet(),
+      equals(candidates.map((event) => event.pubKey).toSet()),
+    );
+  });
+}

--- a/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
+++ b/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
@@ -246,6 +246,32 @@ void main() {
     });
   });
 
+  group('addressable (a-tag) deletion is byte exact on the pubkey', () {
+    test('an uppercased pubkey coordinate deletes nothing', () {
+      // NIP-01 mandates lowercase hex, so a relay never matches this either.
+      final target = addressableEvent(createdAt: 1700000000);
+      final deletion = Nip01Event(
+        pubKey: author,
+        kind: Deletion.kKind,
+        tags: [
+          ['a', '$addressableKind:${author.toUpperCase()}:$dTag'],
+        ],
+        content: 'delete by coordinate',
+        createdAt: 1700000001,
+      );
+
+      final records = EventCacheStateRecord.buildForEvents([
+        target,
+        deletion,
+      ], now: 1700000100);
+
+      expect(
+        records.firstWhere((record) => record.eventId == target.id).isDeleted,
+        isFalse,
+      );
+    });
+  });
+
   group('MemCacheManager addressable (a-tag) deletion visibility', () {
     test('hides an addressable event deleted by coordinate', () async {
       final cache = MemCacheManager();

--- a/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
+++ b/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
@@ -107,6 +107,86 @@ void main() {
     );
   });
 
+  group('addressable (a-tag) deletion is case sensitive on the d-tag', () {
+    // NIP-01 only mandates lowercase hex for the pubkey. A d-tag is an
+    // arbitrary string, so relays match the coordinate byte for byte.
+    const mixedCaseDtag = 'Article-A';
+
+    Nip01Event article() {
+      return Nip01Event(
+        pubKey: author,
+        kind: addressableKind,
+        tags: const [
+          ['d', mixedCaseDtag],
+        ],
+        content: 'v1',
+        createdAt: 1700000000,
+      );
+    }
+
+    Nip01Event deletionOf(String dTag) {
+      return Nip01Event(
+        pubKey: author,
+        kind: Deletion.kKind,
+        tags: [
+          ['a', '$addressableKind:$author:$dTag'],
+        ],
+        content: 'delete by coordinate',
+        createdAt: 1700000001,
+      );
+    }
+
+    test('a mixed case coordinate deletes its own event', () {
+      final target = article();
+      final records = EventCacheStateRecord.buildForEvents([
+        target,
+        deletionOf(mixedCaseDtag),
+      ], now: 1700000100);
+
+      expect(
+        records.firstWhere((record) => record.eventId == target.id).isDeleted,
+        isTrue,
+      );
+    });
+
+    test('a lowercased coordinate deletes nothing', () {
+      final target = article();
+      final records = EventCacheStateRecord.buildForEvents([
+        target,
+        deletionOf(mixedCaseDtag.toLowerCase()),
+      ], now: 1700000100);
+
+      expect(
+        records.firstWhere((record) => record.eventId == target.id).isDeleted,
+        isFalse,
+      );
+    });
+
+    test('eviction sweeps a mixed case coordinate deletion', () {
+      final target = article();
+
+      final plan = EventEvictionPlanner.plan(
+        rawEvents: [target, deletionOf(mixedCaseDtag)],
+        lockedEventIds: const {},
+        deliveredEventIds: const {},
+        policy: const EvictionPolicy(),
+        now: 1700000100,
+      );
+
+      expect(plan.eventIdsToRemove, contains(target.id));
+      expect(plan.removedDeleted, 1);
+    });
+
+    test('cache reads hide a mixed case coordinate deletion', () async {
+      final cache = MemCacheManager();
+      final target = article();
+
+      await cache.saveEvents([target, deletionOf(mixedCaseDtag)]);
+
+      expect(await cache.loadEvents(ids: [target.id]), isEmpty);
+    });
+  });
+
   group('MemCacheManager addressable (a-tag) deletion visibility', () {
     test('hides an addressable event deleted by coordinate', () async {
       final cache = MemCacheManager();

--- a/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
+++ b/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
@@ -187,6 +187,65 @@ void main() {
     });
   });
 
+  group('addressable (a-tag) deletion keeps d-tag whitespace', () {
+    // NIP-01 replaces on an exact kind/pubkey/d-tag combination, so `article `
+    // and `article` are two different addressable events.
+    Nip01Event article(String dTag) {
+      return Nip01Event(
+        pubKey: author,
+        kind: addressableKind,
+        tags: [
+          ['d', dTag],
+        ],
+        content: 'v1',
+        createdAt: 1700000000,
+      );
+    }
+
+    Nip01Event deletionOf(String dTag) {
+      return Nip01Event(
+        pubKey: author,
+        kind: Deletion.kKind,
+        tags: [
+          ['a', '$addressableKind:$author:$dTag'],
+        ],
+        content: 'delete by coordinate',
+        createdAt: 1700000001,
+      );
+    }
+
+    bool isDeleted(Nip01Event target, Nip01Event deletion) {
+      final records = EventCacheStateRecord.buildForEvents([
+        target,
+        deletion,
+      ], now: 1700000100);
+      return records
+          .firstWhere((record) => record.eventId == target.id)
+          .isDeleted;
+    }
+
+    test('a padded coordinate deletes its own event', () {
+      expect(isDeleted(article('article '), deletionOf('article ')), isTrue);
+    });
+
+    test('a trimmed coordinate deletes nothing', () {
+      expect(isDeleted(article('article '), deletionOf('article')), isFalse);
+    });
+
+    test('a padded coordinate spares the unpadded event', () {
+      expect(isDeleted(article('article'), deletionOf('article ')), isFalse);
+    });
+
+    test('cache reads hide a padded coordinate deletion', () async {
+      final cache = MemCacheManager();
+      final target = article('article ');
+
+      await cache.saveEvents([target, deletionOf('article ')]);
+
+      expect(await cache.loadEvents(ids: [target.id]), isEmpty);
+    });
+  });
+
   group('MemCacheManager addressable (a-tag) deletion visibility', () {
     test('hides an addressable event deleted by coordinate', () async {
       final cache = MemCacheManager();

--- a/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
+++ b/packages/ndk/test/usecases/nip09_addressable_deletion_test.dart
@@ -126,6 +126,37 @@ void main() {
       );
     });
 
+    test('hides a replaceable event deleted by either a tag spelling',
+        () async {
+      for (final coordinate in ['0:$author', '0:$author:']) {
+        final cache = MemCacheManager();
+        final metadata = Nip01Event(
+          pubKey: author,
+          kind: Metadata.kKind,
+          tags: const [],
+          content: '{"name":"gone"}',
+          createdAt: 1700000000,
+        );
+        final deletion = Nip01Event(
+          pubKey: author,
+          kind: Deletion.kKind,
+          tags: [
+            ['a', coordinate],
+          ],
+          content: 'delete metadata',
+          createdAt: 1700000001,
+        );
+
+        await cache.saveEvents([metadata, deletion]);
+
+        expect(
+          await cache.loadEvents(ids: [metadata.id]),
+          isEmpty,
+          reason: 'deletion written as `$coordinate` should tombstone kind 0',
+        );
+      }
+    });
+
     test(
       'eviction uses derived state to sweep obsolete replaceable versions',
       () async {

--- a/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite.dart
+++ b/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite.dart
@@ -32,6 +32,7 @@ part 'cache_manager_test_suite_contact_list.dart';
 part 'cache_manager_test_suite_cashu.dart';
 part 'cache_manager_test_suite_eviction.dart';
 part 'cache_manager_test_suite_event.dart';
+part 'cache_manager_test_suite_hidden_event.dart';
 part 'cache_manager_test_suite_metadata.dart';
 part 'cache_manager_test_suite_nip05.dart';
 part 'cache_manager_test_suite_relay_set.dart';
@@ -87,6 +88,10 @@ void runCacheManagerTestSuite({
 
     group('Event Operations', () {
       _runEventTests(() => cacheManager, eventSignerFactory);
+    });
+
+    group('Hidden Event Operations', () {
+      _runHiddenEventTests(() => cacheManager);
     });
 
     group('Metadata Operations', () {

--- a/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite_hidden_event.dart
+++ b/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite_hidden_event.dart
@@ -1,0 +1,245 @@
+part of 'cache_manager_test_suite.dart';
+
+const _hiddenAuthor = 'hidden_event_author';
+
+Nip01Event _article({
+  required String dTag,
+  required int createdAt,
+  required String content,
+}) {
+  return Nip01Event(
+    pubKey: _hiddenAuthor,
+    kind: 30023,
+    tags: [
+      ['d', dTag],
+    ],
+    content: content,
+    createdAt: createdAt,
+  );
+}
+
+void _runHiddenEventTests(CacheManager Function() getCacheManager) {
+  test('loadHiddenEvents returns previous versions, newest first', () async {
+    final cacheManager = getCacheManager();
+
+    final v1 = _article(dTag: 'article-a', createdAt: 100, content: 'draft');
+    final v2 = _article(dTag: 'article-a', createdAt: 200, content: 'revised');
+    final v3 = _article(dTag: 'article-a', createdAt: 300, content: 'final');
+    await cacheManager.saveEvents([v1, v2, v3]);
+
+    final hidden = await cacheManager.loadHiddenEvents(
+      coordinates: ['30023:$_hiddenAuthor:article-a'],
+    );
+
+    expect(hidden.map((e) => e.event.content), equals(['revised', 'draft']));
+    expect(
+      hidden.every((e) => e.reasons.single == HiddenEventReason.superseded),
+      isTrue,
+    );
+    expect(hidden.every((e) => !e.state.isCurrent), isTrue);
+
+    final visible = await cacheManager.loadEvents(
+      pubKeys: [_hiddenAuthor],
+      kinds: [30023],
+    );
+    expect(visible.map((e) => e.content), equals(['final']));
+  });
+
+  test('loadEvents hides a superseded version queried by id', () async {
+    final cacheManager = getCacheManager();
+
+    final v1 = _article(dTag: 'article-a', createdAt: 100, content: 'draft');
+    final v2 = _article(dTag: 'article-a', createdAt: 200, content: 'final');
+    await cacheManager.saveEvents([v1, v2]);
+
+    expect(await cacheManager.loadEvents(ids: [v1.id]), isEmpty);
+    expect((await cacheManager.loadEvents(ids: [v2.id])).single.id, v2.id);
+    // The raw read by id stays the escape hatch for callers that hold an id.
+    expect(await cacheManager.loadEvent(v1.id), isNotNull);
+  });
+
+  test('coordinates filter selects a single conflict domain', () async {
+    final cacheManager = getCacheManager();
+
+    await cacheManager.saveEvents([
+      _article(dTag: 'article-a', createdAt: 100, content: 'a old'),
+      _article(dTag: 'article-a', createdAt: 200, content: 'a new'),
+      _article(dTag: 'article-b', createdAt: 100, content: 'b old'),
+      _article(dTag: 'article-b', createdAt: 200, content: 'b new'),
+    ]);
+
+    final hidden = await cacheManager.loadHiddenEvents(
+      coordinates: ['30023:$_hiddenAuthor:article-b'],
+    );
+
+    expect(hidden.map((e) => e.event.content), equals(['b old']));
+  });
+
+  test('coordinates accept an a tag value for a replaceable kind', () async {
+    final cacheManager = getCacheManager();
+
+    await cacheManager.saveEvents([
+      Nip01Event(
+        pubKey: _hiddenAuthor,
+        kind: Metadata.kKind,
+        tags: [],
+        content: '{"name":"old"}',
+        createdAt: 100,
+      ),
+      Nip01Event(
+        pubKey: _hiddenAuthor,
+        kind: Metadata.kKind,
+        tags: [],
+        content: '{"name":"new"}',
+        createdAt: 200,
+      ),
+    ]);
+
+    final withoutDTag = await cacheManager.loadHiddenEvents(
+      coordinates: ['${Metadata.kKind}:$_hiddenAuthor'],
+    );
+    final withEmptyDTag = await cacheManager.loadHiddenEvents(
+      coordinates: ['${Metadata.kKind}:$_hiddenAuthor:'],
+    );
+
+    expect(withoutDTag.map((e) => e.event.content), equals(['{"name":"old"}']));
+    expect(
+      withEmptyDTag.map((e) => e.event.id),
+      equals(withoutDTag.map((e) => e.event.id)),
+    );
+  });
+
+  test('reasons filter separates deleted from superseded', () async {
+    final cacheManager = getCacheManager();
+
+    final supersededArticle = _article(
+      dTag: 'article-a',
+      createdAt: 100,
+      content: 'a old',
+    );
+    final currentArticle = _article(
+      dTag: 'article-a',
+      createdAt: 200,
+      content: 'a new',
+    );
+    final deletedArticle = _article(
+      dTag: 'article-b',
+      createdAt: 100,
+      content: 'b deleted',
+    );
+    final deletion = Nip01Event(
+      pubKey: _hiddenAuthor,
+      kind: 5,
+      tags: [
+        ['a', '30023:$_hiddenAuthor:article-b'],
+      ],
+      content: 'gone',
+      createdAt: 150,
+    );
+    await cacheManager.saveEvents([
+      supersededArticle,
+      currentArticle,
+      deletedArticle,
+      deletion,
+    ]);
+
+    final superseded = await cacheManager.loadHiddenEvents(
+      kinds: [30023],
+      reasons: {HiddenEventReason.superseded},
+    );
+    final deleted = await cacheManager.loadHiddenEvents(
+      kinds: [30023],
+      reasons: {HiddenEventReason.deleted},
+    );
+
+    expect(superseded.map((e) => e.event.id), equals([supersededArticle.id]));
+    expect(deleted.map((e) => e.event.id), equals([deletedArticle.id]));
+    expect(deleted.single.deletedByEventId, equals(deletion.id));
+    expect(deleted.single.isDeleted, isTrue);
+  });
+
+  test('loadHiddenEvents returns a deleted regular event', () async {
+    final cacheManager = getCacheManager();
+
+    final note = Nip01Event(
+      pubKey: _hiddenAuthor,
+      kind: 1,
+      tags: [],
+      content: 'deleted note',
+      createdAt: 100,
+    );
+    final deletion = Nip01Event(
+      pubKey: _hiddenAuthor,
+      kind: 5,
+      tags: [
+        ['e', note.id],
+      ],
+      content: 'gone',
+      createdAt: 150,
+    );
+    await cacheManager.saveEvents([note, deletion]);
+
+    final hidden = await cacheManager.loadHiddenEvents(kinds: [1]);
+
+    expect(hidden.single.event.content, equals('deleted note'));
+    expect(hidden.single.reasons, equals({HiddenEventReason.deleted}));
+    expect(hidden.single.deletedByEventId, equals(deletion.id));
+  });
+
+  test('loadHiddenEvents reports an expired event', () async {
+    final cacheManager = getCacheManager();
+
+    final expired = Nip01Event(
+      pubKey: _hiddenAuthor,
+      kind: 1,
+      tags: [
+        ['expiration', '1'],
+      ],
+      content: 'expired note',
+      createdAt: 100,
+    );
+    await cacheManager.saveEvent(expired);
+
+    final hidden = await cacheManager.loadHiddenEvents(
+      reasons: {HiddenEventReason.expired},
+    );
+
+    expect(hidden.single.event.id, equals(expired.id));
+    expect(hidden.single.isExpired, isTrue);
+    expect(await cacheManager.loadEvents(ids: [expired.id]), isEmpty);
+  });
+
+  test('limit applies after hidden events are selected', () async {
+    final cacheManager = getCacheManager();
+
+    await cacheManager.saveEvents([
+      _article(dTag: 'article-a', createdAt: 100, content: 'oldest'),
+      _article(dTag: 'article-a', createdAt: 200, content: 'middle'),
+      _article(dTag: 'article-a', createdAt: 300, content: 'current'),
+    ]);
+
+    final hidden = await cacheManager.loadHiddenEvents(
+      coordinates: ['30023:$_hiddenAuthor:article-a'],
+      limit: 1,
+    );
+
+    expect(hidden.map((e) => e.event.content), equals(['middle']));
+  });
+
+  test('loadHiddenEvents ignores visible events', () async {
+    final cacheManager = getCacheManager();
+
+    await cacheManager.saveEvents([
+      Nip01Event(
+        pubKey: _hiddenAuthor,
+        kind: 1,
+        tags: [],
+        content: 'visible note',
+        createdAt: 100,
+      ),
+      _article(dTag: 'article-a', createdAt: 100, content: 'only version'),
+    ]);
+
+    expect(await cacheManager.loadHiddenEvents(), isEmpty);
+  });
+}

--- a/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite_hidden_event.dart
+++ b/packages/ndk_cache_manager_test_suite/lib/src/cache_manager_test_suite_hidden_event.dart
@@ -45,6 +45,32 @@ void _runHiddenEventTests(CacheManager Function() getCacheManager) {
     expect(visible.map((e) => e.content), equals(['final']));
   });
 
+  test('a limited read falls back to the newest visible event', () async {
+    final cacheManager = getCacheManager();
+
+    final v1 = _article(dTag: 'article-a', createdAt: 100, content: 'kept');
+    final v2 = _article(dTag: 'article-a', createdAt: 200, content: 'deleted');
+    final deletion = Nip01Event(
+      pubKey: _hiddenAuthor,
+      kind: 5,
+      tags: [
+        ['e', v2.id],
+      ],
+      content: 'gone',
+      createdAt: 250,
+    );
+    await cacheManager.saveEvents([v1, v2, deletion]);
+
+    // A limit must not be spent on events the visibility rules then remove.
+    final visible = await cacheManager.loadEvents(
+      pubKeys: [_hiddenAuthor],
+      kinds: [30023],
+      limit: 1,
+    );
+
+    expect(visible.map((e) => e.content), equals(['kept']));
+  });
+
   test('loadEvents hides a superseded version queried by id', () async {
     final cacheManager = getCacheManager();
 
@@ -101,12 +127,17 @@ void _runHiddenEventTests(CacheManager Function() getCacheManager) {
     final withEmptyDTag = await cacheManager.loadHiddenEvents(
       coordinates: ['${Metadata.kKind}:$_hiddenAuthor:'],
     );
+    // A kind with no d-tag has no domain named by a non empty third segment.
+    final withJunkDTag = await cacheManager.loadHiddenEvents(
+      coordinates: ['${Metadata.kKind}:$_hiddenAuthor:unexpected'],
+    );
 
     expect(withoutDTag.map((e) => e.event.content), equals(['{"name":"old"}']));
     expect(
       withEmptyDTag.map((e) => e.event.id),
       equals(withoutDTag.map((e) => e.event.id)),
     );
+    expect(withJunkDTag, isEmpty);
   });
 
   test('reasons filter separates deleted from superseded', () async {

--- a/packages/objectbox/lib/data_layer/db/object_box/db_object_box.dart
+++ b/packages/objectbox/lib/data_layer/db/object_box/db_object_box.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:ndk/domain_layer/repositories/wallets_repo.dart';
-import 'package:ndk/shared/nips/nip01/event_kind_classification.dart';
 import 'package:ndk/shared/nips/nip01/event_eviction_planner.dart';
+import 'package:ndk/shared/nips/nip01/event_visibility_resolver.dart';
 import 'package:ndk/entities.dart';
 import 'package:ndk/ndk.dart';
 
@@ -42,6 +42,10 @@ class DbObjectBox extends WalletsRepo implements CacheManager {
   final Map<String, RelayDeliveryTarget> _relayDeliveryTargets = {};
   final Map<String, DecryptedEventPayloadRecord> _decryptedEventPayloadRecords =
       {};
+
+  late final EventVisibilityResolver _visibility = EventVisibilityResolver(
+    _loadRawEvents,
+  );
 
   /// crates objectbox db instace
   /// [attach] to attach to already open instance (e.g. for isolates)
@@ -470,6 +474,63 @@ class DbObjectBox extends WalletsRepo implements CacheManager {
     String? search,
     int? limit,
   }) async {
+    final candidates = await _loadRawEvents(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+    );
+
+    var events = await _visibility.filterVisible(candidates);
+    events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    if (limit != null && limit > 0 && events.length > limit) {
+      events = events.take(limit).toList();
+    }
+
+    return events;
+  }
+
+  @override
+  Future<List<HiddenEvent>> loadHiddenEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    List<String>? coordinates,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+    Set<HiddenEventReason> reasons = kAllHiddenEventReasons,
+  }) {
+    return _visibility.loadHiddenEvents(
+      ids: ids,
+      pubKeys: pubKeys,
+      kinds: kinds,
+      coordinates: coordinates,
+      tags: tags,
+      since: since,
+      until: until,
+      search: search,
+      limit: limit,
+      reasons: reasons,
+    );
+  }
+
+  Future<List<Nip01Event>> _loadRawEvents({
+    List<String>? ids,
+    List<String>? pubKeys,
+    List<int>? kinds,
+    Map<String, List<String>>? tags,
+    int? since,
+    int? until,
+    String? search,
+    int? limit,
+  }) async {
     await dbRdy;
     final eventBox = _objectBox.store.box<DbNip01Event>();
 
@@ -547,17 +608,7 @@ class DbObjectBox extends WalletsRepo implements CacheManager {
     final query = queryBuilder.build();
     final results = query.find();
 
-    final deletions = eventBox
-        .query(DbNip01Event_.kind.equals(5))
-        .build()
-        .find()
-        .map((dbEvent) => dbEvent.toNdk())
-        .toList();
-
-    var events = _applyEventVisibilityRules(
-      results.map((dbEvent) => dbEvent.toNdk()).toList(),
-      deletions,
-    )..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    var events = results.map((dbEvent) => dbEvent.toNdk()).toList();
 
     if (limit != null && limit > 0 && events.length > limit) {
       events = events.take(limit).toList();
@@ -1043,69 +1094,6 @@ class DbObjectBox extends WalletsRepo implements CacheManager {
     eventBox.removeMany(results.map((e) => e.dbId).toList());
     _removeEventSidecarsByIds(removedEventIds);
     await _syncUserRelayListProjections(affectedPubKeys);
-  }
-
-  List<Nip01Event> _applyEventVisibilityRules(
-    List<Nip01Event> events,
-    List<Nip01Event> deletions,
-  ) {
-    final visible = <Nip01Event>[];
-    final replaceableWinners = <String, Nip01Event>{};
-    final now = Nip01Event.secondsSinceEpoch();
-
-    for (final event in events) {
-      if (_isExpired(event, now)) continue;
-      if (_isDeletedByAuthor(event, deletions)) continue;
-
-      final coordinateKey = _coordinateKey(event);
-      if (coordinateKey == null) {
-        visible.add(event);
-        continue;
-      }
-
-      final current = replaceableWinners[coordinateKey];
-      if (current == null || _isMoreRecentReplaceable(event, current)) {
-        replaceableWinners[coordinateKey] = event;
-      }
-    }
-
-    visible.addAll(replaceableWinners.values);
-    return visible;
-  }
-
-  bool _isDeletedByAuthor(Nip01Event target, List<Nip01Event> deletions) {
-    if (target.kind == 5) return false;
-
-    for (final deletion in deletions) {
-      if (deletion.pubKey != target.pubKey) continue;
-      if (deletion.getTags('e').contains(target.id.toLowerCase())) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  bool _isExpired(Nip01Event event, int now) {
-    final expirationValue = event.getFirstTag('expiration');
-    if (expirationValue == null) return false;
-    final expiration = int.tryParse(expirationValue);
-    if (expiration == null) return false;
-    return expiration <= now;
-  }
-
-  String? _coordinateKey(Nip01Event event) {
-    if (!EventKindClassification.isReplaceableKind(event.kind)) return null;
-    final dTag = event.getDtag() ?? '';
-    return '${event.kind}:${event.pubKey}:$dTag';
-  }
-
-  bool _isMoreRecentReplaceable(Nip01Event candidate, Nip01Event current) {
-    if (candidate.createdAt != current.createdAt) {
-      return candidate.createdAt > current.createdAt;
-    }
-
-    return candidate.id.compareTo(current.id) < 0;
   }
 
   Future<Nip01Event?> _loadLatestVisibleEvent({


### PR DESCRIPTION
An app had no way to reach a superseded version of a replaceable event, or one its author deleted. Both stay in the cache, but loadEvents hides them and loadEvent only answers to a caller who already holds the id, which is exactly what it lacks. loadHiddenEvents queries them by filter, including by conflict domain, and pairs each event with the cache state that says why it is hidden.

Two deletion gaps close on the way. The objectbox backend ignored coordinate deletions, its check only looked at `e` tags. And a coordinate for a non addressable replaceable kind now matches whether its `a` tag carries a trailing empty d-tag segment or not.

BREAKING CHANGE: CacheManager gains loadHiddenEvents, so a third-party cache backend has to implement it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving cached events hidden because they were superseded, deleted, or expired.
  * Added filters for hidden-event reasons and event coordinates.
  * Added metadata explaining why an event is hidden, including deletion details.
* **Bug Fixes**
  * Improved deletion matching for replaceable and addressable events.
  * Applied result limits after visibility filtering.
* **Documentation**
  * Documented hidden-event retrieval and cache behavior when displaying history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->