### PR TITLE
feat: indexer relays list

### DIFF
--- a/doc/common-terminology.md
+++ b/doc/common-terminology.md
@@ -14,4 +14,5 @@ icon: bookmark
 | **query**           | get data once and close the request               | get request                 |
 | **subscription**    | stream of events as they come in                  | stream of data              |
 | **bootstrapRelays** | default relays to connect; Used to get Nip65 data | seed relays, initial relays |
+| **indexerRelays**   | relays indexing Nip65 (and often kind 0) for any pubkey | indexers, directory relays |
 | **engine**          | optimized network resolver for nostr requests     | -                           |

--- a/packages/ndk/example/account_test.dart
+++ b/packages/ndk/example/account_test.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: avoid_print
 
-import 'package:ndk/config/bootstrap_relays.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:test/test.dart';

--- a/packages/ndk/example/accounts_example.dart
+++ b/packages/ndk/example/accounts_example.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: avoid_print
 
-import 'package:ndk/config/bootstrap_relays.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 import 'package:ndk/ndk.dart';

--- a/packages/ndk/lib/config/indexer_relays.dart
+++ b/packages/ndk/lib/config/indexer_relays.dart
@@ -1,0 +1,15 @@
+// ignore_for_file: constant_identifier_names
+
+/// default indexer relays
+///
+/// aggregators that serve kind 10002 (nip65) for arbitrary pubkeys, unlike
+/// general purpose relays which only hold the events of their own users \
+/// kind 0 coverage is a bonus, metadata is reachable on the user own relays
+/// once their nip65 list is known
+const List<String> DEFAULT_INDEXER_RELAYS = [
+  "wss://indexer.coracle.social", // nip65 only, no metadata
+  "wss://directory.yabu.me",
+  "wss://purplepag.es",
+  "wss://relay.nos.social",
+  // "wss://user.kindpag.es",
+];

--- a/packages/ndk/lib/domain_layer/usecases/user_relay_lists/user_relay_lists.dart
+++ b/packages/ndk/lib/domain_layer/usecases/user_relay_lists/user_relay_lists.dart
@@ -24,6 +24,8 @@ class UserRelayLists {
   final CacheManager _cacheManager;
   final Broadcast _broadcast;
   final Accounts _accounts;
+  final List<String> _indexerRelays;
+  final List<String> _bootstrapRelays;
 
   /// user relay lists usecase
   UserRelayLists({
@@ -31,10 +33,14 @@ class UserRelayLists {
     required CacheManager cacheManager,
     required Broadcast broadcast,
     required Accounts accounts,
+    required List<String> indexerRelays,
+    required List<String> bootstrapRelays,
   })  : _cacheManager = cacheManager,
         _requests = requests,
         _broadcast = broadcast,
-        _accounts = accounts;
+        _accounts = accounts,
+        _indexerRelays = indexerRelays,
+        _bootstrapRelays = bootstrapRelays;
 
   EventSigner get _signer {
     if (_accounts.isNotLoggedIn) {
@@ -44,11 +50,16 @@ class UserRelayLists {
   }
 
   // TODO try to use generic query with cacheRead/Write mechanism
-  /// load missing user relay lists from nip65 or kind 3 (kind02)
+  /// load missing user relay lists from nip65 or kind 3 (kind02) \
+  /// queried on the indexer and bootstrap relays, since inbox/outbox cannot be
+  /// resolved before these very lists are known \
+  ///
+  /// [additionalRelays] queried on top of those
   Future<void> loadMissingRelayListsFromNip65OrNip02(
     List<String> pubKeys, {
     Function(String stepName, int count, int total)? onProgress,
     bool forceRefresh = false,
+    Iterable<String>? additionalRelays,
   }) async {
     List<String> missingPubKeys = [];
     for (var pubKey in pubKeys) {
@@ -76,6 +87,11 @@ class UserRelayLists {
           missingPubKeys.length,
         );
       }
+      final lookupRelays = {
+        ..._indexerRelays,
+        ..._bootstrapRelays,
+        ...?additionalRelays,
+      };
       try {
         await for (final event in (_requests.query(
           //                timeout: missingPubKeys.length > 1 ? 10 : 3,
@@ -86,6 +102,7 @@ class UserRelayLists {
               kinds: [Nip65.kKind, ContactList.kKind],
             ),
           ],
+          explicitRelays: lookupRelays.isEmpty ? null : lookupRelays,
         )).stream) {
           switch (event.kind) {
             case Nip65.kKind:
@@ -160,15 +177,18 @@ class UserRelayLists {
   Future<UserRelayList?> getSingleUserRelayList(
     String pubKey, {
     bool forceRefresh = false,
+    Iterable<String>? additionalRelays,
   }) async {
     UserRelayList? userRelayList = await _cacheManager.loadUserRelayList(
       pubKey,
     );
 
     if (userRelayList == null || forceRefresh) {
-      await loadMissingRelayListsFromNip65OrNip02([
-        pubKey,
-      ], forceRefresh: forceRefresh);
+      await loadMissingRelayListsFromNip65OrNip02(
+        [pubKey],
+        forceRefresh: forceRefresh,
+        additionalRelays: additionalRelays,
+      );
       userRelayList = await _cacheManager.loadUserRelayList(pubKey);
     }
     return userRelayList;
@@ -248,6 +268,10 @@ class UserRelayLists {
       userRelayList = await getSingleUserRelayList(
         _signer.getPublicKey(),
         forceRefresh: true,
+
+        /// indexers can lag behind an edit another client just wrote to the
+        /// user own relays, and a stale list here means losing relays
+        additionalRelays: userRelayList?.relays.keys,
       );
     }
     return userRelayList;

--- a/packages/ndk/lib/ndk.dart
+++ b/packages/ndk/lib/ndk.dart
@@ -134,6 +134,8 @@ export 'domain_layer/entities/nip77_state.dart' show Nip77Result;
 export 'domain_layer/usecases/ta/trusted_assertions.dart';
 export 'domain_layer/entities/nip_85.dart';
 export 'config/nip85_defaults.dart';
+export 'config/bootstrap_relays.dart';
+export 'config/indexer_relays.dart';
 
 /**
  * other stuff

--- a/packages/ndk/lib/presentation_layer/init.dart
+++ b/packages/ndk/lib/presentation_layer/init.dart
@@ -284,6 +284,8 @@ class Initialization {
       cacheManager: _ndkConfig.cache,
       broadcast: broadcast,
       accounts: accounts,
+      indexerRelays: _ndkConfig.indexerRelays,
+      bootstrapRelays: _ndkConfig.bootstrapRelays,
     );
 
     lists = Lists(

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -1,4 +1,5 @@
 import '../config/bootstrap_relays.dart';
+import '../config/indexer_relays.dart';
 import '../config/nip85_defaults.dart';
 import '../config/broadcast_defaults.dart';
 import '../config/logger_defaults.dart';
@@ -44,6 +45,12 @@ class NdkConfig {
   ///
   /// Defaults to [DEFAULT_BOOTSTRAP_RELAYS].
   List<String> bootstrapRelays;
+
+  /// A list of relay URLs that index nip65 relay lists (kind 10002), and for
+  /// some of them metadata (kind 0), for arbitrary pubkeys.
+  ///
+  /// Defaults to [DEFAULT_INDEXER_RELAYS].
+  List<String> indexerRelays;
 
   /// filters that are applied to the output stream
   List<EventFilter> eventOutFilters;
@@ -124,6 +131,7 @@ class NdkConfig {
   /// [engine] The engine mode to use (defaults to RELAY_SETS). \
   /// [ignoreRelays] A list of relay URLs to ignore (defaults to an empty list). \
   /// [bootstrapRelays] A list of initial relay URLs (defaults to DEFAULT_BOOTSTRAP_RELAYS). \
+  /// [indexerRelays] A list of relay URLs indexing nip65 relay lists (defaults to DEFAULT_INDEXER_RELAYS). \
   /// [eventOutFilters] A list of filters to apply to the output stream (defaults to an empty list). \
   /// [defaultQueryTimeout] The default timeout for queries (defaults to DEFAULT_QUERY_TIMEOUT). \
   /// [logLevel] The log level for the NDK (defaults to warning).
@@ -136,6 +144,7 @@ class NdkConfig {
     this.engine = NdkEngine.RELAY_SETS,
     this.ignoreRelays = const [],
     this.bootstrapRelays = DEFAULT_BOOTSTRAP_RELAYS,
+    this.indexerRelays = DEFAULT_INDEXER_RELAYS,
     this.eventOutFilters = const [],
     this.defaultQueryTimeout = RequestDefaults.DEFAULT_QUERY_TIMEOUT,
     this.defaultBroadcastTimeout = BroadcastDefaults.TIMEOUT,

--- a/packages/ndk/lib/presentation_layer/ndk_config.dart
+++ b/packages/ndk/lib/presentation_layer/ndk_config.dart
@@ -49,6 +49,9 @@ class NdkConfig {
   /// A list of relay URLs that index nip65 relay lists (kind 10002), and for
   /// some of them metadata (kind 0), for arbitrary pubkeys.
   ///
+  /// Queried together with [bootstrapRelays] to resolve relay lists, which
+  /// inbox/outbox cannot do on its own. Set to an empty list to opt out.
+  ///
   /// Defaults to [DEFAULT_INDEXER_RELAYS].
   List<String> indexerRelays;
 

--- a/packages/ndk/test/relays/relay_sets_test.dart
+++ b/packages/ndk/test/relays/relay_sets_test.dart
@@ -183,6 +183,7 @@ void main() async {
           cache: MemCacheManager(),
           engine: NdkEngine.RELAY_SETS,
           bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
+          indexerRelays: [],
         ),
       );
       ndk.accounts.loginPrivateKey(
@@ -253,6 +254,7 @@ void main() async {
             cache: MemCacheManager(),
             engine: NdkEngine.RELAY_SETS,
             bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
+            indexerRelays: [],
           ),
         );
 
@@ -370,6 +372,7 @@ void main() async {
           cache: MemCacheManager(),
           engine: NdkEngine.RELAY_SETS,
           bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
+          indexerRelays: [],
         ),
       );
 
@@ -418,6 +421,7 @@ void main() async {
           cache: MemCacheManager(),
           engine: NdkEngine.RELAY_SETS,
           bootstrapRelays: [relay1.url, relay2.url, relay3.url, relay4.url],
+          indexerRelays: [],
         ),
       );
 

--- a/packages/ndk/test/timeouts/network_speed_test.dart
+++ b/packages/ndk/test/timeouts/network_speed_test.dart
@@ -181,6 +181,7 @@ void main() {
         cache: MemCacheManager(),
         engine: NdkEngine.JIT,
         bootstrapRelays: [relay3.url, relay4.url],
+        indexerRelays: [],
       );
 
       final ndk = Ndk(config);
@@ -217,6 +218,7 @@ void main() {
         cache: MemCacheManager(),
         engine: NdkEngine.JIT,
         bootstrapRelays: [relay3.url, relay4.url],
+        indexerRelays: [],
       );
 
       final ndk = Ndk(config);
@@ -248,6 +250,7 @@ void main() {
         cache: MemCacheManager(),
         engine: NdkEngine.JIT,
         bootstrapRelays: [relay3.url, relay4.url],
+        indexerRelays: [],
       );
 
       final ndk = Ndk(config);
@@ -277,6 +280,7 @@ void main() {
         cache: MemCacheManager(),
         engine: NdkEngine.JIT,
         bootstrapRelays: [relay6.url],
+        indexerRelays: [],
         logLevel: Logger.logLevels.all,
       );
 

--- a/packages/ndk/test/usecases/jit_engine/late_relay_test.dart
+++ b/packages/ndk/test/usecases/jit_engine/late_relay_test.dart
@@ -41,6 +41,7 @@ void main() {
         cache: MemCacheManager(),
         engine: NdkEngine.JIT,
         bootstrapRelays: [fast.url],
+        indexerRelays: [],
       ),
     );
 

--- a/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
+++ b/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
@@ -174,8 +174,8 @@ void main() async {
     late Ndk ndk;
 
     setUp(() async {
-      indexer = MockRelay(name: "indexer", explicitPort: 5102);
-      bootstrap = MockRelay(name: "bootstrap", explicitPort: 5103);
+      indexer = MockRelay(name: "indexer");
+      bootstrap = MockRelay(name: "bootstrap");
 
       await indexer.startServer(
         nip65s: {
@@ -211,6 +211,89 @@ void main() async {
       );
 
       expect(list!.writeUrls, contains("wss://relay.write"));
+    });
+  });
+
+  group('nip65 refresh before editing the own list', () {
+    KeyPair key = Bip340.generatePrivateKey();
+
+    late MockRelay indexer;
+    late MockRelay bootstrap;
+    late MockRelay own;
+    late MemCacheManager cache;
+    late Ndk ndk;
+
+    setUp(() async {
+      indexer = MockRelay(name: "indexer");
+      bootstrap = MockRelay(name: "bootstrap");
+      own = MockRelay(name: "own");
+
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await indexer.startServer(
+        nip65s: {
+          key: Nip65(
+            pubKey: key.publicKey,
+            relays: {"wss://relay.stale": ReadWriteMarker.readWrite},
+            createdAt: now - 3600,
+          ),
+        },
+      );
+      await bootstrap.startServer();
+      await own.startServer(
+        nip65s: {
+          key: Nip65(
+            pubKey: key.publicKey,
+            relays: {"wss://relay.fresh": ReadWriteMarker.readWrite},
+            createdAt: now,
+          ),
+        },
+      );
+
+      cache = MemCacheManager();
+      ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: cache,
+          engine: NdkEngine.RELAY_SETS,
+          bootstrapRelays: [bootstrap.url],
+          indexerRelays: [indexer.url],
+        ),
+      );
+
+      await ndk.relays.seedRelaysConnected;
+
+      ndk.accounts.loginPrivateKey(
+        pubkey: key.publicKey,
+        privkey: key.privateKey!,
+      );
+    });
+
+    tearDown(() async {
+      await ndk.destroy();
+      await indexer.stopServer();
+      await bootstrap.stopServer();
+      await own.stopServer();
+    });
+
+    test('picks up an edit the indexers have not caught up with', () async {
+      await cache.saveUserRelayList(
+        UserRelayList(
+          pubKey: key.publicKey,
+          relays: {own.url: ReadWriteMarker.readWrite},
+          createdAt: 0,
+          refreshedTimestamp: 0,
+        ),
+      );
+
+      final list = await ndk.userRelayLists.broadcastAddNip65Relay(
+        relayUrl: "wss://relay.added",
+        marker: ReadWriteMarker.readWrite,
+        broadcastRelays: [own.url],
+      );
+
+      expect(list.relays.keys, contains("wss://relay.fresh"));
+      expect(list.relays.keys, isNot(contains("wss://relay.stale")));
     });
   });
 }

--- a/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
+++ b/packages/ndk/test/usecases/user_relay_lists/user_relay_lists_test.dart
@@ -42,6 +42,7 @@ void main() async {
         cache: cache,
         engine: NdkEngine.RELAY_SETS,
         bootstrapRelays: [relay0.url],
+        indexerRelays: [],
         // logLevel: Logger.logLevels.trace,
         ignoreRelays: [],
       );
@@ -162,6 +163,54 @@ void main() async {
         forceRefresh: true,
       );
       expect(list!.relays.containsKey(r1), false);
+    });
+  });
+
+  group('nip65 lookup on indexer relays', () {
+    KeyPair key = Bip340.generatePrivateKey();
+
+    late MockRelay indexer;
+    late MockRelay bootstrap;
+    late Ndk ndk;
+
+    setUp(() async {
+      indexer = MockRelay(name: "indexer", explicitPort: 5102);
+      bootstrap = MockRelay(name: "bootstrap", explicitPort: 5103);
+
+      await indexer.startServer(
+        nip65s: {
+          key: Nip65.fromMap(key.publicKey, {
+            "wss://relay.write": ReadWriteMarker.writeOnly,
+          }),
+        },
+      );
+      await bootstrap.startServer();
+
+      ndk = Ndk(
+        NdkConfig(
+          eventVerifier: MockEventVerifier(),
+          cache: MemCacheManager(),
+          engine: NdkEngine.RELAY_SETS,
+          bootstrapRelays: [bootstrap.url],
+          indexerRelays: [indexer.url],
+        ),
+      );
+
+      await ndk.relays.seedRelaysConnected;
+    });
+
+    tearDown(() async {
+      await ndk.destroy();
+      await indexer.stopServer();
+      await bootstrap.stopServer();
+    });
+
+    test('resolved from an indexer the bootstrap relays do not know', () async {
+      final list = await ndk.userRelayLists.getSingleUserRelayList(
+        key.publicKey,
+      );
+
+      expect(list!.writeUrls, contains("wss://relay.write"));
     });
   });
 }


### PR DESCRIPTION
Adds a dedicated list of indexer relays, the aggregators that serve kind 10002 for arbitrary pubkeys, and uses it to resolve relay lists.

Until now `purplepag.es` was buried in `DEFAULT_BOOTSTRAP_RELAYS`, mixed with general purpose relays, and nothing targeted it for nip65. Apps that wanted an indexer list had to hardcode their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added default indexer relays for discovering users’ NIP-65 relay lists.
  - Added configurable indexer relay settings, including the ability to disable indexer lookups.
  - Relay-list lookups can now use configured indexers, bootstrap relays, and additional known relays.
  - Exposed bootstrap and indexer relay configuration through the public package API.

- **Documentation**
  - Defined “indexer relays” and related terminology.

- **Tests**
  - Added coverage for discovering and refreshing relay lists through indexer relays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->