### PR TITLE
feat: let a broadcast say which identity it may be attributed to

### DIFF
--- a/doc/concepts/nip42-auth.md
+++ b/doc/concepts/nip42-auth.md
@@ -4,4 +4,4 @@ NDK handles NIP-42 relay authentication automatically. When a relay requires aut
 
 A connection carries at most one identity, chosen when it is opened and immutable for its whole lifetime, so a request that authenticates moves to its own connection.
 
-Which identity a request may be attributed to is the `auth` parameter, see [requests](/usecases/requests.md#relay-authentication-nip-42). The same parameter says which identity a negentropy reconciliation may use, see [negentropy](/usecases/negentropy.md#relay-authentication-nip-42).
+Which identity a request may be attributed to is the `auth` parameter, see [requests](/usecases/requests.md#relay-authentication-nip-42). The same parameter says which identity a negentropy reconciliation may use, see [negentropy](/usecases/negentropy.md#relay-authentication-nip-42), and which identity an event may be published under, see [broadcast](/usecases/broadcast.md#relay-authentication-nip-42).

--- a/doc/usecases/broadcast.md
+++ b/doc/usecases/broadcast.md
@@ -29,6 +29,53 @@ You might encounter a warning about missing `nip65` data. You can ignore this wa
 If you want to use the outbox model, check out the [enabling gossip](/guides/enabling-gossip.md#broadcast-using-outbox) guide (recommended).
 !!!
 
+## Relay authentication (NIP-42)
+
+Some relays only accept an event from a client that authenticated. The `auth`
+parameter says which identity the broadcast may be attributed to, exactly like
+on [requests](/usecases/requests.md#relay-authentication-nip-42):
+
+```dart
+final myBroadcast = ndk.broadcast.broadcast(
+  nostrEvent: report,
+  auth: const RelayAuth.never(),
+);
+```
+
+| policy | connection | what a relay learns |
+| --- | --- | --- |
+| `RelayAuth.never()` | anonymous, always | nothing. A relay that refuses the event without an identity simply does not accept it |
+| `RelayAuth.allow(a)` | anonymous, moves to one bound to `a` once the relay refuses | who you are, but only after that relay asked |
+| `RelayAuth.require(a)` | bound to `a` from the start | who you are, as soon as it sends a challenge |
+
+Without `auth`, a refused event authenticates as its author when a registered
+account matches, and as the currently logged-in account otherwise. The relay
+therefore decides when your identity is revealed. Pass `auth` explicitly
+whenever that matters.
+
+The account does not have to be one NDK knows: `allow` and `require` take the
+`Account` itself, so an identity you built on the spot works.
+
+If `require` names an account that cannot sign, no connection can carry the
+event. Rather than fall back to the anonymous one, which is what `require`
+rules out, nothing is sent and `broadcast` itself throws
+`BroadcastAuthUnavailableException`.
+
+### Across a restart
+
+A signer is never written to disk, only the policy is, as `never`,
+`allow:<pubkey>` or `require:<pubkey>`. That matters for the background retries
+described below, not for the broadcast you are awaiting.
+
+- `never()` survives a restart whole, because it names nobody. A relay that
+  refuses such an event is a final answer, so it is not retried at all.
+- `allow` and `require` resolve their pubkey through the accounts NDK holds. A
+  retry therefore needs that account to be registered again after a restart.
+- An identity no account can sign for parks the delivery in
+  `EventDeliveryStatus.needsAction` instead of going out as somebody else. You
+  see it through `loadPendingDeliveries()`, and you resume it by broadcasting
+  the same event again with the account in hand.
+
 ## When to use
 
 Broadcast should be used when your use case has no broadcasting method. \

--- a/packages/drift/lib/src/database/database.dart
+++ b/packages/drift/lib/src/database/database.dart
@@ -41,7 +41,7 @@ class NdkCacheDatabase extends _$NdkCacheDatabase {
   NdkCacheDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration {
@@ -76,6 +76,16 @@ class NdkCacheDatabase extends _$NdkCacheDatabase {
           // legacy tables.
           await _migrateLegacyMetadatas();
           await _migrateLegacyContactLists();
+        }
+        // which identity an event goes to a relay under, see RelayAuth. Only
+        // for a database that already had the table: createTable above builds
+        // it from today's definition, column included, so adding it again
+        // there would fail on a duplicate
+        if (from >= 5 && from < 7) {
+          await m.addColumn(
+            relayDeliveryTargetsTable,
+            relayDeliveryTargetsTable.authCanonical,
+          );
         }
       },
     );

--- a/packages/drift/lib/src/database/database.g.dart
+++ b/packages/drift/lib/src/database/database.g.dart
@@ -3004,6 +3004,17 @@ class $RelayDeliveryTargetsTableTable extends RelayDeliveryTargetsTable
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _authCanonicalMeta = const VerificationMeta(
+    'authCanonical',
+  );
+  @override
+  late final GeneratedColumn<String> authCanonical = GeneratedColumn<String>(
+    'auth_canonical',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     eventId,
@@ -3015,6 +3026,7 @@ class $RelayDeliveryTargetsTableTable extends RelayDeliveryTargetsTable
     nextRetryAt,
     lastError,
     lastOkMessage,
+    authCanonical,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3102,6 +3114,15 @@ class $RelayDeliveryTargetsTableTable extends RelayDeliveryTargetsTable
         ),
       );
     }
+    if (data.containsKey('auth_canonical')) {
+      context.handle(
+        _authCanonicalMeta,
+        authCanonical.isAcceptableOrUnknown(
+          data['auth_canonical']!,
+          _authCanonicalMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -3147,6 +3168,10 @@ class $RelayDeliveryTargetsTableTable extends RelayDeliveryTargetsTable
         DriftSqlType.string,
         data['${effectivePrefix}last_ok_message'],
       ),
+      authCanonical: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}auth_canonical'],
+      ),
     );
   }
 
@@ -3167,6 +3192,7 @@ class DbRelayDeliveryTarget extends DataClass
   final int? nextRetryAt;
   final String? lastError;
   final String? lastOkMessage;
+  final String? authCanonical;
   const DbRelayDeliveryTarget({
     required this.eventId,
     required this.relayUrl,
@@ -3177,6 +3203,7 @@ class DbRelayDeliveryTarget extends DataClass
     this.nextRetryAt,
     this.lastError,
     this.lastOkMessage,
+    this.authCanonical,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -3197,6 +3224,9 @@ class DbRelayDeliveryTarget extends DataClass
     }
     if (!nullToAbsent || lastOkMessage != null) {
       map['last_ok_message'] = Variable<String>(lastOkMessage);
+    }
+    if (!nullToAbsent || authCanonical != null) {
+      map['auth_canonical'] = Variable<String>(authCanonical);
     }
     return map;
   }
@@ -3220,6 +3250,9 @@ class DbRelayDeliveryTarget extends DataClass
       lastOkMessage: lastOkMessage == null && nullToAbsent
           ? const Value.absent()
           : Value(lastOkMessage),
+      authCanonical: authCanonical == null && nullToAbsent
+          ? const Value.absent()
+          : Value(authCanonical),
     );
   }
 
@@ -3238,6 +3271,7 @@ class DbRelayDeliveryTarget extends DataClass
       nextRetryAt: serializer.fromJson<int?>(json['nextRetryAt']),
       lastError: serializer.fromJson<String?>(json['lastError']),
       lastOkMessage: serializer.fromJson<String?>(json['lastOkMessage']),
+      authCanonical: serializer.fromJson<String?>(json['authCanonical']),
     );
   }
   @override
@@ -3253,6 +3287,7 @@ class DbRelayDeliveryTarget extends DataClass
       'nextRetryAt': serializer.toJson<int?>(nextRetryAt),
       'lastError': serializer.toJson<String?>(lastError),
       'lastOkMessage': serializer.toJson<String?>(lastOkMessage),
+      'authCanonical': serializer.toJson<String?>(authCanonical),
     };
   }
 
@@ -3266,6 +3301,7 @@ class DbRelayDeliveryTarget extends DataClass
     Value<int?> nextRetryAt = const Value.absent(),
     Value<String?> lastError = const Value.absent(),
     Value<String?> lastOkMessage = const Value.absent(),
+    Value<String?> authCanonical = const Value.absent(),
   }) => DbRelayDeliveryTarget(
     eventId: eventId ?? this.eventId,
     relayUrl: relayUrl ?? this.relayUrl,
@@ -3280,6 +3316,9 @@ class DbRelayDeliveryTarget extends DataClass
     lastOkMessage: lastOkMessage.present
         ? lastOkMessage.value
         : this.lastOkMessage,
+    authCanonical: authCanonical.present
+        ? authCanonical.value
+        : this.authCanonical,
   );
   DbRelayDeliveryTarget copyWithCompanion(
     RelayDeliveryTargetsTableCompanion data,
@@ -3302,6 +3341,9 @@ class DbRelayDeliveryTarget extends DataClass
       lastOkMessage: data.lastOkMessage.present
           ? data.lastOkMessage.value
           : this.lastOkMessage,
+      authCanonical: data.authCanonical.present
+          ? data.authCanonical.value
+          : this.authCanonical,
     );
   }
 
@@ -3316,7 +3358,8 @@ class DbRelayDeliveryTarget extends DataClass
           ..write('lastAttemptAt: $lastAttemptAt, ')
           ..write('nextRetryAt: $nextRetryAt, ')
           ..write('lastError: $lastError, ')
-          ..write('lastOkMessage: $lastOkMessage')
+          ..write('lastOkMessage: $lastOkMessage, ')
+          ..write('authCanonical: $authCanonical')
           ..write(')'))
         .toString();
   }
@@ -3332,6 +3375,7 @@ class DbRelayDeliveryTarget extends DataClass
     nextRetryAt,
     lastError,
     lastOkMessage,
+    authCanonical,
   );
   @override
   bool operator ==(Object other) =>
@@ -3345,7 +3389,8 @@ class DbRelayDeliveryTarget extends DataClass
           other.lastAttemptAt == this.lastAttemptAt &&
           other.nextRetryAt == this.nextRetryAt &&
           other.lastError == this.lastError &&
-          other.lastOkMessage == this.lastOkMessage);
+          other.lastOkMessage == this.lastOkMessage &&
+          other.authCanonical == this.authCanonical);
 }
 
 class RelayDeliveryTargetsTableCompanion
@@ -3359,6 +3404,7 @@ class RelayDeliveryTargetsTableCompanion
   final Value<int?> nextRetryAt;
   final Value<String?> lastError;
   final Value<String?> lastOkMessage;
+  final Value<String?> authCanonical;
   final Value<int> rowid;
   const RelayDeliveryTargetsTableCompanion({
     this.eventId = const Value.absent(),
@@ -3370,6 +3416,7 @@ class RelayDeliveryTargetsTableCompanion
     this.nextRetryAt = const Value.absent(),
     this.lastError = const Value.absent(),
     this.lastOkMessage = const Value.absent(),
+    this.authCanonical = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   RelayDeliveryTargetsTableCompanion.insert({
@@ -3382,6 +3429,7 @@ class RelayDeliveryTargetsTableCompanion
     this.nextRetryAt = const Value.absent(),
     this.lastError = const Value.absent(),
     this.lastOkMessage = const Value.absent(),
+    this.authCanonical = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : eventId = Value(eventId),
        relayUrl = Value(relayUrl),
@@ -3397,6 +3445,7 @@ class RelayDeliveryTargetsTableCompanion
     Expression<int>? nextRetryAt,
     Expression<String>? lastError,
     Expression<String>? lastOkMessage,
+    Expression<String>? authCanonical,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -3409,6 +3458,7 @@ class RelayDeliveryTargetsTableCompanion
       if (nextRetryAt != null) 'next_retry_at': nextRetryAt,
       if (lastError != null) 'last_error': lastError,
       if (lastOkMessage != null) 'last_ok_message': lastOkMessage,
+      if (authCanonical != null) 'auth_canonical': authCanonical,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -3423,6 +3473,7 @@ class RelayDeliveryTargetsTableCompanion
     Value<int?>? nextRetryAt,
     Value<String?>? lastError,
     Value<String?>? lastOkMessage,
+    Value<String?>? authCanonical,
     Value<int>? rowid,
   }) {
     return RelayDeliveryTargetsTableCompanion(
@@ -3435,6 +3486,7 @@ class RelayDeliveryTargetsTableCompanion
       nextRetryAt: nextRetryAt ?? this.nextRetryAt,
       lastError: lastError ?? this.lastError,
       lastOkMessage: lastOkMessage ?? this.lastOkMessage,
+      authCanonical: authCanonical ?? this.authCanonical,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -3469,6 +3521,9 @@ class RelayDeliveryTargetsTableCompanion
     if (lastOkMessage.present) {
       map['last_ok_message'] = Variable<String>(lastOkMessage.value);
     }
+    if (authCanonical.present) {
+      map['auth_canonical'] = Variable<String>(authCanonical.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -3487,6 +3542,7 @@ class RelayDeliveryTargetsTableCompanion
           ..write('nextRetryAt: $nextRetryAt, ')
           ..write('lastError: $lastError, ')
           ..write('lastOkMessage: $lastOkMessage, ')
+          ..write('authCanonical: $authCanonical, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -8350,6 +8406,7 @@ typedef $$RelayDeliveryTargetsTableTableCreateCompanionBuilder =
       Value<int?> nextRetryAt,
       Value<String?> lastError,
       Value<String?> lastOkMessage,
+      Value<String?> authCanonical,
       Value<int> rowid,
     });
 typedef $$RelayDeliveryTargetsTableTableUpdateCompanionBuilder =
@@ -8363,6 +8420,7 @@ typedef $$RelayDeliveryTargetsTableTableUpdateCompanionBuilder =
       Value<int?> nextRetryAt,
       Value<String?> lastError,
       Value<String?> lastOkMessage,
+      Value<String?> authCanonical,
       Value<int> rowid,
     });
 
@@ -8417,6 +8475,11 @@ class $$RelayDeliveryTargetsTableTableFilterComposer
 
   ColumnFilters<String> get lastOkMessage => $composableBuilder(
     column: $table.lastOkMessage,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get authCanonical => $composableBuilder(
+    column: $table.authCanonical,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -8474,6 +8537,11 @@ class $$RelayDeliveryTargetsTableTableOrderingComposer
     column: $table.lastOkMessage,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get authCanonical => $composableBuilder(
+    column: $table.authCanonical,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$RelayDeliveryTargetsTableTableAnnotationComposer
@@ -8517,6 +8585,11 @@ class $$RelayDeliveryTargetsTableTableAnnotationComposer
 
   GeneratedColumn<String> get lastOkMessage => $composableBuilder(
     column: $table.lastOkMessage,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get authCanonical => $composableBuilder(
+    column: $table.authCanonical,
     builder: (column) => column,
   );
 }
@@ -8576,6 +8649,7 @@ class $$RelayDeliveryTargetsTableTableTableManager
                 Value<int?> nextRetryAt = const Value.absent(),
                 Value<String?> lastError = const Value.absent(),
                 Value<String?> lastOkMessage = const Value.absent(),
+                Value<String?> authCanonical = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => RelayDeliveryTargetsTableCompanion(
                 eventId: eventId,
@@ -8587,6 +8661,7 @@ class $$RelayDeliveryTargetsTableTableTableManager
                 nextRetryAt: nextRetryAt,
                 lastError: lastError,
                 lastOkMessage: lastOkMessage,
+                authCanonical: authCanonical,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -8600,6 +8675,7 @@ class $$RelayDeliveryTargetsTableTableTableManager
                 Value<int?> nextRetryAt = const Value.absent(),
                 Value<String?> lastError = const Value.absent(),
                 Value<String?> lastOkMessage = const Value.absent(),
+                Value<String?> authCanonical = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => RelayDeliveryTargetsTableCompanion.insert(
                 eventId: eventId,
@@ -8611,6 +8687,7 @@ class $$RelayDeliveryTargetsTableTableTableManager
                 nextRetryAt: nextRetryAt,
                 lastError: lastError,
                 lastOkMessage: lastOkMessage,
+                authCanonical: authCanonical,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/packages/drift/lib/src/database/tables.dart
+++ b/packages/drift/lib/src/database/tables.dart
@@ -111,6 +111,7 @@ class RelayDeliveryTargetsTable extends Table {
   IntColumn get nextRetryAt => integer().nullable()();
   TextColumn get lastError => text().nullable()();
   TextColumn get lastOkMessage => text().nullable()();
+  TextColumn get authCanonical => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {eventId, relayUrl};

--- a/packages/drift/lib/src/drift_cache_manager.dart
+++ b/packages/drift/lib/src/drift_cache_manager.dart
@@ -1340,7 +1340,8 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
         record.signAttemptCount > 0 ||
         record.lastSignAttemptAt != null ||
         record.nextSignRetryAt != null ||
-        record.lastSignError != null;
+        record.lastSignError != null ||
+        record.authCanonical != null;
     if (!hasSnapshotPayload) {
       await _removeEventDeliverySnapshot(record.eventId);
       return;

--- a/packages/drift/lib/src/drift_cache_manager.dart
+++ b/packages/drift/lib/src/drift_cache_manager.dart
@@ -1340,8 +1340,7 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
         record.signAttemptCount > 0 ||
         record.lastSignAttemptAt != null ||
         record.nextSignRetryAt != null ||
-        record.lastSignError != null ||
-        record.authCanonical != null;
+        record.lastSignError != null;
     if (!hasSnapshotPayload) {
       await _removeEventDeliverySnapshot(record.eventId);
       return;
@@ -1420,6 +1419,7 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
             nextRetryAt: Value(target.nextRetryAt),
             lastError: Value(target.lastError),
             lastOkMessage: Value(target.lastOkMessage),
+            authCanonical: Value(target.authCanonical),
           ),
         );
   }
@@ -1443,6 +1443,7 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
                 nextRetryAt: Value(target.nextRetryAt),
                 lastError: Value(target.lastError),
                 lastOkMessage: Value(target.lastOkMessage),
+                authCanonical: Value(target.authCanonical),
               ),
             )
             .toList(),
@@ -1540,6 +1541,7 @@ class DriftCacheManager extends WalletsRepo implements CacheManager {
       nextRetryAt: row.nextRetryAt,
       lastError: row.lastError,
       lastOkMessage: row.lastOkMessage,
+      authCanonical: row.authCanonical,
     );
   }
 

--- a/packages/drift/test/database_migration_v6_test.dart
+++ b/packages/drift/test/database_migration_v6_test.dart
@@ -5,9 +5,13 @@ import 'package:ndk_drift/ndk_drift.dart';
 
 /// Opens a database seeded with the pre-v6 schema (dedicated metadatas and
 /// contact_lists tables) so that opening it triggers the v5 -> v6 migration.
+///
+/// [version] seeds an older schema instead: below 5 the delivery tables do not
+/// exist yet, and the migration has to create them rather than alter them.
 NdkCacheDatabase openV5Database({
   List<String> metadataInserts = const [],
   List<String> contactListInserts = const [],
+  int version = 5,
 }) {
   return NdkCacheDatabase.forTesting(
     NativeDatabase.memory(
@@ -75,13 +79,29 @@ NdkCacheDatabase openV5Database({
             value TEXT
           );
         ''');
+        if (version >= 5) {
+          db.execute('''
+            CREATE TABLE relay_delivery_targets_table (
+              event_id TEXT NOT NULL,
+              relay_url TEXT NOT NULL,
+              reason TEXT NOT NULL,
+              state TEXT NOT NULL,
+              attempt_count INTEGER NOT NULL DEFAULT 0,
+              last_attempt_at INTEGER,
+              next_retry_at INTEGER,
+              last_error TEXT,
+              last_ok_message TEXT,
+              PRIMARY KEY (event_id, relay_url)
+            );
+          ''');
+        }
         for (final statement in metadataInserts) {
           db.execute(statement);
         }
         for (final statement in contactListInserts) {
           db.execute(statement);
         }
-        db.execute('PRAGMA user_version = 5;');
+        db.execute('PRAGMA user_version = $version;');
       },
     ),
   );
@@ -229,4 +249,30 @@ void main() {
 
     await db.close();
   });
+
+  /// A database older than the delivery tables has them created from today's
+  /// definition, auth_canonical included, so the v7 step must not add it again.
+  test(
+    'v4 -> latest creates the delivery tables instead of altering them',
+    () async {
+      final db = openV5Database(version: 4);
+      final cacheManager = DriftCacheManager(db);
+
+      await cacheManager.saveRelayDeliveryTarget(
+        const RelayDeliveryTarget(
+          eventId: 'event-1',
+          relayUrl: 'wss://relay.example',
+          reason: RelayDeliveryReason.explicit,
+          authCanonical: 'require:alicePubKey',
+        ),
+      );
+
+      final targets = await cacheManager.loadRelayDeliveryTargets(
+        eventId: 'event-1',
+      );
+      expect(targets.single.authCanonical, 'require:alicePubKey');
+
+      await db.close();
+    },
+  );
 }

--- a/packages/ndk/lib/domain_layer/entities/broadcast_state.dart
+++ b/packages/ndk/lib/domain_layer/entities/broadcast_state.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 
 import 'nip_01_event.dart';
+import 'relay_auth.dart';
 
 /// hols information about a individual relay broadcast response \
 /// e.g. \
@@ -46,6 +47,9 @@ class BroadcastState {
 
   /// the event being broadcast (stored for potential retries on auth-required)
   Nip01Event? event;
+
+  /// which identity this broadcast may be attributed to on the relays (NIP-42)
+  final RelayAuth? auth;
 
   /// stream controller for state updates
   final BehaviorSubject<BroadcastState> _stateUpdatesController =
@@ -99,7 +103,11 @@ class BroadcastState {
   bool _timeoutStarted = false;
 
   /// creates a new [BroadcastState] instance
-  BroadcastState({required this.timeout, this.considerDonePercent = 1}) {
+  BroadcastState({
+    required this.timeout,
+    this.considerDonePercent = 1,
+    this.auth,
+  }) {
     _networkSubscription = networkController.stream.listen(
       (response) {
         // got a response from a relay

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -161,6 +161,11 @@ class EventDeliveryRecord {
   final int? nextSignRetryAt;
   final String? lastSignError;
 
+  /// canonical form of the [RelayAuth] this event was broadcast under, see
+  /// `RelayAuth.canonical`. A signer cannot be persisted, so only the intent
+  /// is: the account behind a pubkey is resolved again on retry.
+  final String? authCanonical;
+
   const EventDeliveryRecord({
     required this.eventId,
     this.status = EventDeliveryStatus.pending,
@@ -175,6 +180,7 @@ class EventDeliveryRecord {
     this.lastSignAttemptAt,
     this.nextSignRetryAt,
     this.lastSignError,
+    this.authCanonical,
   });
 
   /// True once all known targets have been acknowledged.
@@ -200,6 +206,7 @@ class EventDeliveryRecord {
     Object? lastSignAttemptAt = _noChange,
     Object? nextSignRetryAt = _noChange,
     Object? lastSignError = _noChange,
+    Object? authCanonical = _noChange,
   }) {
     return EventDeliveryRecord(
       eventId: eventId ?? this.eventId,
@@ -227,6 +234,9 @@ class EventDeliveryRecord {
       lastSignError: identical(lastSignError, _noChange)
           ? this.lastSignError
           : lastSignError as String?,
+      authCanonical: identical(authCanonical, _noChange)
+          ? this.authCanonical
+          : authCanonical as String?,
     );
   }
 
@@ -245,6 +255,7 @@ class EventDeliveryRecord {
       'lastSignAttemptAt': lastSignAttemptAt,
       'nextSignRetryAt': nextSignRetryAt,
       'lastSignError': lastSignError,
+      'authCanonical': authCanonical,
     };
   }
 
@@ -271,6 +282,7 @@ class EventDeliveryRecord {
       lastSignAttemptAt: json['lastSignAttemptAt'] as int?,
       nextSignRetryAt: json['nextSignRetryAt'] as int?,
       lastSignError: json['lastSignError'] as String?,
+      authCanonical: json['authCanonical'] as String?,
     );
   }
 }

--- a/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
+++ b/packages/ndk/lib/domain_layer/entities/event_cache_records.dart
@@ -65,6 +65,13 @@ class RelayDeliveryTarget {
   final String? lastError;
   final String? lastOkMessage;
 
+  /// canonical form of the [RelayAuth] this event goes to this relay under, see
+  /// `RelayAuth.canonical`. It lives here rather than on the event, because the
+  /// same event may be published to two relays under two identities. A signer
+  /// cannot be persisted, so only the intent is: the account behind a pubkey is
+  /// resolved again on retry.
+  final String? authCanonical;
+
   const RelayDeliveryTarget({
     required this.eventId,
     required this.relayUrl,
@@ -75,10 +82,15 @@ class RelayDeliveryTarget {
     this.nextRetryAt,
     this.lastError,
     this.lastOkMessage,
+    this.authCanonical,
   });
 
   /// Stable primary key used by cache backends.
-  String get key => '$eventId|$relayUrl';
+  String get key => '${keyPrefixFor(eventId)}$relayUrl';
+
+  /// What [key] of every target of [eventId] starts with, so a caller keyed by
+  /// [key] can find them all without spelling the format out again.
+  static String keyPrefixFor(String eventId) => '$eventId|';
 
   RelayDeliveryTarget copyWith({
     String? eventId,
@@ -90,6 +102,7 @@ class RelayDeliveryTarget {
     Object? nextRetryAt = _noChange,
     Object? lastError = _noChange,
     Object? lastOkMessage = _noChange,
+    Object? authCanonical = _noChange,
   }) {
     return RelayDeliveryTarget(
       eventId: eventId ?? this.eventId,
@@ -109,6 +122,9 @@ class RelayDeliveryTarget {
       lastOkMessage: identical(lastOkMessage, _noChange)
           ? this.lastOkMessage
           : lastOkMessage as String?,
+      authCanonical: identical(authCanonical, _noChange)
+          ? this.authCanonical
+          : authCanonical as String?,
     );
   }
 
@@ -123,6 +139,7 @@ class RelayDeliveryTarget {
       'nextRetryAt': nextRetryAt,
       'lastError': lastError,
       'lastOkMessage': lastOkMessage,
+      'authCanonical': authCanonical,
     };
   }
 
@@ -137,6 +154,7 @@ class RelayDeliveryTarget {
       nextRetryAt: json['nextRetryAt'] as int?,
       lastError: json['lastError'] as String?,
       lastOkMessage: json['lastOkMessage'] as String?,
+      authCanonical: json['authCanonical'] as String?,
     );
   }
 }
@@ -161,11 +179,6 @@ class EventDeliveryRecord {
   final int? nextSignRetryAt;
   final String? lastSignError;
 
-  /// canonical form of the [RelayAuth] this event was broadcast under, see
-  /// `RelayAuth.canonical`. A signer cannot be persisted, so only the intent
-  /// is: the account behind a pubkey is resolved again on retry.
-  final String? authCanonical;
-
   const EventDeliveryRecord({
     required this.eventId,
     this.status = EventDeliveryStatus.pending,
@@ -180,7 +193,6 @@ class EventDeliveryRecord {
     this.lastSignAttemptAt,
     this.nextSignRetryAt,
     this.lastSignError,
-    this.authCanonical,
   });
 
   /// True once all known targets have been acknowledged.
@@ -206,7 +218,6 @@ class EventDeliveryRecord {
     Object? lastSignAttemptAt = _noChange,
     Object? nextSignRetryAt = _noChange,
     Object? lastSignError = _noChange,
-    Object? authCanonical = _noChange,
   }) {
     return EventDeliveryRecord(
       eventId: eventId ?? this.eventId,
@@ -234,9 +245,6 @@ class EventDeliveryRecord {
       lastSignError: identical(lastSignError, _noChange)
           ? this.lastSignError
           : lastSignError as String?,
-      authCanonical: identical(authCanonical, _noChange)
-          ? this.authCanonical
-          : authCanonical as String?,
     );
   }
 
@@ -255,7 +263,6 @@ class EventDeliveryRecord {
       'lastSignAttemptAt': lastSignAttemptAt,
       'nextSignRetryAt': nextSignRetryAt,
       'lastSignError': lastSignError,
-      'authCanonical': authCanonical,
     };
   }
 
@@ -282,7 +289,6 @@ class EventDeliveryRecord {
       lastSignAttemptAt: json['lastSignAttemptAt'] as int?,
       nextSignRetryAt: json['nextSignRetryAt'] as int?,
       lastSignError: json['lastSignError'] as String?,
-      authCanonical: json['authCanonical'] as String?,
     );
   }
 }

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast.dart
@@ -44,6 +44,11 @@ class Broadcast {
   /// [considerDonePercent] the percentage (0.0, 1.0) of relays that need to respond with "OK" for the broadcast to be considered done (overrides the default value) \
   /// [timeout] the timeout for the broadcast (overrides the default timeout) \
   /// [saveToCache] whether to save the event to cache (overrides the default value from config) \
+  /// [auth] which identity this broadcast may be attributed to on relays (NIP-42), see [RelayAuth].
+  /// Without it, a relay answering `auth-required` is answered as the event author, or as the
+  /// logged-in account when no registered account matches. \
+  /// [throws] [BroadcastAuthUnavailableException], before anything is sent, if [auth] requires
+  /// an identity that cannot sign \
   /// [returns] a [NdkBroadcastResponse] object containing the result => success per relay
   NdkBroadcastResponse broadcast({
     required Nip01Event nostrEvent,
@@ -52,6 +57,7 @@ class Broadcast {
     double? considerDonePercent,
     Duration? timeout,
     bool? saveToCache,
+    RelayAuth? auth,
   }) {
     // prep for pending delivery enrollment
     final cleanedSpecificRelays =
@@ -68,6 +74,7 @@ class Broadcast {
       considerDonePercent: considerDonePercent,
       timeout: timeout,
       saveToCache: saveToCache,
+      auth: auth,
     );
     final responseDoneFuture = response.broadcastDoneFuture;
 
@@ -82,6 +89,7 @@ class Broadcast {
         relayUrls: cleanedSpecificRelays,
         requiresInteractiveSigning:
             signer != null && signer.requiresInteractiveSigning,
+        auth: auth,
       );
     }
 
@@ -173,10 +181,12 @@ class Broadcast {
   /// [eventId] the event you want to react to \
   /// [customRelays] relay URls to send the deletion request to specific relays \
   /// [reaction] the reaction, default + (like) can be 🤔 (emoji)
+  /// [auth] which identity this reaction may be attributed to on relays (NIP-42), see [RelayAuth]
   NdkBroadcastResponse broadcastReaction({
     required String eventId,
     Iterable<String>? customRelays,
     String reaction = "+",
+    RelayAuth? auth,
   }) {
     final signer = _checkSinger();
     Nip01Event event = Nip01Event(
@@ -188,7 +198,11 @@ class Broadcast {
       content: reaction,
       createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
-    return broadcast(nostrEvent: event, specificRelays: customRelays);
+    return broadcast(
+      nostrEvent: event,
+      specificRelays: customRelays,
+      auth: auth,
+    );
   }
 
   /// Request a deletion of an event (NIP-09 compliant).
@@ -206,6 +220,7 @@ class Broadcast {
   /// [customRelays] relay URLs to send the deletion request to specific relays
   /// [customSigner] if you want to use a different signer than the default specified in [NdkConfig]
   /// [reason] reason for deletion (content of the deletion event)
+  /// [auth] which identity this deletion may be attributed to on relays (NIP-42), see [RelayAuth]
   NdkBroadcastResponse broadcastDeletion({
     // New API (NIP-09 compliant)
     Nip01Event? event,
@@ -219,6 +234,7 @@ class Broadcast {
     Iterable<String>? customRelays,
     EventSigner? customSigner,
     String reason = "delete",
+    RelayAuth? auth,
   }) {
     final EventSigner mySigner = _checkSinger(customSigner: customSigner);
 
@@ -322,6 +338,7 @@ class Broadcast {
       nostrEvent: deletionEvent,
       specificRelays: customRelays,
       customSigner: mySigner,
+      auth: auth,
     );
   }
 }

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast_exceptions.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast_exceptions.dart
@@ -1,0 +1,15 @@
+/// Thrown when a broadcast requires an identity that cannot sign, so no
+/// connection can carry it. Nothing is sent: falling back to the anonymous
+/// connection is exactly what [RelayAuthRequire] rules out.
+class BroadcastAuthUnavailableException implements Exception {
+  /// identity the broadcast required
+  final String pubkey;
+
+  /// the required identity cannot sign, so nothing was sent
+  BroadcastAuthUnavailableException(this.pubkey);
+
+  @override
+  String toString() =>
+      'BroadcastAuthUnavailableException: $pubkey cannot sign, so no '
+      'connection can carry this broadcast';
+}

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast_sender.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/broadcast_sender.dart
@@ -53,6 +53,7 @@ class BroadcastSender {
   /// [considerDonePercent] the percentage (0.0, 1.0) of relays that need to respond with "OK" for the broadcast to be considered done (overrides the default value) \
   /// [timeout] the timeout for the broadcast (overrides the default timeout) \
   /// [saveToCache] whether to save the event to cache (overrides the default value from config) \
+  /// [auth] which identity this broadcast may be attributed to on relays (NIP-42), see [RelayAuth] \
   /// [returns] a [NdkBroadcastResponse] object containing the result => success per relay
   NdkBroadcastResponse broadcast({
     required Nip01Event nostrEvent,
@@ -61,14 +62,20 @@ class BroadcastSender {
     double? considerDonePercent,
     Duration? timeout,
     bool? saveToCache,
+    RelayAuth? auth,
   }) {
     final myConsiderDonePercent = considerDonePercent ?? _considerDonePercent;
     final myTimeout = timeout ?? _timeout;
     final mySaveToCache = saveToCache ?? _saveToCache;
 
+    if (auth is RelayAuthRequire && !auth.account.signer.canSign()) {
+      throw BroadcastAuthUnavailableException(auth.account.pubkey);
+    }
+
     final broadcastState = BroadcastState(
       considerDonePercent: myConsiderDonePercent,
       timeout: myTimeout,
+      auth: auth,
     );
     _globalState.inFlightBroadcasts[nostrEvent.id] = broadcastState;
     void cleanupInFlightBroadcastState() {

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/delivery_policy.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/delivery_policy.dart
@@ -1,6 +1,7 @@
 import '../../entities/broadcast_state.dart';
 import '../../entities/event_cache_records.dart';
 import '../../entities/nip_01_event.dart';
+import '../../entities/relay_auth.dart';
 import '../../../shared/nips/nip01/event_kind_classification.dart';
 import '../../../shared/nips/nip09/deletion.dart';
 
@@ -80,7 +81,12 @@ class DeliveryPolicy {
 
   bool get retainsOnlyLatest => kind == DeliveryPolicyKind.latestStateOnly;
 
-  RelayDeliveryState resolveNextState(RelayBroadcastResponse response) {
+  /// [auth] is the policy the broadcast went out under, so a refusal can be
+  /// judged against what this event is allowed to reveal.
+  RelayDeliveryState resolveNextState(
+    RelayBroadcastResponse response, {
+    RelayAuth? auth,
+  }) {
     if (response.okReceived && response.broadcastSuccessful) {
       return RelayDeliveryState.acked;
     }
@@ -97,7 +103,11 @@ class DeliveryPolicy {
 
     if (prefix == 'auth-required' ||
         normalizedMsg.startsWith('auth-required')) {
-      return RelayDeliveryState.authRequired;
+      // no identity may ever be revealed here, so no retry can turn this
+      // refusal into an accepted event
+      return auth is RelayAuthNever
+          ? RelayDeliveryState.permanentFailure
+          : RelayDeliveryState.authRequired;
     }
 
     if (_looksPermanent(response.msg)) {

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
@@ -251,9 +251,20 @@ class PendingBroadcastDelivery {
       if (existingTarget != null) {
         // only the relays of this call are re-attributed; the same event may
         // be on its way to another relay as somebody else
-        return auth == null
-            ? existingTarget
-            : existingTarget.copyWith(authCanonical: auth.canonical);
+        if (auth == null) {
+          return existingTarget;
+        }
+        final reattributed = existingTarget.copyWith(
+          authCanonical: auth.canonical,
+        );
+        // naming an identity is what a target parked for a missing one was
+        // waiting for, so it can move again
+        return _isParkedForIdentity(reattributed)
+            ? reattributed.copyWith(
+                state: RelayDeliveryState.pending,
+                lastError: null,
+              )
+            : reattributed;
       }
       return RelayDeliveryTarget(
         eventId: event.id,
@@ -417,6 +428,10 @@ class PendingBroadcastDelivery {
 
         if (!onlyDue) {
           return true;
+        }
+
+        if (_isParkedForIdentity(target)) {
+          return false;
         }
 
         return target.nextRetryAt == null || target.nextRetryAt! <= now;
@@ -643,6 +658,15 @@ class PendingBroadcastDelivery {
     await _cacheManager.removeEventDeliveryRecord(eventId);
   }
 
+  /// A target waiting for an identity the app has to name again. Nothing about
+  /// it changes on its own, so it must not make its relay due: it would
+  /// reconnect and rewrite the same state on every retry interval, forever.
+  /// A normal auth-required refusal carries a [RelayDeliveryTarget.nextRetryAt]
+  /// and stays retryable.
+  bool _isParkedForIdentity(RelayDeliveryTarget target) =>
+      target.state == RelayDeliveryState.authRequired &&
+      target.nextRetryAt == null;
+
   Future<Set<String>> _relayUrlsWithDuePendingTargets() async {
     final now = Nip01Event.secondsSinceEpoch();
     final targets = await _cacheManager.loadRelayDeliveryTargets(
@@ -652,6 +676,9 @@ class PendingBroadcastDelivery {
     final relayUrls = <String>{};
     for (final target in targets) {
       if (target.state == RelayDeliveryState.permanentFailure) {
+        continue;
+      }
+      if (_isParkedForIdentity(target)) {
         continue;
       }
       if (target.nextRetryAt != null && target.nextRetryAt! > now) {

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
@@ -39,10 +39,11 @@ class PendingBroadcastDelivery {
   final Map<String, int> _activeSignAttemptIds = {};
   final Map<String, int> _latestSignAttemptIds = {};
 
-  /// auth policy per event id, for as long as this process lives. A signer
-  /// cannot be persisted, so an account the caller handed over without ever
-  /// registering it only survives here. What outlives a restart is the
-  /// canonical form on the delivery record, see [_authForDelivery].
+  /// auth policy per relay target, keyed by [RelayDeliveryTarget.key] so one
+  /// event may go to two relays as two identities. For as long as this process
+  /// lives: a signer cannot be persisted, so an account the caller handed over
+  /// without ever registering it only survives here. What outlives a restart is
+  /// the canonical form on the target, see [_authForTarget].
   final Map<String, RelayAuth> _authPolicies = {};
   Iterable<String> Function()? _connectedRelayUrlsProvider;
   Timer? _retryTimer;
@@ -208,9 +209,6 @@ class PendingBroadcastDelivery {
     if (_stopped) {
       return;
     }
-    if (auth != null) {
-      _authPolicies[event.id] = auth;
-    }
     // One durable aggregate record plus one durable target per relay gives NDK
     // enough state to recover delivery after restart without mutating a shared
     // in-memory list.
@@ -238,7 +236,6 @@ class PendingBroadcastDelivery {
         lastSignAttemptAt: existing?.lastSignAttemptAt,
         nextSignRetryAt: existing?.nextSignRetryAt,
         lastSignError: existing?.lastSignError,
-        authCanonical: auth?.canonical ?? existing?.authCanonical,
       ),
     );
 
@@ -249,17 +246,32 @@ class PendingBroadcastDelivery {
       for (final target in existingTargets) target.relayUrl: target,
     };
 
-    await _cacheManager.saveRelayDeliveryTargets(
-      relayUrlList.map((relayUrl) {
-        final existingTarget = existingByRelay[relayUrl];
-        return existingTarget ??
-            RelayDeliveryTarget(
-              eventId: event.id,
-              relayUrl: relayUrl,
-              reason: RelayDeliveryReason.explicit,
-            );
-      }).toList(),
-    );
+    final targets = relayUrlList.map((relayUrl) {
+      final existingTarget = existingByRelay[relayUrl];
+      if (existingTarget != null) {
+        // only the relays of this call are re-attributed; the same event may
+        // be on its way to another relay as somebody else
+        return auth == null
+            ? existingTarget
+            : existingTarget.copyWith(authCanonical: auth.canonical);
+      }
+      return RelayDeliveryTarget(
+        eventId: event.id,
+        relayUrl: relayUrl,
+        reason: RelayDeliveryReason.explicit,
+        authCanonical: auth?.canonical,
+      );
+    }).toList();
+
+    if (auth != null) {
+      // keyed off the targets themselves, so the live policy can only ever be
+      // found under the key the persisted target is read back with
+      for (final target in targets) {
+        _authPolicies[target.key] = auth;
+      }
+    }
+
+    await _cacheManager.saveRelayDeliveryTargets(targets);
   }
 
   Future<void> persistSpecificRelayBroadcastResult(
@@ -301,7 +313,7 @@ class PendingBroadcastDelivery {
       final isAcked = response.okReceived && response.broadcastSuccessful;
       final nextState = policy.resolveNextState(
         response,
-        auth: _authForDelivery(existing).policy,
+        auth: _authForTarget(current).policy,
       );
       final nextRetryAt = policy.shouldRetryState(nextState)
           ? attemptTimestamp +
@@ -370,7 +382,7 @@ class PendingBroadcastDelivery {
         completedAt: completionTimestamp,
       ),
     );
-    _dropAuthPolicyIfSettled(event.id, allTargets);
+    _dropSettledAuthPolicies(allTargets);
     await _purgeEphemeralIfResolved(
       event.id,
       deliveryStatus,
@@ -488,7 +500,7 @@ class PendingBroadcastDelivery {
           continue;
         }
 
-        final auth = _authForDelivery(deliveryRecord);
+        final auth = _authForTarget(target);
         if (!auth.available) {
           await _parkUnattributableDelivery(target, deliveryRecord);
           continue;
@@ -507,7 +519,7 @@ class PendingBroadcastDelivery {
     }
   }
 
-  /// The auth policy a retry must go out under.
+  /// The auth policy a retry to this relay must go out under.
   ///
   /// The live policy wins: it holds the [Account] itself, so an identity the
   /// caller handed over without registering it still works. After a restart
@@ -515,13 +527,13 @@ class PendingBroadcastDelivery {
   /// looked up in [Accounts], the way [_resolveSignerForEvent] looks up a
   /// signer. An identity nobody can sign for resolves to nothing rather than
   /// falling back to the logged account, which is what the policy ruled out.
-  _AuthResolution _authForDelivery(EventDeliveryRecord record) {
-    final live = _authPolicies[record.eventId];
+  _AuthResolution _authForTarget(RelayDeliveryTarget target) {
+    final live = _authPolicies[target.key];
     if (live != null) {
       return _AuthResolution(live);
     }
 
-    final canonical = record.authCanonical;
+    final canonical = target.authCanonical;
     if (canonical == null) {
       return const _AuthResolution(null);
     }
@@ -556,14 +568,14 @@ class PendingBroadcastDelivery {
     EventDeliveryRecord record,
   ) async {
     Logger.log.w(
-      () => 'delivery ${record.eventId} to ${target.relayUrl} needs '
-          '${record.authCanonical}, which no account can sign for',
+      () => 'delivery ${target.eventId} to ${target.relayUrl} needs '
+          '${target.authCanonical}, which no account can sign for',
     );
     await _cacheManager.saveRelayDeliveryTargets([
       target.copyWith(
         state: RelayDeliveryState.authRequired,
         nextRetryAt: null,
-        lastError: 'No available account for ${record.authCanonical}',
+        lastError: 'No available account for ${target.authCanonical}',
       ),
     ]);
     await _saveSigningOutcome(record);
@@ -611,30 +623,22 @@ class PendingBroadcastDelivery {
     return visibleEvents.single.id != event.id;
   }
 
-  /// The live policy is only needed while something may still be sent.
-  /// Dropping it once every target settled keeps the map from growing for the
-  /// life of the process. A delivery that is revived supplies it again through
+  /// A live policy is only needed while something may still be sent to that
+  /// relay. Dropping the settled ones keeps the map from growing for the life
+  /// of the process. A delivery that is revived supplies it again through
   /// [enqueueSpecificRelayBroadcast].
-  void _dropAuthPolicyIfSettled(
-    String eventId,
-    List<RelayDeliveryTarget> targets,
-  ) {
-    // no targets yet means enrollment is still in flight, not that it is over
-    if (targets.isEmpty) {
-      return;
-    }
-    final settled = targets.every(
-      (target) =>
-          target.state == RelayDeliveryState.acked ||
-          target.state == RelayDeliveryState.permanentFailure,
-    );
-    if (settled) {
-      _authPolicies.remove(eventId);
+  void _dropSettledAuthPolicies(List<RelayDeliveryTarget> targets) {
+    for (final target in targets) {
+      if (target.state == RelayDeliveryState.acked ||
+          target.state == RelayDeliveryState.permanentFailure) {
+        _authPolicies.remove(target.key);
+      }
     }
   }
 
   Future<void> _discardEventDelivery(String eventId) async {
-    _authPolicies.remove(eventId);
+    final prefix = RelayDeliveryTarget.keyPrefixFor(eventId);
+    _authPolicies.removeWhere((key, _) => key.startsWith(prefix));
     await _cacheManager.removeRelayDeliveryTargets(eventId);
     await _cacheManager.removeEventDeliveryRecord(eventId);
   }
@@ -1069,7 +1073,7 @@ class PendingBroadcastDelivery {
             : null,
       ),
     );
-    _dropAuthPolicyIfSettled(record.eventId, targets);
+    _dropSettledAuthPolicies(targets);
     await _purgeEphemeralIfResolved(
       record.eventId,
       resolvedStatus,

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
@@ -92,6 +92,7 @@ class PendingBroadcastDelivery {
     _stopped = true;
     _retryTimer?.cancel();
     _retryTimer = null;
+    _authPolicies.clear();
     final operations = _inFlightOperations.toList(growable: false);
     if (operations.isNotEmpty) {
       await Future.wait(operations);
@@ -369,6 +370,7 @@ class PendingBroadcastDelivery {
         completedAt: completionTimestamp,
       ),
     );
+    _dropAuthPolicyIfSettled(event.id, allTargets);
     await _purgeEphemeralIfResolved(
       event.id,
       deliveryStatus,
@@ -609,7 +611,30 @@ class PendingBroadcastDelivery {
     return visibleEvents.single.id != event.id;
   }
 
+  /// The live policy is only needed while something may still be sent.
+  /// Dropping it once every target settled keeps the map from growing for the
+  /// life of the process. A delivery that is revived supplies it again through
+  /// [enqueueSpecificRelayBroadcast].
+  void _dropAuthPolicyIfSettled(
+    String eventId,
+    List<RelayDeliveryTarget> targets,
+  ) {
+    // no targets yet means enrollment is still in flight, not that it is over
+    if (targets.isEmpty) {
+      return;
+    }
+    final settled = targets.every(
+      (target) =>
+          target.state == RelayDeliveryState.acked ||
+          target.state == RelayDeliveryState.permanentFailure,
+    );
+    if (settled) {
+      _authPolicies.remove(eventId);
+    }
+  }
+
   Future<void> _discardEventDelivery(String eventId) async {
+    _authPolicies.remove(eventId);
     await _cacheManager.removeRelayDeliveryTargets(eventId);
     await _cacheManager.removeEventDeliveryRecord(eventId);
   }
@@ -1044,6 +1069,7 @@ class PendingBroadcastDelivery {
             : null,
       ),
     );
+    _dropAuthPolicyIfSettled(record.eventId, targets);
     await _purgeEphemeralIfResolved(
       record.eventId,
       resolvedStatus,

--- a/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
+++ b/packages/ndk/lib/domain_layer/usecases/broadcast/pending_broadcast_delivery.dart
@@ -6,6 +6,7 @@ import '../../entities/broadcast_state.dart';
 import '../../entities/event_cache_records.dart';
 import '../../entities/nip_01_event.dart';
 import '../../entities/pending_signer_request.dart';
+import '../../entities/relay_auth.dart';
 import '../../entities/signer_request_cancelled_exception.dart';
 import '../../entities/signer_request_rejected_exception.dart';
 import '../../repositories/cache_manager.dart';
@@ -37,6 +38,12 @@ class PendingBroadcastDelivery {
   final Set<String> _flushInProgress = {};
   final Map<String, int> _activeSignAttemptIds = {};
   final Map<String, int> _latestSignAttemptIds = {};
+
+  /// auth policy per event id, for as long as this process lives. A signer
+  /// cannot be persisted, so an account the caller handed over without ever
+  /// registering it only survives here. What outlives a restart is the
+  /// canonical form on the delivery record, see [_authForDelivery].
+  final Map<String, RelayAuth> _authPolicies = {};
   Iterable<String> Function()? _connectedRelayUrlsProvider;
   Timer? _retryTimer;
   bool _stopped = false;
@@ -195,9 +202,13 @@ class PendingBroadcastDelivery {
     required Nip01Event event,
     required Iterable<String> relayUrls,
     required bool requiresInteractiveSigning,
+    RelayAuth? auth,
   }) async {
     if (_stopped) {
       return;
+    }
+    if (auth != null) {
+      _authPolicies[event.id] = auth;
     }
     // One durable aggregate record plus one durable target per relay gives NDK
     // enough state to recover delivery after restart without mutating a shared
@@ -226,6 +237,7 @@ class PendingBroadcastDelivery {
         lastSignAttemptAt: existing?.lastSignAttemptAt,
         nextSignRetryAt: existing?.nextSignRetryAt,
         lastSignError: existing?.lastSignError,
+        authCanonical: auth?.canonical ?? existing?.authCanonical,
       ),
     );
 
@@ -286,7 +298,10 @@ class PendingBroadcastDelivery {
       }
 
       final isAcked = response.okReceived && response.broadcastSuccessful;
-      final nextState = policy.resolveNextState(response);
+      final nextState = policy.resolveNextState(
+        response,
+        auth: _authForDelivery(existing).policy,
+      );
       final nextRetryAt = policy.shouldRetryState(nextState)
           ? attemptTimestamp +
               policy
@@ -471,12 +486,85 @@ class PendingBroadcastDelivery {
           continue;
         }
 
-        await _sender.broadcast(
-            nostrEvent: event, specificRelays: [relayUrl]).broadcastDoneFuture;
+        final auth = _authForDelivery(deliveryRecord);
+        if (!auth.available) {
+          await _parkUnattributableDelivery(target, deliveryRecord);
+          continue;
+        }
+
+        await _sender
+            .broadcast(
+              nostrEvent: event,
+              specificRelays: [relayUrl],
+              auth: auth.policy,
+            )
+            .broadcastDoneFuture;
       }
     } finally {
       _flushInProgress.remove(relayUrl);
     }
+  }
+
+  /// The auth policy a retry must go out under.
+  ///
+  /// The live policy wins: it holds the [Account] itself, so an identity the
+  /// caller handed over without registering it still works. After a restart
+  /// only the canonical form is left, and the account behind its pubkey is
+  /// looked up in [Accounts], the way [_resolveSignerForEvent] looks up a
+  /// signer. An identity nobody can sign for resolves to nothing rather than
+  /// falling back to the logged account, which is what the policy ruled out.
+  _AuthResolution _authForDelivery(EventDeliveryRecord record) {
+    final live = _authPolicies[record.eventId];
+    if (live != null) {
+      return _AuthResolution(live);
+    }
+
+    final canonical = record.authCanonical;
+    if (canonical == null) {
+      return const _AuthResolution(null);
+    }
+    if (canonical == 'never') {
+      return const _AuthResolution(RelayAuth.never());
+    }
+
+    final separator = canonical.indexOf(':');
+    if (separator < 0) {
+      Logger.log.w(() => 'Unknown auth policy "$canonical", ignoring it');
+      return const _AuthResolution(null);
+    }
+    final kind = canonical.substring(0, separator);
+    final pubkey = canonical.substring(separator + 1);
+    final account = _accounts.accounts[pubkey];
+    if (account == null || !account.signer.canSign()) {
+      return _AuthResolution.unavailable;
+    }
+
+    return switch (kind) {
+      'allow' => _AuthResolution(RelayAuth.allow(account)),
+      'require' => _AuthResolution(RelayAuth.require(account)),
+      _ => const _AuthResolution(null),
+    };
+  }
+
+  /// Holds a delivery whose identity is gone until the app supplies it again,
+  /// rather than sending it as somebody else. Re-broadcasting the same event
+  /// with [RelayAuth] in hand rewrites the record and resumes it.
+  Future<void> _parkUnattributableDelivery(
+    RelayDeliveryTarget target,
+    EventDeliveryRecord record,
+  ) async {
+    Logger.log.w(
+      () => 'delivery ${record.eventId} to ${target.relayUrl} needs '
+          '${record.authCanonical}, which no account can sign for',
+    );
+    await _cacheManager.saveRelayDeliveryTargets([
+      target.copyWith(
+        state: RelayDeliveryState.authRequired,
+        nextRetryAt: null,
+        lastError: 'No available account for ${record.authCanonical}',
+      ),
+    ]);
+    await _saveSigningOutcome(record);
   }
 
   /// A NIP-40 expired event has no delivery value: relays reject it and it will
@@ -1104,4 +1192,26 @@ class PendingBroadcastDelivery {
 
     return EventDeliveryStatus.inProgress;
   }
+}
+
+/// Outcome of rebuilding a persisted auth policy.
+///
+/// A null [policy] is the historical default, "authenticate as whoever the
+/// relay manager picks". [unavailable] is different: the caller named an
+/// identity and nobody here can sign for it, so nothing may be sent.
+class _AuthResolution {
+  final RelayAuth? policy;
+
+  /// false only for [unavailable]; a const `never` policy would otherwise be
+  /// canonically identical to it
+  final bool available;
+
+  const _AuthResolution(this.policy) : available = true;
+
+  const _AuthResolution._unavailable()
+      : policy = null,
+        available = false;
+
+  /// the named identity is gone, so this delivery has to wait for it
+  static const _AuthResolution unavailable = _AuthResolution._unavailable();
 }

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/jit_engine.dart
@@ -181,9 +181,7 @@ class JitEngine with Logger implements NetworkEngine {
           relayManager: relayManagerLight,
           cacheManager: cache,
           eventToPublish: workingNostrEvent,
-          connectedRelays: relayManagerLight.connectedAnonymousRelays
-              .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
-              .toList(),
+          auth: broadcastState.auth,
         );
         broadcastState.closeIfNoRelays();
         return;
@@ -192,12 +190,10 @@ class JitEngine with Logger implements NetworkEngine {
       // default publish to own outbox
       await RelayJitBroadcastOutboxStrategy.broadcast(
         eventToPublish: workingNostrEvent,
-        connectedRelays: relayManagerLight.connectedAnonymousRelays
-            .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
-            .toList(),
         cacheManager: cache,
         relayManager: relayManagerLight,
         bootstrapRelays: bootstrapRelays,
+        auth: broadcastState.auth,
       );
 
       // check if we need to publish to others inboxes
@@ -205,12 +201,10 @@ class JitEngine with Logger implements NetworkEngine {
           workingNostrEvent.kind != ContactList.kKind) {
         await RelayJitBroadcastOtherReadStrategy.broadcast(
           eventToPublish: workingNostrEvent,
-          connectedRelays: relayManagerLight.connectedAnonymousRelays
-              .whereType<RelayConnectivity<JitEngineRelayConnectivityData>>()
-              .toList(),
           cacheManager: cache,
           relayManager: relayManagerLight,
           pubkeysOfInbox: workingNostrEvent.pTags,
+          auth: broadcastState.auth,
         );
       }
       broadcastState.closeIfNoRelays();

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_other_read.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_other_read.dart
@@ -68,21 +68,6 @@ class RelayJitBroadcastOtherReadStrategy {
       );
 
       try {
-        if (!relayManager.isRelayConnected(relayUrl)) {
-          final success = await relayManager.connectRelay(
-            dirtyUrl: relayUrl,
-            connectionSource: ConnectionSource.broadcastOther,
-          );
-          if (!success.first) {
-            relayManager.failBroadcast(
-              eventToPublish.id,
-              relayUrl,
-              "connection failed",
-            );
-            return;
-          }
-        }
-
         final relay = await relayManager.connectionForBroadcast(
           relayUrl,
           auth,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_other_read.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_other_read.dart
@@ -3,8 +3,8 @@ import 'dart:math';
 import '../../../../config/broadcast_defaults.dart';
 import '../../../../shared/nips/nip01/client_msg.dart';
 import '../../../entities/connection_source.dart';
-import '../../../entities/jit_engine_relay_connectivity_data.dart';
 import '../../../entities/nip_01_event.dart';
+import '../../../entities/relay_auth.dart';
 import '../../../entities/relay_connectivity.dart';
 import '../../../repositories/cache_manager.dart';
 import '../../relay_manager.dart';
@@ -17,11 +17,10 @@ class RelayJitBroadcastOtherReadStrategy {
   /// [onMessage] callback for new connected relays
   static Future broadcast({
     required Nip01Event eventToPublish,
-    required List<RelayConnectivity<JitEngineRelayConnectivityData>>
-        connectedRelays,
     required CacheManager cacheManager,
     required RelayManager relayManager,
     required List<String> pubkeysOfInbox,
+    RelayAuth? auth,
   }) async {
     final nip65Data = await UserRelayLists.getUserRelayListCacheLatest(
       pubkeys: pubkeysOfInbox,
@@ -69,48 +68,35 @@ class RelayJitBroadcastOtherReadStrategy {
       );
 
       try {
-        final isConnected = relayManager.isRelayConnected(relayUrl);
-        if (isConnected) {
-          try {
-            final relay = connectedRelays.firstWhere(
-              (element) => element.url == relayUrl,
-            );
-            sendToRelay(relay: relay);
-          } catch (e) {
+        if (!relayManager.isRelayConnected(relayUrl)) {
+          final success = await relayManager.connectRelay(
+            dirtyUrl: relayUrl,
+            connectionSource: ConnectionSource.broadcastOther,
+          );
+          if (!success.first) {
             relayManager.failBroadcast(
               eventToPublish.id,
               relayUrl,
-              "relay not found in connected list",
+              "connection failed",
             );
+            return;
           }
-          return;
         }
 
-        final success = await relayManager.connectRelay(
-          dirtyUrl: relayUrl,
+        final relay = await relayManager.connectionForBroadcast(
+          relayUrl,
+          auth,
           connectionSource: ConnectionSource.broadcastOther,
         );
-        if (!success.first) {
+        if (relay == null) {
           relayManager.failBroadcast(
             eventToPublish.id,
             relayUrl,
-            "connection failed",
+            "no connection could carry this broadcast",
           );
           return;
         }
-
-        try {
-          final relay = relayManager.connectedAnonymousRelays.firstWhere(
-            (element) => element.url == relayUrl,
-          );
-          sendToRelay(relay: relay);
-        } catch (e) {
-          relayManager.failBroadcast(
-            eventToPublish.id,
-            relayUrl,
-            "relay not found after connection",
-          );
-        }
+        sendToRelay(relay: relay);
       } catch (e) {
         relayManager.failBroadcast(
           eventToPublish.id,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_own.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_own.dart
@@ -1,8 +1,8 @@
 import '../../../../shared/logger/logger.dart';
 import '../../../../shared/nips/nip01/client_msg.dart';
 import '../../../entities/connection_source.dart';
-import '../../../entities/jit_engine_relay_connectivity_data.dart';
 import '../../../entities/nip_01_event.dart';
+import '../../../entities/relay_auth.dart';
 import '../../../entities/relay_connectivity.dart';
 import '../../../repositories/cache_manager.dart';
 import '../../relay_manager.dart';
@@ -13,11 +13,10 @@ class RelayJitBroadcastOutboxStrategy {
   /// publish event to nip65 outbox relays
   static Future broadcast({
     required Nip01Event eventToPublish,
-    required List<RelayConnectivity<JitEngineRelayConnectivityData>>
-        connectedRelays,
     required CacheManager cacheManager,
     required RelayManager relayManager,
     required List<String> bootstrapRelays,
+    RelayAuth? auth,
   }) async {
     final nip65Data = await UserRelayLists.getUserRelayListCacheLatestSingle(
       pubkey: eventToPublish.pubKey,
@@ -63,48 +62,35 @@ class RelayJitBroadcastOutboxStrategy {
       );
 
       try {
-        final isConnected = relayManager.isRelayConnected(relayUrl);
-        if (isConnected) {
-          try {
-            final relay = connectedRelays.firstWhere(
-              (element) => element.url == relayUrl,
-            );
-            sendToRelay(relay: relay);
-          } catch (e) {
+        if (!relayManager.isRelayConnected(relayUrl)) {
+          final success = await relayManager.connectRelay(
+            dirtyUrl: relayUrl,
+            connectionSource: ConnectionSource.broadcastOwn,
+          );
+          if (!success.first) {
             relayManager.failBroadcast(
               eventToPublish.id,
               relayUrl,
-              "relay not found in connected list",
+              "connection failed",
             );
+            return;
           }
-          return;
         }
 
-        final success = await relayManager.connectRelay(
-          dirtyUrl: relayUrl,
+        final relay = await relayManager.connectionForBroadcast(
+          relayUrl,
+          auth,
           connectionSource: ConnectionSource.broadcastOwn,
         );
-        if (!success.first) {
+        if (relay == null) {
           relayManager.failBroadcast(
             eventToPublish.id,
             relayUrl,
-            "connection failed",
+            "no connection could carry this broadcast",
           );
           return;
         }
-
-        try {
-          final relay = relayManager.connectedAnonymousRelays.firstWhere(
-            (element) => element.url == relayUrl,
-          );
-          sendToRelay(relay: relay);
-        } catch (e) {
-          relayManager.failBroadcast(
-            eventToPublish.id,
-            relayUrl,
-            "relay not found after connection",
-          );
-        }
+        sendToRelay(relay: relay);
       } catch (e) {
         relayManager.failBroadcast(
           eventToPublish.id,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_own.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_own.dart
@@ -62,21 +62,6 @@ class RelayJitBroadcastOutboxStrategy {
       );
 
       try {
-        if (!relayManager.isRelayConnected(relayUrl)) {
-          final success = await relayManager.connectRelay(
-            dirtyUrl: relayUrl,
-            connectionSource: ConnectionSource.broadcastOwn,
-          );
-          if (!success.first) {
-            relayManager.failBroadcast(
-              eventToPublish.id,
-              relayUrl,
-              "connection failed",
-            );
-            return;
-          }
-        }
-
         final relay = await relayManager.connectionForBroadcast(
           relayUrl,
           auth,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_specific.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_specific.dart
@@ -2,8 +2,8 @@ import '../../../../shared/nips/nip01/client_msg.dart';
 import '../../../../shared/nips/nip01/event_kind_classification.dart';
 import '../../../repositories/cache_manager.dart';
 import '../../../entities/connection_source.dart';
-import '../../../entities/jit_engine_relay_connectivity_data.dart';
 import '../../../entities/nip_01_event.dart';
+import '../../../entities/relay_auth.dart';
 import '../../../entities/relay_connectivity.dart';
 import '../../relay_manager.dart';
 
@@ -13,10 +13,9 @@ class RelayJitBroadcastSpecificRelaysStrategy {
   static Future broadcast({
     required Nip01Event eventToPublish,
     required CacheManager cacheManager,
-    required List<RelayConnectivity<JitEngineRelayConnectivityData>>
-        connectedRelays,
     required RelayManager relayManager,
     required List<String> specificRelays,
+    RelayAuth? auth,
   }) async {
     // Deduplicate relay URLs
     final uniqueRelayUrls = specificRelays.toSet().toList();
@@ -39,48 +38,23 @@ class RelayJitBroadcastSpecificRelaysStrategy {
       );
 
       try {
-        final isConnected = relayManager.isRelayConnected(relayUrl);
-        if (isConnected) {
-          if (await _shouldSkipObsoleteReplaceableBroadcast(
-            cacheManager: cacheManager,
-            event: eventToPublish,
-          )) {
+        if (!relayManager.isRelayConnected(relayUrl)) {
+          final success = (await relayManager.connectRelay(
+            dirtyUrl: relayUrl,
+            connectionSource: ConnectionSource.broadcastSpecific,
+            connectTimeout: 1,
+          ))
+              .first;
+          if (!success) {
             relayManager.failBroadcast(
               eventToPublish.id,
               relayUrl,
-              "obsolete replaceable event skipped",
+              "connection failed",
             );
             return;
           }
-          try {
-            final relay = connectedRelays.firstWhere(
-              (element) => element.url == relayUrl,
-            );
-            sendToRelay(relay: relay);
-          } catch (e) {
-            relayManager.failBroadcast(
-              eventToPublish.id,
-              relayUrl,
-              "relay not found in connected list",
-            );
-          }
-          return;
         }
 
-        final success = (await relayManager.connectRelay(
-          dirtyUrl: relayUrl,
-          connectionSource: ConnectionSource.broadcastSpecific,
-          connectTimeout: 1,
-        ))
-            .first;
-        if (!success) {
-          relayManager.failBroadcast(
-            eventToPublish.id,
-            relayUrl,
-            "connection failed",
-          );
-          return;
-        }
         if (await _shouldSkipObsoleteReplaceableBroadcast(
           cacheManager: cacheManager,
           event: eventToPublish,
@@ -92,18 +66,20 @@ class RelayJitBroadcastSpecificRelaysStrategy {
           );
           return;
         }
-        try {
-          final relay = relayManager.connectedAnonymousRelays.firstWhere(
-            (element) => element.url == relayUrl,
-          );
-          sendToRelay(relay: relay);
-        } catch (e) {
+
+        final relay = await relayManager.connectionForBroadcast(
+          relayUrl,
+          auth,
+        );
+        if (relay == null) {
           relayManager.failBroadcast(
             eventToPublish.id,
             relayUrl,
-            "relay not found after connection",
+            "no connection could carry this broadcast",
           );
+          return;
         }
+        sendToRelay(relay: relay);
       } catch (e) {
         relayManager.failBroadcast(
           eventToPublish.id,

--- a/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_specific.dart
+++ b/packages/ndk/lib/domain_layer/usecases/jit_engine/relay_jit_broadcast_strategies/relay_jit_broadcast_specific.dart
@@ -1,7 +1,6 @@
 import '../../../../shared/nips/nip01/client_msg.dart';
 import '../../../../shared/nips/nip01/event_kind_classification.dart';
 import '../../../repositories/cache_manager.dart';
-import '../../../entities/connection_source.dart';
 import '../../../entities/nip_01_event.dart';
 import '../../../entities/relay_auth.dart';
 import '../../../entities/relay_connectivity.dart';
@@ -38,23 +37,22 @@ class RelayJitBroadcastSpecificRelaysStrategy {
       );
 
       try {
-        if (!relayManager.isRelayConnected(relayUrl)) {
-          final success = (await relayManager.connectRelay(
-            dirtyUrl: relayUrl,
-            connectionSource: ConnectionSource.broadcastSpecific,
-            connectTimeout: 1,
-          ))
-              .first;
-          if (!success) {
-            relayManager.failBroadcast(
-              eventToPublish.id,
-              relayUrl,
-              "connection failed",
-            );
-            return;
-          }
+        final relay = await relayManager.connectionForBroadcast(
+          relayUrl,
+          auth,
+          connectTimeout: 1,
+        );
+        if (relay == null) {
+          relayManager.failBroadcast(
+            eventToPublish.id,
+            relayUrl,
+            "no connection could carry this broadcast",
+          );
+          return;
         }
 
+        // checked once the connection is there: a newer version may have been
+        // persisted while it was opening, and that one supersedes this send
         if (await _shouldSkipObsoleteReplaceableBroadcast(
           cacheManager: cacheManager,
           event: eventToPublish,
@@ -67,18 +65,6 @@ class RelayJitBroadcastSpecificRelaysStrategy {
           return;
         }
 
-        final relay = await relayManager.connectionForBroadcast(
-          relayUrl,
-          auth,
-        );
-        if (relay == null) {
-          relayManager.failBroadcast(
-            eventToPublish.id,
-            relayUrl,
-            "no connection could carry this broadcast",
-          );
-          return;
-        }
         sendToRelay(relay: relay);
       } catch (e) {
         relayManager.failBroadcast(

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1008,6 +1008,7 @@ class RelayManager<T> {
     String url,
     Account account, {
     ConnectionSource connectionSource = ConnectionSource.explicit,
+    int connectTimeout = DEFAULT_WEB_SOCKET_CONNECT_TIMEOUT,
   }) async {
     if (!account.signer.canSign()) {
       Logger.log.w(() => "Cannot bind a connection to ${account.pubkey}");
@@ -1024,6 +1025,7 @@ class RelayManager<T> {
       dirtyUrl: url,
       connectionSource: connectionSource,
       authPubkey: account.pubkey,
+      connectTimeout: connectTimeout,
     );
     final connectivity = globalState.relays[key];
     if (!connected.first || connectivity == null) {
@@ -1086,6 +1088,7 @@ class RelayManager<T> {
         url,
         auth.account,
         connectionSource: connectionSource,
+        connectTimeout: connectTimeout,
       );
     }
 

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1062,6 +1062,33 @@ class RelayManager<T> {
     );
   }
 
+  /// The connection a broadcast under [auth] must go out on towards [url].
+  ///
+  /// Mirrors [connectionForRequest] for the write path: a broadcast that
+  /// requires an identity gets its own bound connection, opened if it is not
+  /// there yet, so the event never touches the anonymous socket. Null means
+  /// nothing may be sent to that relay.
+  Future<RelayConnectivity?> connectionForBroadcast(
+    String url,
+    RelayAuth? auth, {
+    ConnectionSource connectionSource = ConnectionSource.broadcastSpecific,
+  }) async {
+    if (auth is! RelayAuthRequire) {
+      return getRelayConnectivity(url);
+    }
+    if (!auth.account.signer.canSign()) {
+      Logger.log.w(
+        () => "Broadcast requires ${auth.account.pubkey}, which cannot sign",
+      );
+      return null;
+    }
+    return openConnectionAs(
+      url,
+      auth.account,
+      connectionSource: connectionSource,
+    );
+  }
+
   /// The account [key] authenticates as. A registered account wins, because
   /// [Accounts] owns its signer's lifetime; otherwise it is the one the caller
   /// handed to [RelayAuth], which never had to be registered. Both carry
@@ -1530,6 +1557,26 @@ class RelayManager<T> {
     }
   }
 
+  /// Account a broadcast authenticates as, null when it must stay
+  /// unattributable.
+  ///
+  /// A caller that named an identity gets that one, with no heuristic. Only a
+  /// broadcast that said nothing prefers the event author, because gift wraps
+  /// and other ephemeral-author events have no matching account and the logged
+  /// one is the historical fallback.
+  Account? _accountForBroadcast(BroadcastState state, Nip01Event event) {
+    if (state.auth != null) {
+      return accountForAuth(state.auth);
+    }
+
+    final author = _accounts?.accounts[event.pubKey];
+    if (author != null && author.signer.canSign()) {
+      return author;
+    }
+    final logged = _accounts?.getLoggedAccount();
+    return logged != null && logged.signer.canSign() ? logged : null;
+  }
+
   /// Handles OK auth-required for broadcasts by moving the retry onto an
   /// account-bound connection, authenticating it once, and re-sending EVENT.
   /// Concurrent broadcasts share [authenticateConnection], avoiding duplicate
@@ -1555,24 +1602,25 @@ class RelayManager<T> {
       return;
     }
 
-    // Prefer authenticating as the event author. Gift wraps and other
-    // ephemeral-author events may not have a matching account, so fall back to
-    // the currently logged-in account when needed.
-    Account? account = _accounts?.accounts[eventToResend.pubKey];
-    final loggedAccount = _accounts?.getLoggedAccount();
-    if ((account == null || !account.signer.canSign()) &&
-        loggedAccount != null &&
-        loggedAccount.pubkey != account?.pubkey) {
-      account = loggedAccount;
-    }
+    final resolved = _accountForBroadcast(broadcastState, eventToResend);
 
-    if (account == null || !account.signer.canSign()) {
+    if (resolved == null) {
       Logger.log.w(
         () =>
-            "Received OK auth-required but no account can sign for ${relayConnectivity.url}",
+            "Cannot satisfy auth-required for broadcast $eventId on ${relayConnectivity.url}",
       );
+      // a broadcast that named a policy gets an answer rather than a timeout;
+      // one that said nothing keeps waiting, as it always has
+      if (broadcastState.auth != null) {
+        failBroadcast(
+          eventId,
+          relayConnectivity.url,
+          'auth-required: this broadcast may not reveal an identity',
+        );
+      }
       return;
     }
+    final account = resolved;
 
     final boundKey = RelayConnectionKey.authenticated(
       relayConnectivity.url,
@@ -1583,7 +1631,7 @@ class RelayManager<T> {
       try {
         final bound = await openConnectionAs(
           relayConnectivity.url,
-          account!,
+          account,
           connectionSource: relayConnectivity.relay.connectionSource,
         );
         if (!identical(

--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -1062,31 +1062,45 @@ class RelayManager<T> {
     );
   }
 
-  /// The connection a broadcast under [auth] must go out on towards [url].
+  /// The connection a broadcast under [auth] must go out on towards [url],
+  /// opening it when it is not there yet. Null means nothing may be sent.
   ///
-  /// Mirrors [connectionForRequest] for the write path: a broadcast that
-  /// requires an identity gets its own bound connection, opened if it is not
-  /// there yet, so the event never touches the anonymous socket. Null means
-  /// nothing may be sent to that relay.
+  /// Mirrors [connectionForRequest] for the write path, and owns the connecting
+  /// too: a broadcast that requires an identity must not even open the
+  /// anonymous connection, because a socket we opened is one the relay saw,
+  /// whether or not anything was sent on it.
   Future<RelayConnectivity?> connectionForBroadcast(
     String url,
     RelayAuth? auth, {
     ConnectionSource connectionSource = ConnectionSource.broadcastSpecific,
+    int connectTimeout = DEFAULT_WEB_SOCKET_CONNECT_TIMEOUT,
   }) async {
-    if (auth is! RelayAuthRequire) {
-      return getRelayConnectivity(url);
-    }
-    if (!auth.account.signer.canSign()) {
-      Logger.log.w(
-        () => "Broadcast requires ${auth.account.pubkey}, which cannot sign",
+    if (auth is RelayAuthRequire) {
+      if (!auth.account.signer.canSign()) {
+        Logger.log.w(
+          () => "Broadcast requires ${auth.account.pubkey}, which cannot sign",
+        );
+        return null;
+      }
+      return openConnectionAs(
+        url,
+        auth.account,
+        connectionSource: connectionSource,
       );
-      return null;
     }
-    return openConnectionAs(
-      url,
-      auth.account,
-      connectionSource: connectionSource,
-    );
+
+    if (!isRelayConnected(url)) {
+      final connected = await connectRelay(
+        dirtyUrl: url,
+        connectionSource: connectionSource,
+        connectTimeout: connectTimeout,
+      );
+      if (!connected.first) {
+        Logger.log.w(() => "Could not connect to $url: ${connected.second}");
+        return null;
+      }
+    }
+    return getRelayConnectivity(url);
   }
 
   /// The account [key] authenticates as. A registered account wins, because

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -138,26 +138,25 @@ class RelaySetsEngine implements NetworkEngine {
       relayUrl: relayUrl,
     );
 
-    var connected = _relayManager.isRelayConnected(relayUrl);
+    RelayConnectivity? relayConnectivity;
     Object? error;
-    if (!connected) {
-      try {
-        final result = await _relayManager.connectRelay(
-          dirtyUrl: relayUrl,
-          connectionSource: ConnectionSource.broadcastSpecific,
-          connectTimeout: 1,
-        );
-        connected = result.first;
-      } catch (e) {
-        Logger.log.w(
-          () => "Error during quick connect for $relayUrl in doRelayBroadcast",
-          error: e,
-        );
-        error = e;
-      }
+    try {
+      relayConnectivity = await _relayManager.connectionForBroadcast(
+        relayUrl,
+        auth,
+        connectTimeout: 1,
+      );
+    } catch (e) {
+      Logger.log.w(
+        () => "Error during quick connect for $relayUrl in doRelayBroadcast",
+        error: e,
+      );
+      error = e;
     }
 
-    if (connected) {
+    if (relayConnectivity != null) {
+      // checked once the connection is there: a newer version may have been
+      // persisted while it was opening, and that one supersedes this send
       if (await _shouldSkipObsoleteReplaceableBroadcast(nostrEvent)) {
         Logger.log.d(
           () =>
@@ -171,25 +170,19 @@ class RelaySetsEngine implements NetworkEngine {
         return;
       }
 
-      final relayConnectivity = await _relayManager.connectionForBroadcast(
-        relayUrl,
-        auth,
+      await _relayManager.sendOrThrow(
+        relayConnectivity,
+        ClientMsg(ClientMsgType.kEvent, event: nostrEvent),
       );
-      if (relayConnectivity != null) {
-        await _relayManager.sendOrThrow(
-          relayConnectivity,
-          ClientMsg(ClientMsgType.kEvent, event: nostrEvent),
-        );
-        return;
-      }
-      if (auth is RelayAuthRequire) {
-        _relayManager.failBroadcast(
-          nostrEvent.id,
-          relayUrl,
-          "no connection bound to ${auth.account.pubkey} could be opened",
-        );
-        return;
-      }
+      return;
+    }
+    if (auth is RelayAuthRequire) {
+      _relayManager.failBroadcast(
+        nostrEvent.id,
+        relayUrl,
+        "no connection bound to ${auth.account.pubkey} could be opened",
+      );
+      return;
     }
     _relayManager.failBroadcast(
       nostrEvent.id,

--- a/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_sets_engine.dart
@@ -17,6 +17,7 @@ import '../entities/filter.dart';
 import '../entities/global_state.dart';
 import '../entities/ndk_request.dart';
 import '../entities/nip_01_event.dart';
+import '../entities/relay_auth.dart';
 import '../entities/relay_connection_key.dart';
 import '../entities/relay_connectivity.dart';
 import '../entities/relay_set.dart';
@@ -127,7 +128,11 @@ class RelaySetsEngine implements NetworkEngine {
   /// 3) if connected was successfull send the event
   /// 4) otherwise call failBroadcast in order to publish a RelayBroadcastResponse
   ///   for that specific relay with an error message
-  Future<void> doRelayBroadcast(String relayUrl, Nip01Event nostrEvent) async {
+  Future<void> doRelayBroadcast(
+    String relayUrl,
+    Nip01Event nostrEvent, {
+    RelayAuth? auth,
+  }) async {
     _relayManager.registerRelayBroadcast(
       eventToPublish: nostrEvent,
       relayUrl: relayUrl,
@@ -166,11 +171,22 @@ class RelaySetsEngine implements NetworkEngine {
         return;
       }
 
-      final relayConnectivity = _relayManager.getRelayConnectivity(relayUrl);
+      final relayConnectivity = await _relayManager.connectionForBroadcast(
+        relayUrl,
+        auth,
+      );
       if (relayConnectivity != null) {
         await _relayManager.sendOrThrow(
           relayConnectivity,
           ClientMsg(ClientMsgType.kEvent, event: nostrEvent),
+        );
+        return;
+      }
+      if (auth is RelayAuthRequire) {
+        _relayManager.failBroadcast(
+          nostrEvent.id,
+          relayUrl,
+          "no connection bound to ${auth.account.pubkey} could be opened",
         );
         return;
       }
@@ -378,7 +394,8 @@ class RelaySetsEngine implements NetworkEngine {
             specificRelays.map(
               (relayUrl) =>
                   // broadcast async
-                  doRelayBroadcast(relayUrl, workingEvent),
+                  doRelayBroadcast(relayUrl, workingEvent,
+                      auth: broadcastState.auth),
             ),
           );
         }
@@ -412,7 +429,8 @@ class RelaySetsEngine implements NetworkEngine {
 
         await Future.wait(
           writeRelaysUrls.map(
-            (relayUrl) => doRelayBroadcast(relayUrl, workingEvent),
+            (relayUrl) => doRelayBroadcast(relayUrl, workingEvent,
+                auth: broadcastState.auth),
           ),
         );
 
@@ -447,7 +465,8 @@ class RelaySetsEngine implements NetworkEngine {
 
           await Future.wait(
             myWriteRelayUrlsOthers.map(
-              (relayUrl) => doRelayBroadcast(relayUrl, workingEvent),
+              (relayUrl) => doRelayBroadcast(relayUrl, workingEvent,
+                  auth: broadcastState.auth),
             ),
           );
         }

--- a/packages/ndk/lib/ndk.dart
+++ b/packages/ndk/lib/ndk.dart
@@ -94,6 +94,7 @@ export 'domain_layer/usecases/user_relay_lists/user_relay_lists.dart';
 export 'domain_layer/usecases/lists/lists.dart';
 export 'domain_layer/usecases/relay_sets/relay_sets.dart';
 export 'domain_layer/usecases/broadcast/broadcast.dart';
+export 'domain_layer/usecases/broadcast/broadcast_exceptions.dart';
 export 'domain_layer/usecases/nwc/nwc.dart';
 export 'domain_layer/usecases/zaps/zaps.dart';
 export 'domain_layer/usecases/zaps/zap_request.dart';

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -65,6 +65,29 @@ class MockRelay {
             ...entry.value,
       };
 
+  /// every EVENT received, with the socket that carried it
+  final List<_ReceivedEvent> _receivedEventConnections = [];
+
+  /// Whether [socket] is authenticated as [pubkey] *now*, not when the event
+  /// arrived. A connection bound to an identity sends before the relay has
+  /// accepted its AUTH, so judging at arrival time would call a bound
+  /// connection anonymous.
+  bool _socketCarries(WebSocket socket, String pubkey) =>
+      _authenticatedPubkeys[socket]?.contains(pubkey) ?? false;
+
+  /// ids of EVENTs carried by connections authenticated as [pubkey]
+  Set<String> eventsAuthenticatedAs(String pubkey) => {
+        for (final received in _receivedEventConnections)
+          if (_socketCarries(received.socket, pubkey)) received.eventId,
+      };
+
+  /// ids of EVENTs carried by connections that were never authenticated as
+  /// [pubkey]
+  Set<String> eventsNotAuthenticatedAs(String pubkey) => {
+        for (final received in _receivedEventConnections)
+          if (!_socketCarries(received.socket, pubkey)) received.eventId,
+      };
+
   /// how many live connections are authenticated as [pubkey]
   int connectionsAuthenticatedAs(String pubkey) => _authenticatedPubkeys.values
       .where((pubkeys) => pubkeys.contains(pubkey))
@@ -381,6 +404,9 @@ class MockRelay {
               Nip01Event newEvent = Nip01EventModel.fromJson(eventJson[1]);
               if (verify(newEvent.pubKey, newEvent.id, newEvent.sig!)) {
                 _receivedEvents.add(newEvent);
+                _receivedEventConnections.add(
+                  _ReceivedEvent(eventId: newEvent.id, socket: webSocket),
+                );
                 if (rejectFirstEventPublishes > 0) {
                   rejectFirstEventPublishes--;
                   _send(
@@ -1283,4 +1309,11 @@ class _ReceivedNegOpen {
     required this.subscriptionId,
     required this.connectionPubkeys,
   });
+}
+
+class _ReceivedEvent {
+  final String eventId;
+  final WebSocket socket;
+
+  _ReceivedEvent({required this.eventId, required this.socket});
 }

--- a/packages/ndk/test/mocks/mock_relay.dart
+++ b/packages/ndk/test/mocks/mock_relay.dart
@@ -65,27 +65,25 @@ class MockRelay {
             ...entry.value,
       };
 
-  /// every EVENT received, with the socket that carried it
+  /// every EVENT received, holding its connection's own identity set rather
+  /// than a copy of it. A connection bound to an identity sends before the
+  /// relay accepted its AUTH, so a snapshot taken on arrival would call a bound
+  /// connection anonymous; the live set shows the AUTH that follows. Holding
+  /// the set rather than the socket also outlives the socket's cleanup, so a
+  /// test may assert after the connection closed.
   final List<_ReceivedEvent> _receivedEventConnections = [];
-
-  /// Whether [socket] is authenticated as [pubkey] *now*, not when the event
-  /// arrived. A connection bound to an identity sends before the relay has
-  /// accepted its AUTH, so judging at arrival time would call a bound
-  /// connection anonymous.
-  bool _socketCarries(WebSocket socket, String pubkey) =>
-      _authenticatedPubkeys[socket]?.contains(pubkey) ?? false;
 
   /// ids of EVENTs carried by connections authenticated as [pubkey]
   Set<String> eventsAuthenticatedAs(String pubkey) => {
         for (final received in _receivedEventConnections)
-          if (_socketCarries(received.socket, pubkey)) received.eventId,
+          if (received.connectionPubkeys.contains(pubkey)) received.eventId,
       };
 
   /// ids of EVENTs carried by connections that were never authenticated as
   /// [pubkey]
   Set<String> eventsNotAuthenticatedAs(String pubkey) => {
         for (final received in _receivedEventConnections)
-          if (!_socketCarries(received.socket, pubkey)) received.eventId,
+          if (!received.connectionPubkeys.contains(pubkey)) received.eventId,
       };
 
   /// how many live connections are authenticated as [pubkey]
@@ -405,7 +403,10 @@ class MockRelay {
               if (verify(newEvent.pubKey, newEvent.id, newEvent.sig!)) {
                 _receivedEvents.add(newEvent);
                 _receivedEventConnections.add(
-                  _ReceivedEvent(eventId: newEvent.id, socket: webSocket),
+                  _ReceivedEvent(
+                    eventId: newEvent.id,
+                    connectionPubkeys: authenticatedPubkeys,
+                  ),
                 );
                 if (rejectFirstEventPublishes > 0) {
                   rejectFirstEventPublishes--;
@@ -1313,7 +1314,9 @@ class _ReceivedNegOpen {
 
 class _ReceivedEvent {
   final String eventId;
-  final WebSocket socket;
 
-  _ReceivedEvent({required this.eventId, required this.socket});
+  /// the connection's own set, mutated in place when its AUTH is accepted
+  final Set<String> connectionPubkeys;
+
+  _ReceivedEvent({required this.eventId, required this.connectionPubkeys});
 }

--- a/packages/ndk/test/usecases/broadcast/broadcast_auth_test.dart
+++ b/packages/ndk/test/usecases/broadcast/broadcast_auth_test.dart
@@ -1,0 +1,283 @@
+import 'package:ndk/ndk.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:ndk/shared/nips/nip01/key_pair.dart';
+import 'package:test/test.dart';
+
+import '../../mocks/mock_event_verifier.dart';
+import '../../mocks/mock_relay.dart';
+
+void main() {
+  for (final engine in NdkEngine.values) {
+    broadcastAuthTests(engine);
+  }
+}
+
+/// The identity a broadcast may be attributed to is decided above the engines,
+/// so both must reach the same connection.
+void broadcastAuthTests(NdkEngine engine) {
+  group('broadcast relay authentication [${engine.name}]', () {
+    final key = Bip340.generatePrivateKey();
+    final other = Bip340.generatePrivateKey();
+
+    Account signableAccount(KeyPair k) => Account(
+          pubkey: k.publicKey,
+          type: AccountType.privateKey,
+          signer: Bip340EventSigner(
+            privateKey: k.privateKey!,
+            publicKey: k.publicKey,
+          ),
+        );
+
+    Ndk ndkFor(MockRelay relay) => Ndk(
+          NdkConfig(
+            eventVerifier: MockEventVerifier(),
+            cache: MemCacheManager(),
+            bootstrapRelays: [relay.url],
+            defaultBroadcastTimeout: const Duration(seconds: 2),
+            engine: engine,
+          ),
+        );
+
+    Future<MockRelay> authRelay({bool requireAuth = true}) async {
+      final relay = MockRelay(
+        name: "broadcast auth relay",
+        requireAuthForEvents: requireAuth,
+      );
+      // the relay only challenges once it refuses an event, which is what
+      // `allow` waits for, so every connection has to be offered a challenge
+      relay.sendAuthChallenge = true;
+      await relay.startServer();
+      return relay;
+    }
+
+    Nip01Event noteFrom(KeyPair k, String content) => Nip01Event(
+          pubKey: k.publicKey,
+          kind: Nip01Event.kTextNodeKind,
+          tags: [],
+          content: content,
+        );
+
+    test('never stays unattributable and does not deliver', () async {
+      final relay = await authRelay();
+      final ndk = ndkFor(relay);
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final result = await ndk.broadcast
+          .broadcast(
+            nostrEvent: noteFrom(key, "never"),
+            specificRelays: [relay.url],
+            auth: const RelayAuth.never(),
+          )
+          .broadcastDoneFuture;
+
+      expect(result.any((r) => r.broadcastSuccessful), isFalse);
+      expect(
+        relay.acceptedAuths,
+        0,
+        reason: 'a broadcast that may reveal nobody never answers a challenge',
+      );
+      expect(relay.connectionsAuthenticatedAs(key.publicKey), 0);
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('allow authenticates only once the relay refuses', () async {
+      final relay = await authRelay();
+      final ndk = ndkFor(relay);
+      final account = signableAccount(key);
+      final event = noteFrom(key, "allow");
+
+      final result = await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            customSigner: account.signer,
+            auth: RelayAuth.allow(account),
+          )
+          .broadcastDoneFuture;
+
+      expect(result.any((r) => r.broadcastSuccessful), isTrue);
+      expect(
+        relay.eventsNotAuthenticatedAs(key.publicKey),
+        contains(event.id),
+        reason: 'allow starts on the anonymous connection',
+      );
+      expect(
+        relay.eventsAuthenticatedAs(key.publicKey),
+        contains(event.id),
+        reason: 'and moves to a bound one once refused',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('allow does not authenticate to a relay that never refuses', () async {
+      final relay = await authRelay(requireAuth: false);
+      final ndk = ndkFor(relay);
+      final account = signableAccount(key);
+      final event = noteFrom(key, "allow unrefused");
+
+      final result = await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            customSigner: account.signer,
+            auth: RelayAuth.allow(account),
+          )
+          .broadcastDoneFuture;
+
+      expect(result.any((r) => r.broadcastSuccessful), isTrue);
+      expect(
+        relay.connectionsAuthenticatedAs(key.publicKey),
+        0,
+        reason: 'nothing asked for an identity, so none was revealed',
+      );
+      expect(relay.eventsAuthenticatedAs(key.publicKey), isEmpty);
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('require sends the event only on the bound connection', () async {
+      final relay = await authRelay();
+      final ndk = ndkFor(relay);
+      final account = signableAccount(key);
+      final event = noteFrom(key, "require");
+
+      final result = await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            customSigner: account.signer,
+            auth: RelayAuth.require(account),
+          )
+          .broadcastDoneFuture;
+
+      expect(result.any((r) => r.broadcastSuccessful), isTrue);
+      expect(
+        relay.eventsNotAuthenticatedAs(key.publicKey),
+        isEmpty,
+        reason: 'the event never touches the anonymous connection',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('require binds even when the relay never refuses', () async {
+      final relay = await authRelay(requireAuth: false);
+      final ndk = ndkFor(relay);
+      final account = signableAccount(key);
+      final event = noteFrom(key, "require unrefused");
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            customSigner: account.signer,
+            auth: RelayAuth.require(account),
+          )
+          .broadcastDoneFuture;
+
+      expect(
+        ndk.relays.globalState.relays.keys.where(
+          (connectionKey) => connectionKey.pubkey == key.publicKey,
+        ),
+        isNotEmpty,
+        reason: 'require opens its bound connection whether or not it is asked',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('authenticates as an account NDK never registered', () async {
+      final relay = await authRelay();
+      final ndk = ndkFor(relay);
+      // logged in as one identity, broadcasting as another that was handed
+      // over rather than registered
+      ndk.accounts.loginPrivateKey(
+        pubkey: other.publicKey,
+        privkey: other.privateKey!,
+      );
+      final handedOver = signableAccount(key);
+      final event = noteFrom(key, "unregistered");
+
+      final result = await ndk.broadcast
+          .broadcast(
+            nostrEvent: event,
+            specificRelays: [relay.url],
+            customSigner: handedOver.signer,
+            auth: RelayAuth.require(handedOver),
+          )
+          .broadcastDoneFuture;
+
+      expect(result.any((r) => r.broadcastSuccessful), isTrue);
+      expect(relay.connectionsAuthenticatedAs(key.publicKey), greaterThan(0));
+      expect(
+        relay.connectionsAuthenticatedAs(other.publicKey),
+        0,
+        reason: 'the logged account is not the one that was named',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('require with an account that cannot sign reaches no relay', () async {
+      final relay = await authRelay();
+      final ndk = ndkFor(relay);
+
+      final watchOnly = Account(
+        pubkey: key.publicKey,
+        type: AccountType.publicKey,
+        signer: Bip340EventSigner(privateKey: null, publicKey: key.publicKey),
+      );
+
+      // the call itself throws, so a caller that only reads the future later
+      // never faces an error nobody was listening to
+      expect(
+        () => ndk.broadcast.broadcast(
+          nostrEvent: noteFrom(key, "impossible"),
+          specificRelays: [relay.url],
+          customSigner: signableAccount(key).signer,
+          auth: RelayAuth.require(watchOnly),
+        ),
+        throwsA(isA<BroadcastAuthUnavailableException>()),
+      );
+      expect(
+        relay.receivedEvents,
+        isEmpty,
+        reason: 'an impossible broadcast is sent to no relay at all',
+      );
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+
+    test('without auth a refusal still authenticates as the author', () async {
+      final relay = await authRelay();
+      final ndk = ndkFor(relay);
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+
+      final result = await ndk.broadcast.broadcast(
+        nostrEvent: noteFrom(key, "default"),
+        specificRelays: [relay.url],
+      ).broadcastDoneFuture;
+
+      expect(result.any((r) => r.broadcastSuccessful), isTrue);
+      expect(relay.connectionsAuthenticatedAs(key.publicKey), greaterThan(0));
+
+      await ndk.destroy();
+      await relay.stopServer();
+    });
+  });
+}

--- a/packages/ndk/test/usecases/broadcast/broadcast_auth_test.dart
+++ b/packages/ndk/test/usecases/broadcast/broadcast_auth_test.dart
@@ -159,13 +159,22 @@ void broadcastAuthTests(NdkEngine engine) {
           .broadcastDoneFuture;
 
       expect(result.any((r) => r.broadcastSuccessful), isTrue);
+
+      // asserted after the connections are gone: what carried the event has to
+      // outlive the socket that carried it
+      await ndk.destroy();
+
       expect(
         relay.eventsNotAuthenticatedAs(key.publicKey),
         isEmpty,
         reason: 'the event never touches the anonymous connection',
       );
+      expect(
+        relay.eventsAuthenticatedAs(key.publicKey),
+        contains(event.id),
+        reason: 'and it went out as the identity that was required',
+      );
 
-      await ndk.destroy();
       await relay.stopServer();
     });
 

--- a/packages/ndk/test/usecases/broadcast/broadcast_auth_test.dart
+++ b/packages/ndk/test/usecases/broadcast/broadcast_auth_test.dart
@@ -169,6 +169,44 @@ void broadcastAuthTests(NdkEngine engine) {
       await relay.stopServer();
     });
 
+    test('require never opens the anonymous connection', () async {
+      // bootstrapping to another relay, so the only reason to reach the target
+      // at all is this broadcast
+      final bootstrap = await authRelay(requireAuth: false);
+      final target = await authRelay();
+      final ndk = ndkFor(bootstrap);
+      final account = signableAccount(key);
+
+      await ndk.broadcast
+          .broadcast(
+            nostrEvent: noteFrom(key, "require alone"),
+            specificRelays: [target.url],
+            customSigner: account.signer,
+            auth: RelayAuth.require(account),
+          )
+          .broadcastDoneFuture;
+
+      expect(
+        ndk.relays.globalState.relays.keys.where(
+          (connectionKey) =>
+              connectionKey.url == target.url && connectionKey.isAnonymous,
+        ),
+        isEmpty,
+        reason: 'a socket we opened is one the relay saw, sent on or not',
+      );
+      expect(
+        ndk.relays.globalState.relays.keys.where(
+          (connectionKey) => connectionKey.pubkey == key.publicKey,
+        ),
+        isNotEmpty,
+        reason: 'the bound connection is the one that was opened',
+      );
+
+      await ndk.destroy();
+      await bootstrap.stopServer();
+      await target.stopServer();
+    });
+
     test('require binds even when the relay never refuses', () async {
       final relay = await authRelay(requireAuth: false);
       final ndk = ndkFor(relay);

--- a/packages/ndk/test/usecases/broadcast_delivery_policy_test.dart
+++ b/packages/ndk/test/usecases/broadcast_delivery_policy_test.dart
@@ -1,6 +1,7 @@
 import 'package:ndk/domain_layer/entities/broadcast_state.dart';
 import 'package:ndk/domain_layer/entities/event_cache_records.dart';
 import 'package:ndk/domain_layer/entities/nip_01_event.dart';
+import 'package:ndk/domain_layer/entities/relay_auth.dart';
 import 'package:ndk/domain_layer/usecases/broadcast/delivery_policy.dart';
 import 'package:test/test.dart';
 
@@ -69,6 +70,38 @@ void main() {
           ),
         ),
         RelayDeliveryState.permanentFailure,
+      );
+    });
+
+    test('auth-required under never is permanent, not retryable', () {
+      final event = Nip01Event(
+        id: 'event-never',
+        pubKey: 'pubkey',
+        createdAt: 1700000002,
+        kind: Nip01Event.kTextNodeKind,
+        tags: const [],
+        content: 'text',
+        sig: 'sig',
+      );
+
+      final policy = DeliveryPolicy.forEvent(event);
+      final refusal = RelayBroadcastResponse(
+        relayUrl: 'wss://relay.example',
+        okReceived: false,
+        broadcastSuccessful: false,
+        msg: 'auth-required: please authenticate',
+      );
+
+      // no identity may ever be revealed here, so retrying every minute could
+      // only ever collect the same refusal
+      expect(
+        policy.resolveNextState(refusal, auth: const RelayAuth.never()),
+        RelayDeliveryState.permanentFailure,
+      );
+      expect(
+        policy.resolveNextState(refusal),
+        RelayDeliveryState.authRequired,
+        reason: 'a broadcast that named nobody may still authenticate',
       );
     });
 

--- a/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
+++ b/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
@@ -8,6 +8,10 @@ import 'package:ndk/domain_layer/entities/event_cache_records.dart';
 import 'package:ndk/domain_layer/entities/global_state.dart';
 import 'package:ndk/domain_layer/entities/nip_01_event.dart';
 import 'package:ndk/domain_layer/entities/pending_signer_request.dart';
+import 'package:ndk/domain_layer/entities/account.dart';
+import 'package:ndk/domain_layer/entities/relay_auth.dart';
+import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
+import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/domain_layer/entities/signer_request_rejected_exception.dart';
 import 'package:ndk/domain_layer/repositories/event_signer.dart';
 import 'package:ndk/domain_layer/usecases/accounts/accounts.dart';
@@ -58,6 +62,122 @@ void main() {
 
     tearDown(() async {
       await pendingDelivery.stop();
+    });
+
+    /// A signer never survives a restart, only the canonical policy does, so a
+    /// retry has to find the account again or hold the delivery.
+    group('auth policy across a restart', () {
+      final signerKey = Bip340.generatePrivateKey();
+
+      Account signable() => Account(
+            pubkey: signerKey.publicKey,
+            type: AccountType.privateKey,
+            signer: Bip340EventSigner(
+              privateKey: signerKey.privateKey!,
+              publicKey: signerKey.publicKey,
+            ),
+          );
+
+      Future<void> enqueueUnder(RelayAuth auth) async {
+        await pendingDelivery.enqueueSpecificRelayBroadcast(
+          event: event,
+          relayUrls: const ['wss://relay.example'],
+          requiresInteractiveSigning: false,
+          auth: auth,
+        );
+      }
+
+      /// the same durable state seen by a process that never held the policy
+      PendingBroadcastDelivery afterRestart() => PendingBroadcastDelivery(
+            cacheManager: cacheManager,
+            broadcastSender: broadcast,
+            accounts: accounts,
+          );
+
+      test('persists the canonical policy, never a signer', () async {
+        await enqueueUnder(RelayAuth.require(signable()));
+
+        final record = await cacheManager.loadEventDeliveryRecord(event.id);
+        expect(record?.authCanonical, 'require:${signerKey.publicKey}');
+      });
+
+      test('never survives a restart, since it names nobody', () async {
+        await enqueueUnder(const RelayAuth.never());
+        final restarted = afterRestart();
+        addTearDown(restarted.stop);
+
+        await restarted.flushForRelay('wss://relay.example');
+
+        expect(broadcast.broadcastedAuth, [isA<RelayAuthNever>()]);
+      });
+
+      test('rebuilds a named policy from a registered account', () async {
+        await enqueueUnder(RelayAuth.allow(signable()));
+        accounts.addAccount(
+          pubkey: signerKey.publicKey,
+          type: AccountType.privateKey,
+          signer: Bip340EventSigner(
+            privateKey: signerKey.privateKey!,
+            publicKey: signerKey.publicKey,
+          ),
+        );
+        final restarted = afterRestart();
+        addTearDown(restarted.stop);
+
+        await restarted.flushForRelay('wss://relay.example');
+
+        expect(broadcast.broadcastedAuth, [isA<RelayAuthAllow>()]);
+        expect(
+          (broadcast.broadcastedAuth.single as RelayAuthAllow).account.pubkey,
+          signerKey.publicKey,
+        );
+      });
+
+      test('holds a delivery whose identity no account can sign for', () async {
+        await enqueueUnder(RelayAuth.require(signable()));
+        // the account was handed over, never registered, so a new process has
+        // the pubkey and no way to sign as it
+        final restarted = afterRestart();
+        addTearDown(restarted.stop);
+
+        await restarted.flushForRelay('wss://relay.example');
+
+        expect(
+          broadcast.broadcastedEvents,
+          isEmpty,
+          reason: 'sending it as anybody else is what require ruled out',
+        );
+
+        final targets = await cacheManager.loadRelayDeliveryTargets(
+          eventId: event.id,
+        );
+        expect(targets.single.state, RelayDeliveryState.authRequired);
+        expect(targets.single.nextRetryAt, isNull);
+        expect(targets.single.lastError, contains(signerKey.publicKey));
+
+        final record = await cacheManager.loadEventDeliveryRecord(event.id);
+        expect(record?.status, EventDeliveryStatus.needsAction);
+      });
+
+      test('resumes once the event is broadcast with the account', () async {
+        await enqueueUnder(RelayAuth.require(signable()));
+        final restarted = afterRestart();
+        addTearDown(restarted.stop);
+        await restarted.flushForRelay('wss://relay.example');
+        expect(broadcast.broadcastedEvents, isEmpty);
+
+        // the app hands the identity back by broadcasting the same event again
+        await restarted.enqueueSpecificRelayBroadcast(
+          event: event,
+          relayUrls: const ['wss://relay.example'],
+          requiresInteractiveSigning: false,
+          auth: RelayAuth.require(signable()),
+        );
+        await restarted.flushForRelay('wss://relay.example');
+
+        expect(broadcast.broadcastedEvents, [event]);
+        expect(broadcast.broadcastedAuth, [isA<RelayAuthRequire>()]);
+      });
     });
 
     test('does not rebroadcast permanent failures during due flush', () async {
@@ -833,6 +953,7 @@ void main() {
 
 class RecordingBroadcastSender extends BroadcastSender {
   final List<Nip01Event> broadcastedEvents = [];
+  final List<RelayAuth?> broadcastedAuth = [];
 
   RecordingBroadcastSender({required MemCacheManager cacheManager})
       : super(
@@ -853,8 +974,10 @@ class RecordingBroadcastSender extends BroadcastSender {
     double? considerDonePercent,
     Duration? timeout,
     bool? saveToCache,
+    RelayAuth? auth,
   }) {
     broadcastedEvents.add(nostrEvent);
+    broadcastedAuth.add(auth);
     return NdkBroadcastResponse(
       publishEvent: nostrEvent,
       broadcastDoneStream: Stream.value(const <RelayBroadcastResponse>[]),

--- a/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
+++ b/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
@@ -159,6 +159,52 @@ void main() {
         expect(record?.status, EventDeliveryStatus.needsAction);
       });
 
+      test('drops the live policy once every target settled', () async {
+        // handed over, never registered, so it only exists in memory
+        await enqueueUnder(RelayAuth.require(signable()));
+
+        await pendingDelivery.persistSpecificRelayBroadcastResult(event, [
+          RelayBroadcastResponse(
+            relayUrl: 'wss://relay.example',
+            okReceived: true,
+            broadcastSuccessful: true,
+          ),
+        ]);
+
+        // a delivery revived after that has to rebuild the policy from the
+        // record, so the handed-over identity is gone even in this process
+        await cacheManager.saveRelayDeliveryTarget(
+          RelayDeliveryTarget(
+            eventId: event.id,
+            relayUrl: 'wss://relay.example',
+            reason: RelayDeliveryReason.explicit,
+          ),
+        );
+        await pendingDelivery.flushForRelay('wss://relay.example');
+
+        expect(broadcast.broadcastedEvents, isEmpty);
+        final targets = await cacheManager.loadRelayDeliveryTargets(
+          eventId: event.id,
+        );
+        expect(targets.single.state, RelayDeliveryState.authRequired);
+      });
+
+      test('keeps the live policy while a target is still pending', () async {
+        await enqueueUnder(RelayAuth.require(signable()));
+
+        await pendingDelivery.persistSpecificRelayBroadcastResult(event, [
+          RelayBroadcastResponse(
+            relayUrl: 'wss://relay.example',
+            okReceived: false,
+            broadcastSuccessful: false,
+            msg: 'auth-required: please authenticate',
+          ),
+        ]);
+        await pendingDelivery.flushForRelay('wss://relay.example');
+
+        expect(broadcast.broadcastedAuth, [isA<RelayAuthRequire>()]);
+      });
+
       test('resumes once the event is broadcast with the account', () async {
         await enqueueUnder(RelayAuth.require(signable()));
         final restarted = afterRestart();

--- a/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
+++ b/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
@@ -246,6 +246,60 @@ void main() {
         expect(broadcast.broadcastedAuth, [isA<RelayAuthRequire>()]);
       });
 
+      test('a parked delivery does not reconnect on every interval', () async {
+        await enqueueUnder(RelayAuth.require(signable()));
+        final restarted = afterRestart();
+        addTearDown(restarted.stop);
+        await restarted.flushForRelay('wss://relay.example');
+
+        // nothing about it changes on its own, so waking the relay for it would
+        // only rewrite the same state every interval
+        await restarted.retryDueDeliveries(
+          connectedRelayUrls: () => const <String>[],
+          reconnectRelay: (relayUrl) async {
+            reconnectAttempts.add(relayUrl);
+            return true;
+          },
+        );
+
+        expect(reconnectAttempts, isEmpty);
+        expect(broadcast.broadcastedEvents, isEmpty);
+      });
+
+      test('a parked delivery becomes due again once an identity is named',
+          () async {
+        await enqueueUnder(RelayAuth.require(signable()));
+        final restarted = afterRestart();
+        addTearDown(restarted.stop);
+        await restarted.flushForRelay('wss://relay.example');
+
+        accounts.addAccount(
+          pubkey: signerKey.publicKey,
+          type: AccountType.privateKey,
+          signer: Bip340EventSigner(
+            privateKey: signerKey.privateKey!,
+            publicKey: signerKey.publicKey,
+          ),
+        );
+        await restarted.enqueueSpecificRelayBroadcast(
+          event: event,
+          relayUrls: const ['wss://relay.example'],
+          requiresInteractiveSigning: false,
+          auth: RelayAuth.require(signable()),
+        );
+
+        await restarted.retryDueDeliveries(
+          connectedRelayUrls: () => const <String>[],
+          reconnectRelay: (relayUrl) async {
+            reconnectAttempts.add(relayUrl);
+            return true;
+          },
+        );
+
+        expect(reconnectAttempts, ['wss://relay.example']);
+        expect(broadcast.broadcastedEvents, [event]);
+      });
+
       test('resumes once the event is broadcast with the account', () async {
         await enqueueUnder(RelayAuth.require(signable()));
         final restarted = afterRestart();

--- a/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
+++ b/packages/ndk/test/usecases/pending_broadcast_delivery_test.dart
@@ -12,6 +12,7 @@ import 'package:ndk/domain_layer/entities/account.dart';
 import 'package:ndk/domain_layer/entities/relay_auth.dart';
 import 'package:ndk/data_layer/repositories/signers/bip340_event_signer.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
+import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:ndk/domain_layer/entities/signer_request_rejected_exception.dart';
 import 'package:ndk/domain_layer/repositories/event_signer.dart';
 import 'package:ndk/domain_layer/usecases/accounts/accounts.dart';
@@ -64,6 +65,45 @@ void main() {
       await pendingDelivery.stop();
     });
 
+    /// One event may be published to two relays under two identities, so the
+    /// policy belongs to the relay target, not to the event.
+    test('keeps one policy per relay for the same event', () async {
+      final alice = Bip340.generatePrivateKey();
+      final bob = Bip340.generatePrivateKey();
+
+      Account accountOf(KeyPair k) => Account(
+            pubkey: k.publicKey,
+            type: AccountType.privateKey,
+            signer: Bip340EventSigner(
+              privateKey: k.privateKey!,
+              publicKey: k.publicKey,
+            ),
+          );
+
+      await pendingDelivery.enqueueSpecificRelayBroadcast(
+        event: event,
+        relayUrls: const ['wss://r1.example'],
+        requiresInteractiveSigning: false,
+        auth: RelayAuth.require(accountOf(alice)),
+      );
+      await pendingDelivery.enqueueSpecificRelayBroadcast(
+        event: event,
+        relayUrls: const ['wss://r2.example'],
+        requiresInteractiveSigning: false,
+        auth: RelayAuth.require(accountOf(bob)),
+      );
+
+      await pendingDelivery.flushForRelay('wss://r1.example');
+      await pendingDelivery.flushForRelay('wss://r2.example');
+
+      expect(
+        broadcast.broadcastedAuth
+            .map((auth) => (auth as RelayAuthRequire).account.pubkey),
+        [alice.publicKey, bob.publicKey],
+        reason: 'the second broadcast must not re-attribute the first',
+      );
+    });
+
     /// A signer never survives a restart, only the canonical policy does, so a
     /// retry has to find the account again or hold the delivery.
     group('auth policy across a restart', () {
@@ -97,8 +137,10 @@ void main() {
       test('persists the canonical policy, never a signer', () async {
         await enqueueUnder(RelayAuth.require(signable()));
 
-        final record = await cacheManager.loadEventDeliveryRecord(event.id);
-        expect(record?.authCanonical, 'require:${signerKey.publicKey}');
+        final targets = await cacheManager.loadRelayDeliveryTargets(
+          eventId: event.id,
+        );
+        expect(targets.single.authCanonical, 'require:${signerKey.publicKey}');
       });
 
       test('never survives a restart, since it names nobody', () async {
@@ -172,13 +214,12 @@ void main() {
         ]);
 
         // a delivery revived after that has to rebuild the policy from the
-        // record, so the handed-over identity is gone even in this process
+        // target, so the handed-over identity is gone even in this process
+        final settled = await cacheManager.loadRelayDeliveryTargets(
+          eventId: event.id,
+        );
         await cacheManager.saveRelayDeliveryTarget(
-          RelayDeliveryTarget(
-            eventId: event.id,
-            relayUrl: 'wss://relay.example',
-            reason: RelayDeliveryReason.explicit,
-          ),
+          settled.single.copyWith(state: RelayDeliveryState.pending),
         );
         await pendingDelivery.flushForRelay('wss://relay.example');
 


### PR DESCRIPTION
The auth parameter now reaches the write path, so a caller can refuse to be attributable, or bind the connection before the relay asks. Only the canonical policy is persisted for background retries: a delivery whose identity no account can sign for waits in needsAction rather than going out as the logged account.

Closes #665.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NIP-42 relay authentication options for event broadcasts, including anonymous, allowed-identity, and required-identity policies.
  * Broadcasts now apply authentication consistently across direct delivery, retries, reactions, and deletions.
  * Added handling for required identities that cannot sign, with resumable pending deliveries.

* **Bug Fixes**
  * Preserved authentication settings for pending broadcasts across application restarts.

* **Documentation**
  * Documented relay authentication behavior, policies, errors, and restart handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->