### PR TITLE
chore: stop refusing connections to brb.io

### DIFF
--- a/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
+++ b/packages/ndk/lib/domain_layer/usecases/relay_manager.dart
@@ -286,22 +286,6 @@ class RelayManager<T> {
 
       relayConnectivity.relay.tryingToConnect();
 
-      /// TO BE REMOVED, ONCE WE FIND A WAY OF AVOIDING PROBLEM WHEN CONNECTING TO THIS
-      if (url.startsWith("wss://brb.io")) {
-        relayConnectivity.relay.failedToConnect();
-        if (!connectCompleter.isCompleted) {
-          connectCompleter.complete(false);
-        }
-        if (identical(
-          _connectReadyCompleters[connectionKey],
-          connectCompleter,
-        )) {
-          _connectReadyCompleters.remove(connectionKey);
-        }
-        updateRelayConnectivity();
-        return Tuple(false, "bad relay");
-      }
-
       Logger.log.i(() => "connecting to relay $dirtyUrl");
 
       // a fresh socket for a key we may already know: nothing the previous one

--- a/packages/ndk/test/relays/relay_manager_test.dart
+++ b/packages/ndk/test/relays/relay_manager_test.dart
@@ -172,24 +172,6 @@ void main() async {
       await relay1.stopServer();
     });
 
-    test('Try to connect to wss://brb.io', skip: true, () async {
-      RelayManager manager = RelayManager(
-        nostrTransportFactory: webSocketNostrTransportFactory,
-        bootstrapRelays: [],
-        globalState: GlobalState(),
-      );
-
-      try {
-        await manager.connectRelay(
-          dirtyUrl: "wss://brb.io",
-          connectionSource: ConnectionSource.seed,
-        );
-        fail("should throw exception");
-      } catch (e) {
-        // success
-      }
-    });
-
     test(
         'CLOSED message bug - should not remove entire request from inFlightRequests',
         () async {


### PR DESCRIPTION
The guard dates from 2023, when the host broke the websocket handshake in a way the client did not handle. brb.io no longer runs a relay: it answers the upgrade request with an HTTP 404, which the normal connect path already handles through the bounded wait and the catch that returns a failure.

Drop the skipped test that covered the guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay connectivity by allowing connections to `wss://brb.io` relays to proceed through the normal connection flow.
  * Preserved active subscriptions when one relay closes, allowing events to continue arriving from other connected relays.

* **Tests**
  * Added coverage for handling closed relay connections while maintaining delivery from remaining relays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->