### PR TITLE
Make ndk flutter version aligned with ndk 0.10.0

### DIFF
--- a/packages/ndk_flutter/CHANGELOG.md
+++ b/packages/ndk_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0-dev.2
+
+ - Align package version with ndk core 0.10.0-dev.2.
+
 ## 0.9.0-dev.8
 
  - Update a dependency to the latest release.

--- a/packages/ndk_flutter/pubspec.yaml
+++ b/packages/ndk_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ndk_flutter
 description: "A Flutter UI package providing ready-to-use widgets."
-version: 0.9.0-dev.8
+version: 0.10.0-dev.2
 repository: https://github.com/relaystr/ndk
 topics:
   - ndk


### PR DESCRIPTION
fixes #806 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Flutter package version to `0.10.0-dev.2`.
  * Added a changelog entry documenting alignment with the corresponding core package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->